### PR TITLE
Add EAC and EAG export and tweak implementation

### DIFF
--- a/modules/admin/app/controllers/authorities/HistoricalAgents.scala
+++ b/modules/admin/app/controllers/authorities/HistoricalAgents.scala
@@ -3,11 +3,14 @@ package controllers.authorities
 import auth.AccountManager
 import backend.rest.cypher.Cypher
 import controllers.generic._
+import play.api.libs.concurrent.Execution.Implicits._
 import forms.VisibilityForm
 import models._
 import play.api.cache.CacheApi
 import play.api.i18n.{MessagesApi, Messages}
 import defines.{EntityType, PermissionType}
+import play.api.libs.iteratee.Enumerator
+import play.api.mvc.{Result, ResponseHeader}
 import utils.MovedPageLookup
 import utils.search._
 import javax.inject._
@@ -161,5 +164,14 @@ case class HistoricalAgents @Inject()(
           Redirect(histRoutes.get(id))
             .flashing("success" -> "item.update.confirmation")
       }
+  }
+
+  def exportEac(id: String) = OptionalUserAction.async { implicit request =>
+    val params = request.queryString.filterKeys(_ == "lang")
+    userBackend.stream(s"${EntityType.HistoricalAgent}/$id/eac", params = params).map { case (head, body) =>
+      Status(head.status)
+        .chunked(body.andThen(Enumerator.eof))
+        .withHeaders(head.headers.map(s => (s._1, s._2.head)).toSeq: _*)
+    }
   }
 }

--- a/modules/admin/app/views/admin/historicalAgent/adminActions.scala.html
+++ b/modules/admin/app/views/admin/historicalAgent/adminActions.scala.html
@@ -19,4 +19,8 @@
     @views.html.admin.common.sidebarAction() {
         <a href="@controllers.admin.routes.ApiController.getItem(item.isA, item.id)">@Messages("item.export.json")</a>
     }
+    @views.html.admin.common.sidebarAction() {
+        <a href="@controllers.authorities.routes.HistoricalAgents.exportEac(item.id)">@Messages("historicalAgent.export.eac")
+        </a>
+    }
 }

--- a/modules/admin/app/views/admin/repository/adminActions.scala.html
+++ b/modules/admin/app/views/admin/repository/adminActions.scala.html
@@ -28,4 +28,8 @@
     @views.html.admin.common.sidebarAction() {
         <a href="@controllers.admin.routes.ApiController.getItem(item.isA, item.id)">@Messages("item.export.json")</a>
     }
+    @views.html.admin.common.sidebarAction() {
+        <a href="@controllers.institutions.routes.Repositories.exportEag(item.id)">@Messages("repository.export.eag")
+        </a>
+    }
 }

--- a/modules/admin/conf/authorities.routes
+++ b/modules/admin/conf/authorities.routes
@@ -18,3 +18,4 @@ GET     /:id/link                      @controllers.authorities.HistoricalAgents
 GET     /:id/link/:toType              @controllers.authorities.HistoricalAgents.linkAnnotateSelect(id: String, toType: EntityType.Value)
 GET     /:id/link/:toType/:to          @controllers.authorities.HistoricalAgents.linkAnnotate(id: String, toType: EntityType.Value, to: String)
 POST    /:id/link/:toType/:to          @controllers.authorities.HistoricalAgents.linkAnnotatePost(id: String, toType: EntityType.Value, to: String)
+GET     /:id/eac                       @controllers.authorities.HistoricalAgents.exportEac(id: String)

--- a/modules/admin/conf/institutions.routes
+++ b/modules/admin/conf/institutions.routes
@@ -25,4 +25,5 @@ GET         /:id/link/:toType/:to                     @controllers.institutions.
 POST        /:id/link/:toType/:to                     @controllers.institutions.Repositories.linkAnnotatePost(id: String, toType: EntityType.Value, to: String)
 GET         /:id/reindex                              @controllers.institutions.Repositories.updateIndex(id: String)
 POST        /:id/reindex                              @controllers.institutions.Repositories.updateIndexPost(id: String)
+GET         /:id/eag                                  @controllers.institutions.Repositories.exportEag(id: String)
 

--- a/modules/admin/conf/messages
+++ b/modules/admin/conf/messages
@@ -685,6 +685,7 @@ repository.create=Create Repository
 repository.create.submit=Create Repository
 repository.update=Update Repository
 repository.update.submit=Update Repository
+repository.export.eag=Export EAG (Testing)
 
 repository.descriptionArea=Description Area
 repository.identity=Identity Area
@@ -926,6 +927,7 @@ historicalAgent.create=Create Authority
 historicalAgent.create.submit=Create Authority
 historicalAgent.update=Update Authority
 historicalAgent.update.submit=Update Authority
+historicalAgent.export.eac=Export EAC (Testing)
 
 #
 # ISAAR Field definitions

--- a/modules/backend/src/main/scala/backend/rest/RestDAO.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestDAO.scala
@@ -168,9 +168,7 @@ trait RestDAO {
    * Standard headers we sent to every Neo4j/EHRI Server request.
    */
   protected val headers = Map(
-    HeaderNames.ACCEPT -> ContentTypes.JSON,
-    HeaderNames.ACCEPT_CHARSET -> StandardCharsets.UTF_8.name,
-    HeaderNames.CONTENT_TYPE -> ContentTypes.JSON
+    HeaderNames.ACCEPT_CHARSET -> StandardCharsets.UTF_8.name
   )
 
   /**

--- a/modules/core/app/controllers/generic/Generic.scala
+++ b/modules/core/app/controllers/generic/Generic.scala
@@ -62,4 +62,5 @@ trait Generic extends CoreActionBuilders with RestHelpers {
       async(f.andThen(_.andThen(t => immediate(t))))
     }
   }
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")
 

--- a/test/integration/DocumentaryUnitViewsSpec.scala
+++ b/test/integration/DocumentaryUnitViewsSpec.scala
@@ -95,7 +95,7 @@ class DocumentaryUnitViewsSpec extends IntegrationTestRunner {
       val ead = FakeRequest(docRoutes.exportEad("c1")).withUser(privilegedUser).call()
       status(ead) must equalTo(OK)
       contentType(ead) must beSome.which { ct =>
-        ct must equalTo(MimeTypes.XML)
+        ct must equalTo("text/xml")
       }
     }
   }

--- a/test/integration/EntityViewsSpec.scala
+++ b/test/integration/EntityViewsSpec.scala
@@ -21,9 +21,12 @@ class EntityViewsSpec extends IntegrationTestRunner {
   val noItemsHeader = "No items found"
 
   "HistoricalAgent views" should {
+
+    val histAgentRoutes = controllers.authorities.routes.HistoricalAgents
+
     "list should get some items" in new ITestApp {
 
-      val list = FakeRequest(controllers.authorities.routes.HistoricalAgents.list())
+      val list = FakeRequest(histAgentRoutes.list())
         .withUser(unprivilegedUser).call()
       status(list) must equalTo(OK)
       contentAsString(list) must contain(multipleItemsHeader)
@@ -78,13 +81,13 @@ class EntityViewsSpec extends IntegrationTestRunner {
 
 
     "link to other privileged actions when logged in" in new ITestApp {
-      val show = FakeRequest(controllers.authorities.routes.HistoricalAgents.get("a1"))
+      val show = FakeRequest(histAgentRoutes.get("a1"))
         .withUser(privilegedUser).call()
       status(show) must equalTo(OK)
-      contentAsString(show) must contain(controllers.authorities.routes.HistoricalAgents.update("a1").url)
-      contentAsString(show) must contain(controllers.authorities.routes.HistoricalAgents.delete("a1").url)
-      contentAsString(show) must contain(controllers.authorities.routes.HistoricalAgents.visibility("a1").url)
-      contentAsString(show) must contain(controllers.authorities.routes.HistoricalAgents.search().url)
+      contentAsString(show) must contain(histAgentRoutes.update("a1").url)
+      contentAsString(show) must contain(histAgentRoutes.delete("a1").url)
+      contentAsString(show) must contain(histAgentRoutes.visibility("a1").url)
+      contentAsString(show) must contain(histAgentRoutes.search().url)
     }
 
     "allow updating items when logged in as privileged user" in new ITestApp {
@@ -99,7 +102,7 @@ class EntityViewsSpec extends IntegrationTestRunner {
         "descriptions[0].descriptionArea.generalContext" -> Seq("New Content for a1"),
         "publicationStatus" -> Seq("Draft")
       )
-      val cr = FakeRequest(controllers.authorities.routes.HistoricalAgents.updatePost("a1"))
+      val cr = FakeRequest(histAgentRoutes.updatePost("a1"))
         .withUser(privilegedUser).withCsrf.callWith(testData)
       status(cr) must equalTo(SEE_OTHER)
 
@@ -112,7 +115,7 @@ class EntityViewsSpec extends IntegrationTestRunner {
       val testData: Map[String, Seq[String]] = Map(
         "identifier" -> Seq("a1")
       )
-      val cr = FakeRequest(controllers.authorities.routes.HistoricalAgents.updatePost("a1"))
+      val cr = FakeRequest(histAgentRoutes.updatePost("a1"))
         .withUser(unprivilegedUser).withCsrf.callWith(testData)
       status(cr) must equalTo(FORBIDDEN)
     }
@@ -126,11 +129,18 @@ class EntityViewsSpec extends IntegrationTestRunner {
     }
 
     "contain links to external items" in new ITestApp {
-      val show = FakeRequest(controllers.authorities.routes.HistoricalAgents.get("a1"))
+      val show = FakeRequest(histAgentRoutes.get("a1"))
         .withUser(privilegedUser).call()
       contentAsString(show) must contain("external-item-link")
       contentAsString(show) must contain(
         controllers.units.routes.DocumentaryUnits.get("c1").url)
+    }
+
+    "allow exporting EAC" in new ITestApp {
+      val exportReq = FakeRequest(histAgentRoutes.exportEac("a1"))
+        .withUser(privilegedUser).withCsrf.call()
+      status(exportReq) must equalTo(OK)
+      contentType(exportReq) must equalTo(Some("text/xml"))
     }
   }
 

--- a/test/integration/RepositoryViewsSpec.scala
+++ b/test/integration/RepositoryViewsSpec.scala
@@ -157,4 +157,13 @@ class RepositoryViewsSpec extends IntegrationTestRunner {
       contentAsString(show) must not contain "New Content for r1"
     }
   }
+
+  "Repository export functionality" should {
+    "allow exporting EAG" in new ITestApp {
+      val exportReq = FakeRequest(repoRoutes.exportEag("r1"))
+        .withUser(privilegedUser).withCsrf.call()
+      status(exportReq) must equalTo(OK)
+      contentType(exportReq) must equalTo(Some("text/xml"))
+    }
+  }
 }


### PR DESCRIPTION
- Roll back to Play 2.4.3 for the moment since 2.4.4 has some issues
- Revise method for forwarding backend requests directly.
- Remove some default accepts/content-type headers from backend
  call helpers (relying on the default)
- Added menu items and controller actions.