### PR TITLE
Fix entity type restrictions on the link item select view.

### DIFF
--- a/modules/core/app/controllers/generic/Linking.scala
+++ b/modules/core/app/controllers/generic/Linking.scala
@@ -57,7 +57,11 @@ trait Linking[MT <: AnyModel] extends Read[MT] with Search {
     WithItemPermissionAction(id, PermissionType.Annotate) andThen new ActionTransformer[ItemPermissionRequest, LinkSelectRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[LinkSelectRequest[A]] = {
         implicit val req = request
-        find[AnyModel](facetBuilder = facets, defaultParams = SearchParams(entities = List(toType), excludes=Some(List(id)))).map { r =>
+        find[AnyModel](
+          facetBuilder = facets,
+          defaultParams = SearchParams(excludes=Some(List(id))),
+          entities = Seq(toType)
+        ).map { r =>
           LinkSelectRequest(request.item, r, toType, request.userOpt, request)
         }
       }

--- a/test/integration/DocumentaryUnitViewsSpec.scala
+++ b/test/integration/DocumentaryUnitViewsSpec.scala
@@ -404,6 +404,15 @@ class DocumentaryUnitViewsSpec extends IntegrationTestRunner {
         docRoutes.get("c4").url)
     }
 
+    "offer correct set of types to link against" in new ITestApp {
+      val select = route(fakeLoggedInHtmlRequest(privilegedUser,
+        docRoutes.linkAnnotateSelect("c1", EntityType.DocumentaryUnit))).get
+      contentAsString(select) must contain(docRoutes
+        .linkAnnotate("c1", EntityType.DocumentaryUnit, "c4").url)
+      contentAsString(select) must not contain(docRoutes
+        .linkAnnotate("c1", EntityType.DocumentaryUnit, "a1").url)
+    }
+
     "allow linking to items via annotation" in new ITestApp {
       val testItem = "c1"
       val linkSrc = "cvocc1"


### PR DESCRIPTION
Due to the confusingness of the search API, this was not being applied
as previously.

TODO: Fix the search API to be less confusing.

Fixes #606.