### PR TITLE
Change the default distance for geo facets, when none specified in the query.

### DIFF
--- a/modules/guides/app/controllers/portal/guides/Guides.scala
+++ b/modules/guides/app/controllers/portal/guides/Guides.scala
@@ -88,7 +88,7 @@ case class Guides @Inject()(implicit globalConfig: global.GlobalConfig, searchEn
           "pt" -> s"$lat,$lng",
           "sfield" -> "location",
           "sort" -> "geodist() asc",
-          "d" -> dist.getOrElse(1.0),
+          "d" -> dist.getOrElse(1000), // km
           "fq" -> "{!bbox}"
         )
       }


### PR DESCRIPTION
The previous default of 1.0 (km) didn't work for the Jewish council guide, and just happened to work for the Terezin one because most the of geo facets are closely clustered around the same point.

Fixes #615.