### PR TITLE
Use chunked encoding for EAD export, since we don't know the size.

### DIFF
--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -383,15 +383,13 @@ case class DocumentaryUnits @Inject()(
 
   def exportEad(id: String) = OptionalAccountAction.async { implicit authRequest =>
     val eadId: String = docRoutes.exportEad(id).absoluteURL(globalConfig.https)
-
     EadExporter(userBackend).exportEad(id, eadId).map { ead =>
-
       val enumerator = Enumerator.outputStream { os =>
         val writer = new OutputStreamWriter(os)
         xmlPrinter.write(xml.XML.loadString(ead), null, addXmlDeclaration = true)(writer)
       }
 
-      Ok.stream(enumerator >>> Enumerator.eof).as(MimeTypes.XML)
+      Ok.chunked(enumerator.andThen(Enumerator.eof)).as(MimeTypes.XML)
     }
   }
 }

--- a/modules/admin/app/utils/ead/ToEadSerializer.java
+++ b/modules/admin/app/utils/ead/ToEadSerializer.java
@@ -1,6 +1,7 @@
 package utils.ead;
 
 import org.parboiled.common.StringUtils;
+import org.pegdown.FastEncoder;
 import org.pegdown.LinkRenderer;
 import org.pegdown.Printer;
 import org.pegdown.ast.*;
@@ -20,8 +21,8 @@ import static org.parboiled.common.Preconditions.checkArgNotNull;
  */
 public class ToEadSerializer implements Visitor {
     protected Printer printer = new Printer();
-    protected final Map<String, ReferenceNode> references = new HashMap<String, ReferenceNode>();
-    protected final Map<String, String> abbreviations = new HashMap<String, String>();
+    protected final Map<String, ReferenceNode> references = new HashMap<>();
+    protected final Map<String, String> abbreviations = new HashMap<>();
     protected final LinkRenderer linkRenderer;
 
     protected TableNode currentTableNode;
@@ -359,11 +360,11 @@ public class ToEadSerializer implements Visitor {
 
     protected void printLink(LinkRenderer.Rendering rendering) {
         printer.print('<').print("extptr");
-        printAttribute("href", rendering.href);
+        printAttribute("href", FastEncoder.encode(rendering.href));
         for (LinkRenderer.Attribute attr : rendering.attributes) {
             printAttribute(attr.name, attr.value);
         }
-        printer.print('>').print(rendering.text).print("</extptr>");
+        printer.print('>').printEncoded(rendering.text).print("</extptr>");
     }
 
     private void printAttribute(String name, String value) {
@@ -416,7 +417,7 @@ public class ToEadSerializer implements Visitor {
 
                 // ok, legal match so save an expansions "task" for all matches
                 if (expansions == null) {
-                    expansions = new TreeMap<Integer, Map.Entry<String, String>>();
+                    expansions = new TreeMap<>();
                 }
                 expansions.put(sx, entry);
             }

--- a/modules/admin/test/views/export/ead/ToEadSerializerSpec.scala
+++ b/modules/admin/test/views/export/ead/ToEadSerializerSpec.scala
@@ -40,7 +40,7 @@ class ToEadSerializerSpec extends PlaySpecification {
       | 2. two item
       | 3. three item
       |
-      |Blah blah and [a link](http://portal.ehri-project.eu).
+      |Blah blah and [a link](http://portal.ehri-project.eu?foo=bar&bar=baz).
     """.stripMargin
 
   "ToEadSerializer" should {
@@ -55,6 +55,7 @@ class ToEadSerializerSpec extends PlaySpecification {
       ead must contain("<list>")
       ead must contain("<item>")
       ead must not contain "<item><p>"
+      ead must contain("http://portal.ehri-project.eu?foo=bar&amp;bar=baz")
       ead must contain("extptr")
     }
   }


### PR DESCRIPTION
Also ensure external web links are XML encoded.

Fixes #655.