### PR TITLE
Convert some authority description fields to multi-value.

### DIFF
--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -10,7 +10,6 @@ import controllers.generic._
 import play.api.i18n.{MessagesApi, Messages}
 import defines.{ContentTypes,EntityType,PermissionType}
 import play.api.libs.iteratee.Enumerator
-import play.api.mvc.{Headers, ResponseHeader, Result}
 import utils.MovedPageLookup
 import views.{MarkdownRenderer, Helpers}
 import utils.search._
@@ -18,7 +17,6 @@ import javax.inject._
 import scala.concurrent.Future.{successful => immediate}
 import backend.Backend
 import play.api.Configuration
-import play.api.http.{HeaderNames, MimeTypes}
 import controllers.base.AdminController
 
 

--- a/modules/admin/app/views/admin/historicalAgent/description.scala.html
+++ b/modules/admin/app/views/admin/historicalAgent/description.scala.html
@@ -19,9 +19,9 @@
         @views.html.admin.common.stringValue(desc.details.datesOfExistence, DATES_OF_EXISTENCE)
         @views.html.admin.common.stringValue(desc.details.history, HISTORY)
         @views.html.admin.common.listValue(desc.details.places, PLACES)
-        @views.html.admin.common.stringValue(desc.details.legalStatus, LEGAL_STATUS)
-        @views.html.admin.common.stringValue(desc.details.functions, FUNCTIONS)
-        @views.html.admin.common.stringValue(desc.details.mandates, MANDATES)
+        @views.html.admin.common.listValue(desc.details.legalStatus, LEGAL_STATUS)
+        @views.html.admin.common.listValue(desc.details.functions, FUNCTIONS)
+        @views.html.admin.common.listValue(desc.details.mandates, MANDATES)
         @views.html.admin.common.stringValue(desc.details.internalStructure, INTERNAL_STRUCTURE)
         @views.html.admin.common.stringValue(desc.details.generalContext, GENERAL_CONTEXT)
     }

--- a/modules/admin/app/views/admin/historicalAgent/descriptionForm.scala.html
+++ b/modules/admin/app/views/admin/historicalAgent/descriptionForm.scala.html
@@ -40,10 +40,10 @@
         @defining(desc(DESCRIPTION_AREA)) { desc =>
             @textInput(desc, DATES_OF_EXISTENCE)
             @textInput(desc, HISTORY)
-            @inlineTextSet(desc, PLACES)
-            @textInput(desc, LEGAL_STATUS)
-            @textInput(desc, FUNCTIONS)
-            @textInput(desc, MANDATES)
+            @inlineNameSet(desc, PLACES)
+            @inlineNameSet(desc, LEGAL_STATUS)
+            @inlineNameSet(desc, FUNCTIONS)
+            @inlineNameSet(desc, MANDATES)
             @textInput(desc, INTERNAL_STRUCTURE)
             @textInput(desc, GENERAL_CONTEXT)
         }

--- a/modules/admin/app/views/formHelpers/inlineName.scala.html
+++ b/modules/admin/app/views/formHelpers/inlineName.scala.html
@@ -1,9 +1,11 @@
-@(field: play.api.data.Field)(implicit fieldPrefix: String, messages: Messages, md: views.MarkdownRenderer, fieldConstructor: views.html.helper.FieldConstructor)
+@(field: play.api.data.Field, name: String)(implicit fieldPrefix: String, messages: Messages, md: views.MarkdownRenderer, fieldConstructor: views.html.helper.FieldConstructor)
 
 <div class="inline-element">
     <div class="form-group @{if(field.hasErrors) "has-error"}">
         <div class="inline-element-data">
-            <input type="text" class="form-control" name="@field.name" id="@field.id" value="@field.value" />
+            <input type="text" class="form-control"
+                name="@field.name" id="@field.id" value="@field.value"
+                title="@(md.renderMarkdown(Messages((if (fieldPrefix != "") fieldPrefix + "." else "") + name + ".description")))" />
             <span class="help-block errors">@field.errors.map(e => Messages(e.message)).mkString(", ")</span>
         </div>
        <div class="inline-element-remove">

--- a/modules/admin/app/views/formHelpers/inlineNameSet.scala.html
+++ b/modules/admin/app/views/formHelpers/inlineNameSet.scala.html
@@ -11,11 +11,11 @@
     </label>
 
     <div class="inline-element-template form-template">
-        @formHelpers.inlineName(field(name + "[IDX]"))
+        @formHelpers.inlineName(field(name + "[IDX]"), name)
     </div>
     <div class="inline-element-list">
         @helper.repeat(field(name), min = 0) { f =>
-            @formHelpers.inlineName(f)
+            @formHelpers.inlineName(f, name)
         }
     </div>
 </div>

--- a/modules/admin/app/views/formHelpers/inlineText.scala.html
+++ b/modules/admin/app/views/formHelpers/inlineText.scala.html
@@ -1,9 +1,10 @@
-@(desc: Field, rows: Int = 2)(implicit fieldPrefix: String, messages: Messages, fieldConstructor: views.html.helper.FieldConstructor)
+@(desc: Field, name: String, rows: Int = 2)(implicit fieldPrefix: String, messages: Messages, md: views.MarkdownRenderer, fieldConstructor: views.html.helper.FieldConstructor)
 
 <div class="inline-element">
     <div class="form-group @{if(desc.hasErrors) "has-error"}">
         <div class="inline-control">
-            <textarea class="form-control" rows="@rows" name="@desc.name" id="@desc.id">@desc.value</textarea>
+            <textarea class="form-control" rows="@rows" name="@desc.name" id="@desc.id"
+                title="@(md.renderMarkdown(Messages((if (fieldPrefix != "") fieldPrefix + "." else "") + name + ".description")))">@desc.value</textarea>
             <span class="help-block col-sm-10 errors">@desc.errors.map(e => Messages(e.message)).mkString(", ")</span>
         </div>
         <div class="inline-remove">

--- a/modules/admin/app/views/formHelpers/inlineTextSet.scala.html
+++ b/modules/admin/app/views/formHelpers/inlineTextSet.scala.html
@@ -1,4 +1,4 @@
-@(desc: Field, label: String, rows: Int = 2)(implicit fieldPrefix: String, messages: Messages, fieldConstructor: views.html.helper.FieldConstructor)
+@(desc: Field, label: String, rows: Int = 2)(implicit fieldPrefix: String, messages: Messages, md: views.MarkdownRenderer, fieldConstructor: views.html.helper.FieldConstructor)
 
 <div class="inline-formset form-group clearfix" data-prefix="@label">
     <!-- Template for adding inline date forms via JS -->
@@ -7,11 +7,11 @@
         <a href="#" class="add-inline-element"><i class="glyphicon glyphicon-plus-sign"></i></a>
     </label>
     <div class="inline-element-template form-template ">
-        @inlineText(desc(label + "[IDX]"), rows)
+        @inlineText(desc(label + "[IDX]"), label, rows)
     </div>
     <div class="inline-element-list">
         @helper.repeat(desc(label), min = 0) { field =>
-            @inlineText(field, rows)
+            @inlineText(field, label, rows)
         }
     </div>
 </div>

--- a/modules/core/app/models/HistoricalAgentDescription.scala
+++ b/modules/core/app/models/HistoricalAgentDescription.scala
@@ -17,9 +17,9 @@ case class IsaarDetail(
   datesOfExistence: Option[String] = None,
   history: Option[String] = None,
   places: Option[Seq[String]] = None,
-  legalStatus: Option[String] = None,
-  functions: Option[String] = None,
-  mandates: Option[String] = None,
+  legalStatus: Option[Seq[String]] = None,
+  functions: Option[Seq[String]] = None,
+  mandates: Option[Seq[String]] = None,
   internalStructure: Option[String] = None,
   generalContext: Option[String] = None
 ) extends AttributeSet
@@ -59,9 +59,9 @@ object HistoricalAgentDescriptionF {
       (__ \ DATES_OF_EXISTENCE).formatNullable[String] and
       (__ \ HISTORY).formatNullable[String] and
       (__ \ PLACES).formatSeqOrSingleNullable[String] and
-      (__ \ LEGAL_STATUS).formatNullable[String] and
-      (__ \ FUNCTIONS).formatNullable[String] and
-      (__ \ MANDATES).formatNullable[String] and
+      (__ \ LEGAL_STATUS).formatSeqOrSingleNullable[String] and
+      (__ \ FUNCTIONS).formatSeqOrSingleNullable[String] and
+      (__ \ MANDATES).formatSeqOrSingleNullable[String] and
       (__ \ INTERNAL_STRUCTURE).formatNullable[String] and
       (__ \ GENERAL_CONTEXT).formatNullable[String]
     )(IsaarDetail.apply, unlift(IsaarDetail.unapply))) and
@@ -110,7 +110,7 @@ case class HistoricalAgentDescriptionF(
   with Description
   with Temporal {
 
-  def displayText = details.history orElse details.generalContext orElse details.functions
+  def displayText = details.history orElse details.generalContext orElse details.internalStructure
 
   import Isaar._
 
@@ -118,9 +118,9 @@ case class HistoricalAgentDescriptionF(
     DATES_OF_EXISTENCE -> details.datesOfExistence,
     HISTORY -> details.history,
     PLACES -> details.places.map(_.mkString("\n")),
-    LEGAL_STATUS -> details.legalStatus,
-    FUNCTIONS -> details.functions,
-    MANDATES -> details.mandates,
+    LEGAL_STATUS -> details.legalStatus.map(_.mkString("\n")),
+    FUNCTIONS -> details.functions.map(_.mkString("\n")),
+    MANDATES -> details.mandates.map(_.mkString("\n")),
     INTERNAL_STRUCTURE -> details.internalStructure,
     GENERAL_CONTEXT -> details.generalContext,
     DESCRIPTION_IDENTIFIER -> control.descriptionIdentifier,
@@ -152,9 +152,9 @@ object HistoricalAgentDescription {
         DATES_OF_EXISTENCE -> optional(text),
         HISTORY -> optional(text),
         PLACES -> optional(seq(text)),
-        LEGAL_STATUS -> optional(text),
-        FUNCTIONS -> optional(text),
-        MANDATES -> optional(text),
+        LEGAL_STATUS -> optional(seq(text)),
+        FUNCTIONS -> optional(seq(text)),
+        MANDATES -> optional(seq(text)),
         INTERNAL_STRUCTURE -> optional(text),
         GENERAL_CONTEXT -> optional(text)
       )(IsaarDetail.apply)(IsaarDetail.unapply),

--- a/modules/core/test/resources/historicalAgent.json
+++ b/modules/core/test/resources/historicalAgent.json
@@ -19,6 +19,7 @@
         "typeOfEntity" : "corporateBody",
         "parallelFormsOfName" : [ "Parellel name for Test Authority 2" ],
         "datesOfExistence" : "1900-2000",
+        "places": ["Germany", "Poland"],
         "history": "Some history"
       },
       "type" : "historicalAgentDescription",

--- a/modules/portal/app/assets/js/admin.js
+++ b/modules/portal/app/assets/js/admin.js
@@ -117,6 +117,19 @@ jQuery(function($) {
 
   $("nav.responsive").stickyFormFooter();
 
+  function addPopover($elem, trigger) {
+    var trigger = trigger || "blur";
+    $elem.popover({
+      html: true,
+      delay:{
+        show: 500,
+        hide: 100
+      },
+      trigger: trigger,
+      placement: "bottom"
+    });
+  }
+
   // Add Bootstrap tooltip on input boxes with a title.
   // Filter items with an empty title.
   $("input[type=text][title!=''],textarea[title!='']").each(function() {
@@ -124,15 +137,7 @@ jQuery(function($) {
       that.attr("data-content", that.attr("title"));
       that.attr("title", that.parents(".control-group").find(".control-label").text());
       if(!that.parents(".control-group").hasClass("quiet")) {
-        that.popover({
-          html: true,
-          delay:{
-            show: 500,
-            hide: 100
-          },
-          trigger: "blur",
-          placement: "bottom"
-        });
+        addPopover(that);
       }
   });
 
@@ -182,14 +187,16 @@ jQuery(function($) {
     // We want to replace all instances of prefix[IDX] and prefix_IDX
     var re1 = new RegExp(prefix + "\\[IDX\\]", "g");
     var re2 = new RegExp(prefix + "_IDX", "g");
-    var elem = $(template.html()
+    var $elem = $(template.html()
         .replace(re1, prefix + "[" + idx + "]")
         .replace(re2, prefix + "_" + idx));
     //container.append(elem);
-    set.append(elem);
-
+    set.append($elem);
     // Add select2 support...
-    elem.find("div.select2-container").remove();
-    elem.find("select.select2").removeClass(".select2-offscreen").select2();
+    $elem.find("div.select2-container").remove();
+    $elem.find("select.select2").removeClass(".select2-offscreen").select2();
+
+    // And a help popover
+    addPopover($elem.find("textarea,input"));
   });
 });

--- a/modules/portal/app/views/historicalAgent/description.scala.html
+++ b/modules/portal/app/views/historicalAgent/description.scala.html
@@ -19,9 +19,9 @@
                 @textField(item, descId,   desc.details.datesOfExistence, DATES_OF_EXISTENCE)
                 @textField(item, descId,   desc.details.history, HISTORY)
                 @listField(item, descId,   desc.details.places, PLACES)
-                @textField(item, descId,   desc.details.legalStatus, LEGAL_STATUS)
-                @textField(item, descId,   desc.details.functions, FUNCTIONS)
-                @textField(item, descId,   desc.details.mandates, MANDATES)
+                @listField(item, descId,   desc.details.legalStatus, LEGAL_STATUS)
+                @listField(item, descId,   desc.details.functions, FUNCTIONS)
+                @listField(item, descId,   desc.details.mandates, MANDATES)
                 @textField(item, descId,   desc.details.internalStructure, INTERNAL_STRUCTURE)
                 @textField(item, descId,   desc.details.generalContext, GENERAL_CONTEXT)
             }


### PR DESCRIPTION
 - Additionally, fix display of popover field description text on multi-value name and text fields.
