### PR TITLE
URL encode log message values to prevent higher chars getting mangled.

### DIFF
--- a/modules/backend/src/main/scala/backend/rest/RestDAO.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestDAO.scala
@@ -1,5 +1,7 @@
 package backend.rest
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 
 import play.api.Logger
@@ -130,24 +132,24 @@ trait RestDAO {
    * Header to add for log messages.
    */
   protected def msgHeader(msg: Option[String]): Seq[(String,String)] =
-    msg.map(m => Seq(LOG_MESSAGE_HEADER_NAME -> m)).getOrElse(Seq.empty)
+    msg
+      .map(m => Seq(LOG_MESSAGE_HEADER_NAME -> URLEncoder.encode(m, StandardCharsets.UTF_8.name)))
+      .getOrElse(Seq.empty)
 
   /**
    * Join params into a query string
    */
-  protected def joinQueryString(qs: Map[String, Seq[String]]): String = {
-    import java.net.URLEncoder
+  protected def joinQueryString(qs: Map[String, Seq[String]]): String =
     qs.flatMap { case (key, vals) =>
-      vals.map(v => s"$key=${URLEncoder.encode(v, "UTF-8")}")
+      vals.map(v => s"$key=${URLEncoder.encode(v, StandardCharsets.UTF_8.name)}")
     }.mkString("&")
-  }
 
   /**
    * Standard headers we sent to every Neo4j/EHRI Server request.
    */
   protected val headers = Map(
     HeaderNames.ACCEPT -> ContentTypes.JSON,
-    HeaderNames.ACCEPT_CHARSET -> "UTF-8",
+    HeaderNames.ACCEPT_CHARSET -> StandardCharsets.UTF_8.name,
     HeaderNames.CONTENT_TYPE -> ContentTypes.JSON
   )
 
@@ -164,8 +166,8 @@ trait RestDAO {
    * Create a web request with correct auth parameters for the REST API.
    */
   import scala.collection.JavaConversions._
-  private lazy val includeProps
-    = config.getStringList("ehri.backend.includedProperties").map(_.toSeq)
+  private lazy val includeProps =
+    config.getStringList("ehri.backend.includedProperties").map(_.toSeq)
         .getOrElse(Seq.empty[String])
 
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -28,7 +28,7 @@ object ApplicationBuild extends Build {
     cache,
 
     // Ontology
-    "ehri-project" % "ehri-definitions" % "0.10.2-SNAPSHOT",
+    "ehri-project" % "ehri-definitions" % "0.10.3-SNAPSHOT",
 
     // The ever-vital Joda time
     "joda-time" % "joda-time" % "2.7"
@@ -47,8 +47,8 @@ object ApplicationBuild extends Build {
     // We need the backend code to test against, but exclude any
     // groovy stuff because a) it's not needed, and b) it has a
     // ton of awkward transitive dependencies
-    "ehri-project" % "ehri-frames" % "0.10.2-SNAPSHOT" % "test" classifier "tests" classifier "" exclude("com.tinkerpop.gremlin", "gremlin-groovy") exclude("org.mockito", "mockito-core"),
-    "ehri-project" % "ehri-extension" % "0.10.2-SNAPSHOT" % "test" classifier "tests" classifier "" exclude("com.tinkerpop.gremlin", "gremlin-groovy") exclude("org.mockito", "mockito-core")
+    "ehri-project" % "ehri-frames" % "0.10.3-SNAPSHOT" % "test" classifier "tests" classifier "" exclude("com.tinkerpop.gremlin", "gremlin-groovy") exclude("org.mockito", "mockito-core"),
+    "ehri-project" % "ehri-extension" % "0.10.3-SNAPSHOT" % "test" classifier "tests" classifier "" exclude("com.tinkerpop.gremlin", "gremlin-groovy") exclude("org.mockito", "mockito-core")
   )
 
 

--- a/test/backend/BackendModelSpec.scala
+++ b/test/backend/BackendModelSpec.scala
@@ -102,6 +102,16 @@ class BackendModelSpec extends RestBackendRunner with PlaySpecification {
       await(testBackend.create[UserProfile,UserProfileF](user))
     }
 
+    "use higher characters in log messages" in new WithApplicationLoader(appLoader) {
+      val msg = "This is a 日本語メッセージ"
+      val user = UserProfileF(id = None, identifier = "foobar", name = "Foobar")
+      await(testBackend.create[UserProfile,UserProfileF](user, logMsg = Some(msg)))
+      val history = await(testBackend.history[SystemEvent]("foobar", RangeParams(limit = 1)))
+      history.items.size must_== 1
+      history.head.size must_== 1
+      history.head.head.model.logMessage must_== Some(msg)
+    }
+
     "create an item in (agent) context" in new WithApplicationLoader(appLoader) {
       val doc = DocumentaryUnitF(id = None, identifier = "foobar")
       val r = await(testBackend


### PR DESCRIPTION
Some additional cleanup. Bumb backend version.

Fixes #640.