### PR TITLE
Add annotations to mock search results and fix erroneous test.

### DIFF
--- a/test/integration/portal/AnnotationsSpec.scala
+++ b/test/integration/portal/AnnotationsSpec.scala
@@ -80,8 +80,8 @@ class AnnotationsSpec extends IntegrationTestRunner {
 
       val userList = route(fakeLoggedInHtmlRequest(privilegedUser,
         controllers.portal.users.routes.UserProfiles.annotations())).get
-      contentAsString(list) must contain(innocuousText)
-      contentAsString(list) must not contain evilText
+      contentAsString(userList) must contain(innocuousText)
+      contentAsString(userList) must not contain evilText
     }
 
     "disallow creating annotations without permission" in new ITestApp {

--- a/test/utils/search/MockSearchDispatcher.scala
+++ b/test/utils/search/MockSearchDispatcher.scala
@@ -37,7 +37,8 @@ case class MockSearchDispatcher(
     EntityType.Repository,
     EntityType.HistoricalAgent,
     EntityType.VirtualUnit,
-    EntityType.UserProfile
+    EntityType.UserProfile,
+    EntityType.Annotation
   )
 
   private implicit def handle(implicit userOpt: Option[UserProfile]): BackendHandle =


### PR DESCRIPTION
When testing a page which used a user's annotations via the search engine, no results would have been returned since the mock ignored these. However, since we were testing the wrong data this went unnoticed.