### PR TITLE
Restrict the format of external page ids (fixes #635)

### DIFF
--- a/modules/portal/conf/portal.routes
+++ b/modules/portal/conf/portal.routes
@@ -19,7 +19,7 @@ GET         /contact                              @controllers.portal.Portal.con
 GET         /about                                @controllers.portal.Portal.about
 GET         /terms                                @controllers.portal.Portal.terms
 
-GET         /help/:page                           @controllers.portal.Portal.externalPage(page: String)
+GET         /help/$page<\w+>                      @controllers.portal.Portal.externalPage(page: String)
 
 # Change locale
 GET         /prefs                                @controllers.portal.Portal.prefs

--- a/test/integration/portal/PortalSpec.scala
+++ b/test/integration/portal/PortalSpec.scala
@@ -88,5 +88,10 @@ class PortalSpec extends IntegrationTestRunner {
       status(faq) must equalTo(OK)
       contentAsString(faq) must contain(mockdata.externalPages.get("faq").get.toString())
     }
+
+    "return 404 for external pages with a malformed id (bug #635)" in new ITestApp {
+      val faq = FakeRequest(portalRoutes.externalPage(",b.name,k.length")).call()
+      status(faq) must equalTo(NOT_FOUND)
+    }
   }
 }


### PR DESCRIPTION
IDs can now only be word-chars.