### PR TITLE
Fix bugs 592 and 593.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -70,7 +70,7 @@ solr.path = "http://localhost:8983/solr/portal"
 
 # Yuck - specify where the indexer binary is location...
 # Overridden by the prod config
-solr.indexer.jar = ${?HOME}/dev/play/docview/bin/indexer.jar
+solr.indexer.jar = ${?HOME}/dev/play/ehri-frontend/bin/indexer.jar
 
 # Contexts for Play's thread pools. Mostly the default context
 # is used. See: https://www.playframework.com/documentation/2.3.0/ThreadPools

--- a/modules/admin/app/views/admin/link/accessPointLinks.scala.html
+++ b/modules/admin/app/views/admin/link/accessPointLinks.scala.html
@@ -1,4 +1,4 @@
-@(item: WithDescriptions[Description], desc: models.base.Description, links: Seq[Link])(implicit prefix: String, userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, lang: Lang)
+@(item: models.base.WithDescriptions[models.base.Description], desc: models.base.Description, links: Seq[Link])(implicit prefix: String, userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, lang: Lang)
 
 @if(desc.accessPoints.nonEmpty) {
     <h3>@Messages(prefix + ".accessPoints")</h3>
@@ -9,7 +9,7 @@
                 <ul class="access-point-links">
                     @linksOfType.map { ap =>
                         @ap.target(item, links).map { case (link, other) =>
-                            <li class="access-point-link resolved-access-point">
+                            <li class="access-point-link resolved-access-point" data-apid="@ap.id">
                                 @itemLink(link, other)
                             </li>
                         }.getOrElse {

--- a/modules/backend/app/backend/Descriptions.scala
+++ b/modules/backend/app/backend/Descriptions.scala
@@ -6,13 +6,60 @@ import scala.concurrent.Future
  * @author Mike Bryant (http://github.com/mikesname)
  */
 trait Descriptions {
-  def createDescription[MT, DT](id: String, item: DT, logMsg: Option[String] = None)(implicit rs: Resource[MT], fmt: Writable[DT], rd: Readable[DT]): Future[DT]
+  /**
+   * Create a new description on a given item.
+   *
+   * @param id the item's ID
+   * @param desc the description data
+   * @param logMsg an optional log message
+   * @tparam MT the item's meta type
+   * @tparam DT the item's description type
+   */
+  def createDescription[MT: Resource, DT: Writable](id: String, desc: DT, logMsg: Option[String] = None): Future[DT]
 
-  def updateDescription[MT, DT](id: String, did: String, item: DT, logMsg: Option[String] = None)(implicit rs: Resource[MT], fmt: Writable[DT], rd: Readable[DT]): Future[DT]
+  /**
+   * Update a description on a given item.
+   *
+   * @param id the item's ID
+   * @param did the description ID           
+   * @param desc the description data
+   * @param logMsg an optional log message
+   * @tparam MT the item's meta type
+   * @tparam DT the item's description type
+   * @return
+   */
+  def updateDescription[MT: Resource, DT: Writable](id: String, did: String, desc: DT, logMsg: Option[String] = None): Future[DT]
 
-  def deleteDescription[MT](id: String, did: String, logMsg: Option[String] = None)(implicit rs: Resource[MT]): Future[Unit]
+  /**
+   * Create a new access point on the given item description.
+   *
+   * @param id the item's ID
+   * @param did the description ID
+   * @param ap the access point data
+   * @param logMsg an optional log message
+   * @tparam MT the item's meta type
+   * @tparam AP the access point type
+   */
+  def createAccessPoint[MT: Resource, AP: Writable](id: String, did: String, ap: AP, logMsg: Option[String] = None): Future[AP]
 
-  def createAccessPoint[MT, DT](id: String, did: String, item: DT, logMsg: Option[String] = None)(implicit rs: Resource[MT], fmt: Writable[DT]): Future[DT]
+  /**
+   * Delete a given description.
+   *
+   * @param id the item's ID
+   * @param did the description ID
+   * @param logMsg an optional log message
+   * @tparam MT the access point type
+   */
+  def deleteDescription[MT: Resource](id: String, did: String, logMsg: Option[String] = None): Future[Unit]
 
-  def deleteAccessPoint(id: String, did: String, apid: String, logMsg: Option[String] = None): Future[Unit]
+  /**
+   * Delete a given access point.
+   *
+   * @param id the item's ID
+   * @param did the description ID
+   * @param apid the access point ID
+   * @param logMsg an optional log message
+   * @tparam MT the item's meta type
+   */
+  def deleteAccessPoint[MT: Resource](id: String, did: String, apid: String, logMsg: Option[String] = None): Future[Unit]
 }

--- a/modules/backend/app/backend/rest/RestDescriptions.scala
+++ b/modules/backend/app/backend/rest/RestDescriptions.scala
@@ -44,14 +44,14 @@ trait RestDescriptions extends RestDAO with RestContext with Descriptions {
     }
   }
 
-  override def createAccessPoint[MT: Resource, DT: Writable](id: String, did: String, item: DT, logMsg: Option[String] = None): Future[DT] = {
+  override def createAccessPoint[MT: Resource, AP: Writable](id: String, did: String, item: AP, logMsg: Option[String] = None): Future[AP] = {
     val url: String = enc(requestUrl, id, did, EntityType.AccessPoint)
     userCall(url)
         .withHeaders(msgHeader(logMsg): _*)
-        .post(Json.toJson(item)(Writable[DT].restFormat)).map { response =>
+        .post(Json.toJson(item)(Writable[AP].restFormat)).map { response =>
       eventHandler.handleUpdate(id)
       Cache.remove(canonicalUrl(id))
-      checkErrorAndParse(response, context = Some(url))(Writable[DT].restFormat)
+      checkErrorAndParse(response, context = Some(url))(Writable[AP].restFormat)
     }
   }
 

--- a/modules/backend/app/backend/rest/RestDescriptions.scala
+++ b/modules/backend/app/backend/rest/RestDescriptions.scala
@@ -59,7 +59,7 @@ trait RestDescriptions extends RestDAO with RestContext with Descriptions {
     val url = enc(requestUrl, id, did, EntityType.AccessPoint, apid)
     userCall(url).withHeaders(msgHeader(logMsg): _*).delete().map { response =>
       checkError(response)
-      eventHandler.handleDelete(id)
+      eventHandler.handleUpdate(id)
       Cache.remove(canonicalUrl(id))
     }
   }

--- a/test/integration/DocumentaryUnitViewsSpec.scala
+++ b/test/integration/DocumentaryUnitViewsSpec.scala
@@ -355,6 +355,27 @@ class DocumentaryUnitViewsSpec extends IntegrationTestRunner {
       indexEventBuffer.last must equalTo("cd1-2")
     }
 
+    "allow deleting access points" in new ITestApp {
+      val testItem = "c1"
+      val testItemDesc = "cd1"
+      val testItemAp = "ur1"
+      val get1 = route(fakeLoggedInHtmlRequest(
+          privilegedUser, docRoutes.get(testItem))).get
+      contentAsString(get1) must contain(testItemAp)
+      // Now try again to update the item, which should succeed
+      // Check we can update the item
+      val cr = route(fakeLoggedInHtmlRequest(privilegedUser,
+        docRoutes.deleteAccessPoint(testItem, testItemDesc, testItemAp))).get
+      // NB: This is a JSON-only endpoint so it will give us OK instead
+      // of a redirect
+      status(cr) must equalTo(OK)
+      val get2 = route(fakeLoggedInHtmlRequest(privilegedUser,
+        docRoutes.get(testItem))).get
+      status(get2) must equalTo(OK)
+      indexEventBuffer.last must equalTo(testItem)
+      contentAsString(get2) must not contain testItemAp
+    }
+
     "allow updating visibility" in new ITestApp {
       val test1 = route(fakeLoggedInHtmlRequest(unprivilegedUser, docRoutes.get("c1"))).get
       status(test1) must equalTo(NOT_FOUND)


### PR DESCRIPTION
Lots of access-point related fixes. When access points were deleted two things went wrong:

 - the item's cache wasn't cleared
 - it was erroneously delete from the search engine (!)
 - refactor backend description-deleted methods to match newer style, using context bounds instead of implicit parameters for the resource/writeable types

Better late than never...