### PR TITLE
Updates for backend 0.11.0 etc

### DIFF
--- a/conf/logback-play-dev.xml
+++ b/conf/logback-play-dev.xml
@@ -29,21 +29,29 @@
 
   <logger name="play" level="INFO" />
   
-  <!-- Turn down the default level of some classes that log with each
-       application restart -->
-  <logger name="com.zaxxer.hikari.pool.HikariPool" level="ERROR" />
-  <logger name="com.zaxxer.hikari.HikariDataSource" level="ERROR" />
-  <logger name="play.api.libs.concurrent.ActorSystemProvider" level="ERROR" />
-  <logger name="application" level="WARN" />
-  
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
   <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
   <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
   <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
-  <!--  <logger name="com.ning.http.client" level="DEBUG" />
-  <logger name="play.api.libs.ws" level="DEBUG" /> -->
+  <!-- Turn down the default level of some classes that log with each
+       application restart -->
+  <logger name="com.zaxxer.hikari.pool.HikariPool" level="ERROR" />
+  <logger name="com.zaxxer.hikari.HikariDataSource" level="ERROR" />
+  <logger name="play.api.libs.concurrent.ActorSystemProvider" level="ERROR" />
+
+  <!-- Uncomment to see backend request HTTP calls -->
+  <!-- <logger name="backend" level="DEBUG" /> -->
+
+  <!-- Uncomment to log backend transaction opening and closing -->
+  <!--<logger name="eu.ehri.project.core.impl" level="TRACE" />-->
+
+  <!-- Uncomment to show LOTS of debug info about HTTP calls -->
+  <!-- <logger name="com.ning.http.client" level="DEBUG" /> -->
+  <!-- <logger name="play.api.libs.ws" level="DEBUG" /> -->
+
+  <logger name="application" level="WARN" />
 
   <root level="ERROR">
     <appender-ref ref="STDOUT" />

--- a/modules/admin/app/controllers/admin/ApiController.scala
+++ b/modules/admin/app/controllers/admin/ApiController.scala
@@ -32,7 +32,7 @@ case class ApiController @Inject()(
 ) extends AdminController {
 
   def listItems(contentType: EntityType.Value) = Action.async { implicit request =>
-    get(s"$contentType/list")(request)
+    get(contentType)(request)
   }
 
   def getItem(contentType: EntityType.Value, id: String) = Action.async { implicit request =>

--- a/modules/backend/src/main/scala/backend/rest/RestEvents.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestEvents.scala
@@ -31,8 +31,7 @@ trait RestEvents extends Events with RestDAO with RestContext {
   }
 
   override def listEvents[A: Readable](params: RangeParams, filters: SystemEventParams = SystemEventParams.empty): Future[RangePage[Seq[A]]] = {
-    val url = enc(requestUrl, "aggregate")
-    fetchRange(userCall(url, filters.toSeq), params, Some(url))(Reads.seq(Readable[A].restReads))
+    fetchRange(userCall(requestUrl, filters.toSeq), params, Some(requestUrl))(Reads.seq(Readable[A].restReads))
   }
 
   override def listUserActions[A: Readable](userId: String, params: RangeParams, filters: SystemEventParams = SystemEventParams.empty): Future[RangePage[Seq[A]]] = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -23,12 +23,16 @@ object ApplicationBuild extends Build {
   val appName = "docview"
   val appVersion = "1.0.4-SNAPSHOT"
 
+  val backendVersion = "0.11.0-SNAPSHOT"
+  val neo4jVersion = "2.2.5"
+  val jerseyVersion = "1.19"
+
   val backendDependencies = Seq(
     ws,
     cache,
 
     // Ontology
-    "ehri-project" % "ehri-definitions" % "0.10.4-SNAPSHOT",
+    "ehri-project" % "ehri-definitions" % backendVersion,
 
     // The ever-vital Joda time
     "joda-time" % "joda-time" % "2.8.1"
@@ -36,19 +40,22 @@ object ApplicationBuild extends Build {
 
   val backendTestDependencies = Seq(
     specs2 % Test,
-    "org.neo4j" % "neo4j-kernel" % "2.2.1" % "test" classifier "tests" classifier "" exclude("org.mockito", "mockito-core"),
-    "org.neo4j" % "neo4j-io" % "2.2.1" % "test" classifier "tests" classifier "" exclude("org.mockito", "mockito-core"),
-    "org.neo4j.app" % "neo4j-server" % "2.2.1" % "test" classifier "tests" classifier "" exclude("org.mockito", "mockito-core"),
+    "org.neo4j" % "neo4j-kernel" % neo4jVersion % "test" classifier "tests" classifier "" exclude("org.mockito", "mockito-core"),
+    "org.neo4j" % "neo4j-io" % neo4jVersion % "test" classifier "tests" classifier "" exclude("org.mockito", "mockito-core"),
+    "org.neo4j.app" % "neo4j-server" % neo4jVersion % "test" classifier "tests" classifier "" exclude("org.mockito",
+      "mockito-core"),
     "org.hamcrest" % "hamcrest-all" % "1.3" % "test",
 
     // This is necessary to allow the Neo4j server to start
-    "com.sun.jersey" % "jersey-core" % "1.18.2" % "test",
+    "com.sun.jersey" % "jersey-core" % jerseyVersion % "test",
+    "com.sun.jersey" % "jersey-server" % jerseyVersion % "test",
 
     // We need the backend code to test against, but exclude any
     // groovy stuff because a) it's not needed, and b) it has a
     // ton of awkward transitive dependencies
-    "ehri-project" % "ehri-frames" % "0.10.4-SNAPSHOT" % "test" classifier "tests" classifier "" exclude("com.tinkerpop.gremlin", "gremlin-groovy") exclude("org.mockito", "mockito-core"),
-    "ehri-project" % "ehri-extension" % "0.10.4-SNAPSHOT" % "test" classifier "tests" classifier "" exclude("com.tinkerpop.gremlin", "gremlin-groovy") exclude("org.mockito", "mockito-core")
+    "ehri-project" % "ehri-frames" % backendVersion % "test" classifier "tests" classifier "" exclude("com.tinkerpop.gremlin",
+      "gremlin-groovy") exclude("org.mockito", "mockito-core"),
+    "ehri-project" % "ehri-extension" % backendVersion % "test" classifier "tests" classifier "" exclude("com.tinkerpop.gremlin", "gremlin-groovy") exclude("org.mockito", "mockito-core")
   )
 
 
@@ -93,8 +100,9 @@ object ApplicationBuild extends Build {
     "com.opencsv" % "opencsv" % "3.4",
 
     // EHRI indexing tools
-    "ehri-project" % "index-data-converter" % "1.1.1-SNAPSHOT" exclude("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"),
-    "com.sun.jersey" % "jersey-core" % "1.18.2",
+    "ehri-project" % "index-data-converter" % "1.1.3-SNAPSHOT" exclude("log4j", "log4j") exclude ("org.slf4j",
+      "slf4j-log4j12"),
+    "com.sun.jersey" % "jersey-core" % jerseyVersion,
 
     // S3 Upload plugin
     "com.github.seratch" %% "awscala" % "0.3.+"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")
 

--- a/test/backend/BackendModelSpec.scala
+++ b/test/backend/BackendModelSpec.scala
@@ -238,6 +238,11 @@ class BackendModelSpec extends RestBackendRunner with PlaySpecification {
       r mustEqual 5L
     }
 
+    "count child items" in new WithApplicationLoader(appLoader) {
+      var r = await(testBackend.countChildren[DocumentaryUnit]("c1"))
+      r mustEqual 1L
+    }
+
     "emit appropriate signals" in new WithApplicationLoader(appLoader) {
     }
   }


### PR DESCRIPTION
Update client for backend 0.11.0.

 - remove `/list` from list endpoints
 - do counting via `HEAD` requests on the list endpoints
 - fixes for finer-grained logging on backend
 - update to Play 2.4.3
 - tweak index mediator API
 - small tweaks to the build