### PR TITLE
Update toNeo4j 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-    - 2.10.5
+    - 2.11.7
 
 jdk:
     oraclejdk8

--- a/conf/logback-play-dev.xml
+++ b/conf/logback-play-dev.xml
@@ -27,6 +27,14 @@
     </encoder>
   </appender>
 
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
   <logger name="play" level="INFO" />
   
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
@@ -37,15 +45,14 @@
 
   <!-- Turn down the default level of some classes that log with each
        application restart -->
-  <logger name="com.zaxxer.hikari.pool.HikariPool" level="ERROR" />
-  <logger name="com.zaxxer.hikari.HikariDataSource" level="ERROR" />
+  <logger name="com.zaxxer.hikari" level="ERROR" />
   <logger name="play.api.libs.concurrent.ActorSystemProvider" level="ERROR" />
 
   <!-- Uncomment to see backend request HTTP calls -->
   <!-- <logger name="backend" level="DEBUG" /> -->
 
   <!-- Uncomment to log backend transaction opening and closing -->
-  <!--<logger name="eu.ehri.project.core.impl" level="TRACE" />-->
+  <!-- <logger name="eu.ehri.project.core.impl" level="TRACE" /> -->
 
   <!-- Uncomment to show LOTS of debug info about HTTP calls -->
   <!-- <logger name="com.ning.http.client" level="DEBUG" /> -->
@@ -54,8 +61,8 @@
   <logger name="application" level="WARN" />
 
   <root level="ERROR">
-    <appender-ref ref="STDOUT" />
-    <appender-ref ref="FILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
+    <appender-ref ref="ASYNCFILE" />
   </root>
   
 </configuration>

--- a/modules/admin/app/controllers/admin/Utils.scala
+++ b/modules/admin/app/controllers/admin/Utils.scala
@@ -115,10 +115,7 @@ case class Utils @Inject()(
 
     for {
       allAccounts <- accounts.findAll(PageParams.empty.withoutLimit)
-      profileIds <- cypher.get(
-        """START n = node:entities("__ISA__:userProfile")
-          |RETURN n.__ID__
-        """.stripMargin, Map.empty)(stringList)
+      profileIds <- cypher.get("MATCH (n:userProfile) RETURN n.__ID__", Map.empty)(stringList)
       accountIds = allAccounts.map(_.id)
     } yield {
       val noProfile = accountIds.diff(profileIds)

--- a/modules/backend/src/main/scala/backend/rest/RestHelpers.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestHelpers.scala
@@ -1,7 +1,7 @@
 package backend.rest
 
 import play.api.cache.CacheApi
-import play.api.libs.json.{JsString, JsValue}
+import play.api.libs.json.JsValue
 import defines.EntityType
 import play.api.libs.concurrent.Execution.Implicits._
 import scala.concurrent.Future
@@ -14,24 +14,17 @@ trait RestHelpers {
   implicit def cache: CacheApi
   def cypher: Cypher
 
-  def parseUsers(json: JsValue): Seq[(String, String)] = {
+  private def parseIds(json: JsValue): Seq[(String, String)] = {
     (json \ "data").as[Seq[Seq[String]]].flatMap {
       case x :: y :: _ => Some((x, y))
       case _ => None
     }
   }
 
-  def getGroupList: Future[Seq[(String,String)]] = {
-    cypher.cypher("START n=node:entities(__ISA__ = {isA}) RETURN n.__ID__, n.name",
-        Map("isA" -> JsString(EntityType.Group))).map { goe =>
-      parseUsers(goe)
-    }    
-  }
+  private def getTypeIdAndName(s: EntityType.Value): Future[Seq[(String, String)]] =
+    cypher.cypher(s"MATCH (n:$s) RETURN n.__ID__, n.name").map(parseIds)
+
+  def getGroupList: Future[Seq[(String,String)]] = getTypeIdAndName(EntityType.Group)
   
-  def getUserList: Future[Seq[(String,String)]] = {
-    cypher.cypher("START n=node:entities(__ISA__ = {isA}) RETURN n.__ID__, n.name",
-        Map("isA" -> JsString(EntityType.UserProfile))).map { goe =>
-      parseUsers(goe)
-    }    
-  }  
+  def getUserList: Future[Seq[(String,String)]] = getTypeIdAndName(EntityType.UserProfile)
 }


### PR DESCRIPTION
 - Bumped backend to 0.11.1, Neo4j to 2.3.0, and Scala to 2.11.7.
 - Some additional cleanups to build and logger config.
 - Don't chunk Cypher responses when query came via Ajax.

JS doesn't handle chunked responses very nicely. Also tweak some
Cypher queries to use MATCH and labels instead of START.