### PR TITLE
Ensure any test external pages conf is not deployed. This led to #597.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -218,7 +218,7 @@ object ApplicationBuild extends Build {
     // Exclude certain conf files (e.g. those containing secret keys)
     // that we do not want packaged
     excludeFilter in unmanagedResources := ("oauth2.conf"
-        || "parse.conf" || "aws.conf" || "test.conf")
+        || "parse.conf" || "aws.conf" || "test.conf" || "external_pages.conf")
   )
 
   val assetSettings = Seq(


### PR DESCRIPTION
This file has previously been (erroneously) deployed, and the app was reading it instead of the prod file, which also was not being included in the prod conf. This meant that when the site was deployed from the test instance the external pages stopped working.