### PR TITLE
Prevent certain actions evading the maintenance etc filters.

### DIFF
--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -362,7 +362,7 @@ case class DocumentaryUnits @Inject()(implicit globalConfig: global.GlobalConfig
     }
   }
 
-  def exportEad(id: String) = OptionalAuthAction.async { implicit authRequest =>
+  def exportEad(id: String) = OptionalAccountAction.async { implicit authRequest =>
     val eadId: String = docRoutes.exportEad(id).absoluteURL(globalConfig.https)
 
     EadExporter(userBackend).exportEad(id, eadId).map { xml =>

--- a/modules/core/app/controllers/base/CoreActionBuilders.scala
+++ b/modules/core/app/controllers/base/CoreActionBuilders.scala
@@ -248,13 +248,17 @@ trait CoreActionBuilders extends Controller with ControllerHelpers with AuthActi
    *  - the site is not in maintenance mode
    *  - they are allowed in this controller
    */
-  protected def OptionalUserAction =
+  protected def OptionalAccountAction =
     OptionalAuthAction andThen
-    MaintenanceFilter andThen
-    IpFilter andThen
-    ReadOnlyTransformer andThen
-    AllowedFilter andThen
-    FetchProfile
+      MaintenanceFilter andThen
+      IpFilter andThen
+      ReadOnlyTransformer andThen
+      AllowedFilter
+
+  /**
+   * Fetch the profile in addition to the account
+   */
+  protected def OptionalUserAction = OptionalAccountAction andThen FetchProfile
 
   /**
    * Ensure that a user is present

--- a/modules/portal/app/controllers/portal/account/Accounts.scala
+++ b/modules/portal/app/controllers/portal/account/Accounts.scala
@@ -190,7 +190,7 @@ case class Accounts @Inject()(implicit globalConfig: GlobalConfig, searchEngine:
 
   def signup = loginOrSignup(isLogin = false)
 
-  def loginOrSignup(isLogin: Boolean) = OptionalAuthAction { implicit authRequest =>
+  def loginOrSignup(isLogin: Boolean) = OptionalAccountAction { implicit authRequest =>
     if (globalConfig.readOnly) {
       Redirect(portalRoutes.index()).flashing("warning" -> "login.disabled")
     } else {

--- a/modules/portal/app/controllers/portal/base/PortalController.scala
+++ b/modules/portal/app/controllers/portal/base/PortalController.scala
@@ -184,7 +184,7 @@ trait PortalController
   /**
    * Action which fetches a user's profile and list of watched items.
    */
-  protected def UserBrowseAction = OptionalAuthAction andThen new ActionTransformer[OptionalAuthRequest, UserDetailsRequest] {
+  protected def UserBrowseAction = OptionalAccountAction andThen new ActionTransformer[OptionalAuthRequest, UserDetailsRequest] {
     override protected def transform[A](request: OptionalAuthRequest[A]): Future[UserDetailsRequest[A]] = {
       request.user.map { account =>
         import play.api.libs.concurrent.Execution.Implicits._


### PR DESCRIPTION
These were using `OptionalAuthAction` directly, which was bad.

Fixes #560.