### PR TITLE
Cleanup refactoring, more type safely, better testing of murky areas.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot/
 
-script:
-  # Your normal script
-  - sbt ++$TRAVIS_SCALA_VERSION -J-XX:ReservedCodeCacheSize=256M test
-
+before_cache:
   #     # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" -exec rm "{}" ";"
   - find $HOME/.ivy2 -name "ivydata-*.properties" -exec rm "{}" ";"
+
+script:
+  # Your normal script
+  - sbt ++$TRAVIS_SCALA_VERSION -J-XX:ReservedCodeCacheSize=256M test

--- a/modules/backend/src/main/scala/backend/rest/RestDAO.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestDAO.scala
@@ -116,7 +116,7 @@ trait RestDAO {
      */
     def withBody[T](body: T)(implicit wrt: Writeable[T], ct: ContentTypeOf[T]): BackendRequest = {
       val wsBody = InMemoryBody(wrt.transform(body))
-      if (headers.contains(HeaderNames.CONTENT_TYPE)) {
+      if (headers.toMap.contains(HeaderNames.CONTENT_TYPE)) {
         withBody(wsBody)
       } else {
         ct.mimeType.fold(withBody(wsBody)) { contentType =>
@@ -248,7 +248,7 @@ trait RestDAO {
             e => {
               // Temporary approach to handling random Deserialization errors.
               // In practice this should happen
-              if ((response.json \ "error").asOpt[String] == Some("DeserializationError")) {
+              if ((response.json \ "error").asOpt[String].contains("DeserializationError")) {
                 logger.error(s"Derialization error! : ${response.json}")
                 throw DeserializationError()
               } else {

--- a/modules/core/app/controllers/core/auth/persona/PersonaLoginHandler.scala
+++ b/modules/core/app/controllers/core/auth/persona/PersonaLoginHandler.scala
@@ -63,7 +63,7 @@ trait PersonaLoginHandler extends AccountHelpers {
                     r <- f(Right(account))(request)
                   } yield r
               }
-            case other => f(Left(other.toString()))(request)
+            case other => f(Left(other.toString))(request)
           }
         }
       }

--- a/modules/core/app/controllers/generic/AccessPoints.scala
+++ b/modules/core/app/controllers/generic/AccessPoints.scala
@@ -87,7 +87,7 @@ trait AccessPoints[D <: Description, T <: Model with Described[D], MT <: MetaMod
         val list = item.model.descriptions.map { desc =>
           val accessPointTypes = AccessPointF.AccessPointType.values.toList.map { apt =>
             val apTypes = desc.accessPoints.filter(_.accessPointType == apt).map { ap =>
-              val linkOpt = links.find(_.bodies.exists(b => b.id == ap.id))
+              val linkOpt = links.find(_.bodies.exists(b => b.model.id == ap.id))
               new LinkItem(
                 ap,
                 linkOpt.map(_.model),

--- a/modules/core/app/controllers/generic/Linking.scala
+++ b/modules/core/app/controllers/generic/Linking.scala
@@ -189,7 +189,7 @@ trait Linking[MT <: AnyModel] extends Read[MT] with Search {
    */
   def getLink(id: String, apid: String) = OptionalUserAction.async { implicit  request =>
     userBackend.getLinksForItem[Link](id).map { links =>
-      val linkOpt = links.find(link => link.bodies.exists(b => b.id == Some(apid)))
+      val linkOpt = links.find(link => link.bodies.exists(b => b.model.id.contains(apid)))
       val res = for {
         link <- linkOpt
         target <- link.opposingTarget(id)

--- a/modules/core/app/controllers/generic/Search.scala
+++ b/modules/core/app/controllers/generic/Search.scala
@@ -38,7 +38,7 @@ trait Search extends CoreActionBuilders {
    * request, as opposed to facet filtering a full list.
    */
   protected def hasActiveQuery(request: RequestHeader): Boolean =
-    request.getQueryString(SearchParams.QUERY).filter(_.nonEmpty).isDefined
+    request.getQueryString(SearchParams.QUERY).exists(_.nonEmpty)
 
   private def bindFacetsFromRequest(facetClasses: Seq[FacetClass[Facet]])(implicit request: RequestHeader): Seq[AppliedFacet] =
     facetClasses.flatMap { fc =>

--- a/modules/core/app/defines/EnumerationBinders.scala
+++ b/modules/core/app/defines/EnumerationBinders.scala
@@ -2,6 +2,8 @@ package defines
 
 import play.api.mvc.{QueryStringBindable, PathBindable}
 
+import scala.language.implicitConversions
+
 /**
  * @author Mike Bryant (http://github.com/mikesname)
  */

--- a/modules/core/app/models/AccessPoint.scala
+++ b/modules/core/app/models/AccessPoint.scala
@@ -78,13 +78,13 @@ case class AccessPointF(
    * Given a set of links, see if we can find one with this access point
    * as a body.
    */
-  def linkFor(links: Seq[Link]): Option[Link] = links.find(_.bodies.exists(body => body.id == id))
+  def linkFor(links: Seq[Link]): Option[Link] = links.find(_.bodies.exists(body => body.model.id == id))
 
   /**
    * Given a set of links, see if we can find one with this access point
    * as a body.
    */
-  def linksFor(links: Seq[Link]): Seq[Link] = links.filter(_.bodies.exists(body => body.id == id))
+  def linksFor(links: Seq[Link]): Seq[Link] = links.filter(_.bodies.exists(body => body.model.id == id))
 
   /**
    * Given an item and a set of links, see if we can resolve the
@@ -113,7 +113,7 @@ object AccessPoint {
 
 
   def linksOfType(links: Seq[Link], `type`: AccessPointF.AccessPointType.Value): Seq[Link]
-      = links.filter(_.bodies.exists(body => body.accessPointType == `type`))
+      = links.filter(_.bodies.exists(body => body.model.accessPointType == `type`))
 
   val form = Form(mapping(
     ISA -> ignored(EntityType.AccessPoint),

--- a/modules/core/app/models/Annotation.scala
+++ b/modules/core/app/models/Annotation.scala
@@ -109,13 +109,13 @@ object Annotation {
    * Filter annotations on individual fields
    */
   def fieldAnnotations(partId: Option[String], annotations: Seq[Annotation]): Seq[Annotation] =
-    annotations.filter(_.targetParts.exists(p => Some(p.id) == partId)).filter(_.model.field.isDefined)
+    annotations.filter(_.targetParts.exists(p => partId.contains(p.id))).filter(_.model.field.isDefined)
 
   /**
    * Filter annotations on the item
    */
   def itemAnnotations(partId: Option[String], annotations: Seq[Annotation]): Seq[Annotation] =
-    annotations.filter(_.targetParts.exists(p => Some(p.id) == partId))
+    annotations.filter(_.targetParts.exists(p => partId.contains(p.id)))
 
   /**
    * Filter annotations on the item

--- a/modules/core/app/models/Concept.scala
+++ b/modules/core/app/models/Concept.scala
@@ -42,7 +42,7 @@ object ConceptF {
           IDENTIFIER -> d.identifier
         ),
         RELATIONSHIPS -> Json.obj(
-          DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)).toSeq)
+          DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)))
         )
       )
     }
@@ -74,6 +74,7 @@ case class ConceptF(
 object Concept {
   import eu.ehri.project.definitions.Ontology._
   import play.api.libs.functional.syntax._
+  import DescribedMeta._
   import Entity._
 
   private implicit val systemEventReads = SystemEvent.SystemEventResource.restReads
@@ -101,10 +102,10 @@ object Concept {
 
   val form = Form(
     mapping(
-      Entity.ISA -> ignored(EntityType.Concept),
-      Entity.ID -> optional(nonEmptyText),
-      Entity.IDENTIFIER -> nonEmptyText,
-      "descriptions" -> seq(ConceptDescription.form.mapping)
+      ISA -> ignored(EntityType.Concept),
+      ID -> optional(nonEmptyText),
+      IDENTIFIER -> nonEmptyText,
+      DESCRIPTIONS -> seq(ConceptDescription.form.mapping)
     )(ConceptF.apply)(ConceptF.unapply)
   )
 }

--- a/modules/core/app/models/ConceptDescription.scala
+++ b/modules/core/app/models/ConceptDescription.scala
@@ -36,8 +36,8 @@ object ConceptDescriptionF {
           CREATION_PROCESS -> d.creationProcess
         ),
         RELATIONSHIPS -> Json.obj(
-          Ontology.HAS_ACCESS_POINT -> Json.toJson(d.accessPoints.map(Json.toJson(_)).toSeq),
-          Ontology.HAS_UNKNOWN_PROPERTY -> Json.toJson(d.unknownProperties.map(Json.toJson(_)).toSeq)
+          Ontology.HAS_ACCESS_POINT -> Json.toJson(d.accessPoints.map(Json.toJson(_))),
+          Ontology.HAS_UNKNOWN_PROPERTY -> Json.toJson(d.unknownProperties.map(Json.toJson(_)))
         )
       )
     }

--- a/modules/core/app/models/DocumentaryUnit.scala
+++ b/modules/core/app/models/DocumentaryUnit.scala
@@ -55,7 +55,7 @@ object DocumentaryUnitF {
           SCOPE -> d.scope
         ),
         RELATIONSHIPS -> Json.obj(
-          Ontology.DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)).toSeq)
+          Ontology.DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)))
         )
       )
     }
@@ -94,12 +94,13 @@ case class DocumentaryUnitF(
   with Persistable
   with Described[DocumentaryUnitDescriptionF] {
 
-  override def description(did: String): Option[DocumentaryUnitDescriptionF]
-    = descriptions.find(d => d.id.isDefined && d.id.get == did)
+  override def description(did: String): Option[DocumentaryUnitDescriptionF] =
+    descriptions.find(d => d.id.isDefined && d.id.get == did)
 }
 
 object DocumentaryUnit {
   import Entity._
+  import DescribedMeta._
   import models.DocumentaryUnitF._
   import eu.ehri.project.definitions.Ontology.{OTHER_IDENTIFIERS => _, _}
   import defines.EnumUtils.enumMapping
@@ -142,7 +143,7 @@ object DocumentaryUnit {
       PUBLICATION_STATUS -> optional(enumMapping(models.PublicationStatus)),
       COPYRIGHT -> optional(enumMapping(CopyrightStatus)),
       SCOPE -> optional(enumMapping(Scope)),
-      "descriptions" -> seq(DocumentaryUnitDescription.form.mapping)
+      DESCRIPTIONS -> seq(DocumentaryUnitDescription.form.mapping)
     )(DocumentaryUnitF.apply)(DocumentaryUnitF.unapply)
   )
 }

--- a/modules/core/app/models/DocumentaryUnitDescription.scala
+++ b/modules/core/app/models/DocumentaryUnitDescription.scala
@@ -113,10 +113,10 @@ object DocumentaryUnitDescriptionF {
           CREATION_PROCESS -> d.creationProcess
         ),
         RELATIONSHIPS -> Json.obj(
-          ENTITY_HAS_DATE -> Json.toJson(d.dates.map(Json.toJson(_)).toSeq),
-          HAS_ACCESS_POINT -> Json.toJson(d.accessPoints.map(Json.toJson(_)).toSeq),
-          HAS_MAINTENANCE_EVENT -> Json.toJson(d.maintenanceEvents.map(Json.toJson(_)).toSeq),
-          HAS_UNKNOWN_PROPERTY -> Json.toJson(d.unknownProperties.map(Json.toJson(_)).toSeq)
+          ENTITY_HAS_DATE -> Json.toJson(d.dates.map(Json.toJson(_))),
+          HAS_ACCESS_POINT -> Json.toJson(d.accessPoints.map(Json.toJson(_))),
+          HAS_MAINTENANCE_EVENT -> Json.toJson(d.maintenanceEvents.map(Json.toJson(_))),
+          HAS_UNKNOWN_PROPERTY -> Json.toJson(d.unknownProperties.map(Json.toJson(_)))
         )
       )
     }

--- a/modules/core/app/models/HistoricalAgent.scala
+++ b/modules/core/app/models/HistoricalAgent.scala
@@ -36,7 +36,7 @@ object HistoricalAgentF {
           PUBLICATION_STATUS -> d.publicationStatus
         ),
         RELATIONSHIPS -> Json.obj(
-          DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)).toSeq)
+          DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)))
         )
       )
     }
@@ -73,6 +73,7 @@ case class HistoricalAgentF(
 object HistoricalAgent {
   import play.api.libs.functional.syntax._
   import Entity._
+  import DescribedMeta._
   import HistoricalAgentF._
   import Ontology._
   import defines.EnumUtils.enumMapping
@@ -100,7 +101,7 @@ object HistoricalAgent {
       ID -> optional(nonEmptyText),
       IDENTIFIER -> nonEmptyText(minLength=2), // TODO: Increase to > 2, not done yet 'cos of test fixtures,
       PUBLICATION_STATUS -> optional(enumMapping(models.PublicationStatus)),
-      "descriptions" -> seq(HistoricalAgentDescription.form.mapping)
+      DESCRIPTIONS -> seq(HistoricalAgentDescription.form.mapping)
     )(HistoricalAgentF.apply)(HistoricalAgentF.unapply)
   )
 }

--- a/modules/core/app/models/HistoricalAgentDescription.scala
+++ b/modules/core/app/models/HistoricalAgentDescription.scala
@@ -78,8 +78,8 @@ object HistoricalAgentDescriptionF {
           CREATION_PROCESS -> d.creationProcess
         ),
         RELATIONSHIPS -> Json.obj(
-          HAS_ACCESS_POINT -> Json.toJson(d.accessPoints.map(Json.toJson(_)).toSeq),
-          HAS_UNKNOWN_PROPERTY -> Json.toJson(d.unknownProperties.map(Json.toJson(_)).toSeq),
+          HAS_ACCESS_POINT -> Json.toJson(d.accessPoints.map(Json.toJson(_))),
+          HAS_UNKNOWN_PROPERTY -> Json.toJson(d.unknownProperties.map(Json.toJson(_))),
           ENTITY_HAS_DATE -> Json.toJson(d.dates.map(Json.toJson(_)))
         )
       )

--- a/modules/core/app/models/Link.scala
+++ b/modules/core/app/models/Link.scala
@@ -43,7 +43,7 @@ object LinkF {
           IS_PROMOTABLE -> d.isPromotable
         ),
         RELATIONSHIPS -> Json.obj(
-          ENTITY_HAS_DATE -> Json.toJson(d.dates.map(Json.toJson(_)).toSeq)
+          ENTITY_HAS_DATE -> Json.toJson(d.dates.map(Json.toJson(_)))
         )
       )
     }
@@ -67,7 +67,7 @@ case class LinkF(
   isA: EntityType.Value = EntityType.Link,
   id: Option[String],
   linkType: LinkF.LinkType.Type,
-  description: Option[String],
+  description: Option[String] = None,
   isPromotable: Boolean = false,
   @models.relation(Ontology.ENTITY_HAS_DATE)
   dates: Seq[DatePeriodF] = Nil
@@ -88,7 +88,7 @@ object Link {
     __.read[LinkF] and
     (__ \ RELATIONSHIPS \ LINK_HAS_TARGET).lazyNullableSeqReads(AnyModel.Converter.restReads) and
     (__ \ RELATIONSHIPS \ LINK_HAS_LINKER).nullableHeadReads[UserProfile] and
-    (__ \ RELATIONSHIPS \ LINK_HAS_BODY).nullableSeqReads[AccessPointF] and
+    (__ \ RELATIONSHIPS \ LINK_HAS_BODY).nullableSeqReads[AccessPoint] and
     (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyNullableSeqReads(Accessor.Converter.restReads) and
     (__ \ RELATIONSHIPS \ PROMOTED_BY).nullableSeqReads[UserProfile] and
     (__ \ RELATIONSHIPS \ DEMOTED_BY).nullableSeqReads[UserProfile] and
@@ -126,7 +126,7 @@ case class Link(
   model: LinkF,
   targets: Seq[AnyModel] = Nil,
   user: Option[UserProfile] = None,
-  bodies: Seq[AccessPointF] = Nil,
+  bodies: Seq[AccessPoint] = Nil,
   accessors: Seq[Accessor] = Nil,
   promoters: Seq[UserProfile] = Nil,
   demoters: Seq[UserProfile] = Nil,

--- a/modules/core/app/models/Relation.java
+++ b/modules/core/app/models/Relation.java
@@ -16,5 +16,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER,ElementType.FIELD,ElementType.METHOD})
 public @interface Relation {
-	public String value();
+	String value();
 }

--- a/modules/core/app/models/Repository.scala
+++ b/modules/core/app/models/Repository.scala
@@ -42,7 +42,7 @@ object RepositoryF {
           LOGO_URL -> d.logoUrl
         ),
         RELATIONSHIPS -> Json.obj(
-          DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)).toSeq)
+          DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)))
         )
       )
     }
@@ -120,6 +120,7 @@ case class Repository(
 
 object Repository {
   import Entity._
+  import DescribedMeta._
   import RepositoryF._
   import Ontology._
   import defines.EnumUtils.enumMapping
@@ -155,7 +156,7 @@ object Repository {
       ID -> optional(nonEmptyText),
       IDENTIFIER -> nonEmptyText(minLength=2), // TODO: Increase to > 2, not done yet 'cos of test fixtures
       PUBLICATION_STATUS -> optional(enumMapping(models.PublicationStatus)),
-      "descriptions" -> seq(RepositoryDescription.form.mapping),
+      DESCRIPTIONS -> seq(RepositoryDescription.form.mapping),
       PRIORITY -> optional(number(min = -1, max = 5)),
       URL_PATTERN -> optional(nonEmptyText verifying("errors.badUrlPattern",
         pattern => validateUrlPattern(pattern)

--- a/modules/core/app/models/RepositoryDescription.scala
+++ b/modules/core/app/models/RepositoryDescription.scala
@@ -91,10 +91,10 @@ object RepositoryDescriptionF {
           CREATION_PROCESS -> d.creationProcess
         ),
         RELATIONSHIPS -> Json.obj(
-          ENTITY_HAS_ADDRESS -> Json.toJson(d.addresses.map(Json.toJson(_)).toSeq),
-          HAS_ACCESS_POINT -> Json.toJson(d.accessPoints.map(Json.toJson(_)).toSeq),
-          HAS_MAINTENANCE_EVENT -> Json.toJson(d.maintenanceEvents.map(Json.toJson(_)).toSeq),
-          HAS_UNKNOWN_PROPERTY -> Json.toJson(d.unknownProperties.map(Json.toJson(_)).toSeq)
+          ENTITY_HAS_ADDRESS -> Json.toJson(d.addresses.map(Json.toJson(_))),
+          HAS_ACCESS_POINT -> Json.toJson(d.accessPoints.map(Json.toJson(_))),
+          HAS_MAINTENANCE_EVENT -> Json.toJson(d.maintenanceEvents.map(Json.toJson(_))),
+          HAS_UNKNOWN_PROPERTY -> Json.toJson(d.unknownProperties.map(Json.toJson(_)))
         )
       )
     }

--- a/modules/core/app/models/SystemEvent.scala
+++ b/modules/core/app/models/SystemEvent.scala
@@ -18,7 +18,7 @@ object SystemEventF {
   final val EVENT_TYPE = "eventType"
   final val FORMAT = "yyyy-MM-dd'T'HH:mm:ssSSSZ"
 
-  import SystemEventF.{EVENT_TYPE => EVENT_PROP, _}
+  import SystemEventF.{EVENT_TYPE => EVENT_PROP}
   import Entity._
 
   // We won't need to use this, since events are created automatically
@@ -64,7 +64,7 @@ case class SystemEventF(
 
 object SystemEvent {
   import play.api.libs.functional.syntax._
-  import SystemEventF.{EVENT_TYPE => EVENT_PROP, _}
+  import SystemEventF._
   import Entity._
   import eu.ehri.project.definitions.Ontology._
 
@@ -103,7 +103,7 @@ case class SystemEvent(
    * rather than the link/annotation itself.
    */
   def effectiveSubject: Option[AnyModel] =
-    if (model.eventType == Some(EventType.link) || model.eventType == Some(EventType.annotation))
+    if (model.eventType.contains(EventType.link) || model.eventType.contains(EventType.annotation))
       scope else firstSubject
 
   import EventType._

--- a/modules/core/app/models/VirtualUnit.scala
+++ b/modules/core/app/models/VirtualUnit.scala
@@ -32,7 +32,7 @@ object VirtualUnitF {
           IDENTIFIER -> d.identifier
         ),
         RELATIONSHIPS -> Json.obj(
-          Ontology.DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)).toSeq)
+          Ontology.DESCRIPTION_FOR_ENTITY -> Json.toJson(d.descriptions.map(Json.toJson(_)))
         )
       )
     }

--- a/modules/core/app/models/json/Utils.scala
+++ b/modules/core/app/models/json/Utils.scala
@@ -3,28 +3,28 @@ package models.json
 import models.base.AnyModel
 import defines.EntityType
 import models._
-import play.api.libs.json.{Format, Reads}
+import play.api.libs.json.Reads
 
 /**
  * @author Mike Bryant (http://github.com/mikesname
  */
 object Utils {
-  val restReadRegistry: Map[EntityType.Value, Reads[AnyModel]] = Map(
-    EntityType.Repository -> Repository.RepositoryResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.Country -> Country.CountryResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.DocumentaryUnit -> DocumentaryUnit.DocumentaryUnitResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.Vocabulary -> Vocabulary.VocabularyResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.Concept -> Concept.ConceptResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.HistoricalAgent -> HistoricalAgent.HistoricalAgentResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.AuthoritativeSet -> AuthoritativeSet.AuthoritativeSetResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.SystemEvent -> SystemEvent.SystemEventResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.Group -> Group.GroupResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.UserProfile -> UserProfile.UserProfileResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.Link -> Link.LinkResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.Annotation -> Annotation.AnnotationResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.PermissionGrant -> PermissionGrant.PermissionGrantResource.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.ContentType -> ContentType.Converter.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.AccessPoint -> AccessPoint.Converter.restReads.asInstanceOf[Reads[AnyModel]],
-    EntityType.VirtualUnit -> VirtualUnit.VirtualUnitResource.restReads.asInstanceOf[Reads[AnyModel]]
-  )
+  val restReadRegistry: PartialFunction[EntityType.Value, Reads[AnyModel]] = {
+    case EntityType.Repository => Repository.RepositoryResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.Country => Country.CountryResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.DocumentaryUnit => DocumentaryUnit.DocumentaryUnitResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.Vocabulary => Vocabulary.VocabularyResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.Concept => Concept.ConceptResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.HistoricalAgent => HistoricalAgent.HistoricalAgentResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.AuthoritativeSet => AuthoritativeSet.AuthoritativeSetResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.SystemEvent => SystemEvent.SystemEventResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.Group => Group.GroupResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.UserProfile => UserProfile.UserProfileResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.Link => Link.LinkResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.Annotation => Annotation.AnnotationResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.PermissionGrant => PermissionGrant.PermissionGrantResource.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.ContentType => ContentType.Converter.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.AccessPoint => AccessPoint.Converter.restReads.asInstanceOf[Reads[AnyModel]]
+    case EntityType.VirtualUnit => VirtualUnit.VirtualUnitResource.restReads.asInstanceOf[Reads[AnyModel]]
+  }
 }

--- a/modules/core/app/utils/search/SearchParams.scala
+++ b/modules/core/app/utils/search/SearchParams.scala
@@ -77,7 +77,7 @@ case class SearchParams(
    * Is there an active constraint on these params?
    * TODO: Should this include page etc?
    */
-  def isFiltered: Boolean = query.filterNot(_.trim.isEmpty).isDefined
+  def isFiltered: Boolean = !query.forall(_.trim.isEmpty)
 
   def offset = Math.max(0, (pageOrDefault - 1) * countOrDefault)
 

--- a/modules/core/app/views/Helpers.scala
+++ b/modules/core/app/views/Helpers.scala
@@ -8,7 +8,7 @@ import play.api.mvc.RequestHeader
 import backend.Entity
 
 
-package object Helpers {
+object Helpers {
 
   // Pretty relative date/time handling
   import org.ocpsoft.prettytime.PrettyTime

--- a/modules/core/test/models/base/AnyModelSpec.scala
+++ b/modules/core/test/models/base/AnyModelSpec.scala
@@ -1,11 +1,11 @@
 package models.base
 
+import models.AccessPointF.AccessPointType
 import play.api.test.PlaySpecification
-import models.relation
+import models._
 import eu.ehri.project.definitions.Ontology
 import play.api.libs.json.{Json, JsObject}
 import defines.EntityType
-import models.AccessPointF
 import play.api.i18n.{MessagesApi, Messages, Lang}
 import Description._
 import backend.Entity
@@ -17,8 +17,8 @@ case class TestDescriptionF(
   languageCode: String,
   @relation(Ontology.HAS_ACCESS_POINT)
   creationProcess: CreationProcess.Value = CreationProcess.Manual,
-  accessPoints: List[AccessPointF] = Nil,
-  @relation(Ontology.HAS_ACCESS_POINT)
+  accessPoints: Seq[AccessPointF] = Nil,
+  @relation(Ontology.HAS_UNKNOWN_PROPERTY)
   unknownProperties: List[Entity] = Nil
 ) extends Model
   with Description {
@@ -48,6 +48,24 @@ class AnyModelSpec extends PlaySpecification with play.api.i18n.I18nSupport {
   implicit val application = new play.api.inject.guice.GuiceApplicationBuilder().build
   implicit val messagesApi = application.injector.instanceOf[MessagesApi]
 
+  val accessPoint1 = AccessPoint(model = AccessPointF(
+    id = Some("ap1"),
+    accessPointType = AccessPointF.AccessPointType.PersonAccess,
+    name = "AP1"
+  ))
+
+  val accessPoint2 = AccessPoint(model = AccessPointF(
+    id = Some("ap2"),
+    accessPointType = AccessPointF.AccessPointType.CorporateBodyAccess,
+    name = "AP2"
+  ))
+
+  val accessPoint3 = AccessPoint(model = AccessPointF(
+    id = Some("ap3"),
+    accessPointType = AccessPointF.AccessPointType.FamilyAccess,
+    name = "AP3"
+  ))
+
   val testModel = TestModel(
     TestModelF(
       id = Some("id1"),
@@ -55,7 +73,8 @@ class AnyModelSpec extends PlaySpecification with play.api.i18n.I18nSupport {
         TestDescriptionF(
           id = Some("did1"),
           name = "name1",
-          languageCode = "eng"
+          languageCode = "eng",
+          accessPoints = Seq(accessPoint1.model, accessPoint2.model)
         ),
         TestDescriptionF(
           id = Some("did2"),
@@ -75,6 +94,81 @@ class AnyModelSpec extends PlaySpecification with play.api.i18n.I18nSupport {
 
     "count descriptions properly" in {
       testModel.descriptions.size must equalTo(2)
+    }
+
+    "categorise access point links properly" in {
+      val links = Seq(
+        Link(
+          model = LinkF(
+            id = Some("ln1"),
+            linkType = LinkF.LinkType.Associative
+          ),
+          bodies = Seq(accessPoint1)
+        )
+      )
+      testModel.accessPointLinks(links).headOption must beSome.which { case (link, ap) =>
+        link.id must_== "ln1"
+        ap.id must_== Some("ap1")
+      }
+      testModel.externalLinks(links) must beEmpty
+      testModel.annotationLinks(links) must beEmpty
+    }
+
+    "categorise external links properly" in {
+      val links = Seq(
+        Link(
+          model = LinkF(
+            id = Some("ln1"),
+            linkType = LinkF.LinkType.Associative
+          ),
+          bodies = Seq(accessPoint3)
+        )
+      )
+      testModel.externalLinks(links).headOption must beSome.which { ext =>
+        ext.id must_== "ln1"
+      }
+      testModel.accessPointLinks(links) must beEmpty
+      testModel.annotationLinks(links) must beEmpty
+    }
+
+    "categorise annotation links properly" in {
+      val links = Seq(
+        Link(
+          model = LinkF(
+            id = Some("ln1"),
+            linkType = LinkF.LinkType.Associative
+          ),
+          targets = Seq(accessPoint3)
+        )
+      )
+      testModel.annotationLinks(links).headOption must beSome.which { ext =>
+        ext.id must_== "ln1"
+      }
+      testModel.accessPointLinks(links) must beEmpty
+      testModel.externalLinks(links) must beEmpty
+    }
+
+    "categorise access point links by type" in {
+      val links = Seq(
+        Link(
+          model = LinkF(
+            id = Some("ln1"),
+            linkType = LinkF.LinkType.Associative
+          ),
+          bodies = Seq(accessPoint1)
+        )
+      )
+      val byType = testModel.accessPointLinksByType(links)
+      byType.size must_== 1
+      byType.toSeq.headOption must beSome.which { case (t, aps) =>
+        t must_== AccessPointF.AccessPointType.PersonAccess
+        aps.headOption must beSome.which { case (link, ap) =>
+          link.id must_== "ln1"
+          ap.id must_== Some("ap1")
+        }
+      }
+      testModel.annotationLinks(links) must beEmpty
+      testModel.externalLinks(links) must beEmpty
     }
   }
 }

--- a/modules/portal/app/views/annotation/customVisibility.scala.html
+++ b/modules/portal/app/views/annotation/customVisibility.scala.html
@@ -11,15 +11,15 @@
 
     <div class="preset-visibility">
         <label for="@(PARAM)_@(Me)" class="radio-inline">
-            <input class="visibility" type="radio" id="@(PARAM)_@(Me)" name="@PARAM" value="@Me" @{if(visForm.value == Some(Me)) "checked"}>
+            <input class="visibility" type="radio" id="@(PARAM)_@(Me)" name="@PARAM" value="@Me" @{if(visForm.value.contains(Me)) "checked"}>
             @Messages("contribution.visibility.me")
         </label>
         <label for="@(PARAM)_@(Groups)" class="radio-inline">
-            <input class="visibility" type="radio" id="@(PARAM)_@(Groups)" name="@PARAM" value="@Groups" @{if(visForm.value == Some(Groups)) "checked"}>
+            <input class="visibility" type="radio" id="@(PARAM)_@(Groups)" name="@PARAM" value="@Groups" @{if(visForm.value.contains(Groups)) "checked"}>
             @Messages("contribution.visibility.groups")
         </label>
         <label for="@(PARAM)_@(Custom)" class="radio-inline">
-            <input class="visibility" type="radio" id="@(PARAM)_@(Custom)" name="@PARAM" value="@Custom" @{if(visForm.value == Some(Custom)) "checked"}>
+            <input class="visibility" type="radio" id="@(PARAM)_@(Custom)" name="@PARAM" value="@Custom" @{if(visForm.value.contains(Custom)) "checked"}>
             @Messages("contribution.visibility.custom")
         </label>
     </div>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,7 +25,7 @@ object ApplicationBuild extends Build {
   val appVersion = "1.0.5-SNAPSHOT"
 
   val backendVersion = "0.11.1-SNAPSHOT"
-  val neo4jVersion = "2.3.0"
+  val neo4jVersion = "2.3.1"
   val jerseyVersion = "1.19"
 
   val backendDependencies = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")
 


### PR DESCRIPTION
 - update to Play 2.4.4 and Neo4j 2.3.1
 - remove some (un-type-safe) equality comparisons
 - add better testing for (wierd) AnyModel/AccessPoint/Link methods
 - make Link's meta-relationship to its "body" AccessPoint be the
    access point meta model, rather than its form object (this is
    more consistent with other meta model relations)
 - change AnyModel's JSON conversion registry from a map
    to a partial function
 - remove a few small code smells
