### PR TITLE
Move EAC/EAD/EAG export functionality from admin to portal.

### DIFF
--- a/modules/admin/app/controllers/authorities/HistoricalAgents.scala
+++ b/modules/admin/app/controllers/authorities/HistoricalAgents.scala
@@ -3,14 +3,11 @@ package controllers.authorities
 import auth.AccountManager
 import backend.rest.cypher.Cypher
 import controllers.generic._
-import play.api.libs.concurrent.Execution.Implicits._
 import forms.VisibilityForm
 import models._
 import play.api.cache.CacheApi
 import play.api.i18n.{MessagesApi, Messages}
 import defines.{EntityType, PermissionType}
-import play.api.libs.iteratee.Enumerator
-import play.api.mvc.{Result, ResponseHeader}
 import utils.MovedPageLookup
 import utils.search._
 import javax.inject._
@@ -164,14 +161,5 @@ case class HistoricalAgents @Inject()(
           Redirect(histRoutes.get(id))
             .flashing("success" -> "item.update.confirmation")
       }
-  }
-
-  def exportEac(id: String) = OptionalUserAction.async { implicit request =>
-    val params = request.queryString.filterKeys(_ == "lang")
-    userBackend.stream(s"${EntityType.HistoricalAgent}/$id/eac", params = params).map { case (head, body) =>
-      Status(head.status)
-        .chunked(body.andThen(Enumerator.eof))
-        .withHeaders(head.headers.map(s => (s._1, s._2.head)).toSeq: _*)
-    }
   }
 }

--- a/modules/admin/app/controllers/institutions/Repositories.scala
+++ b/modules/admin/app/controllers/institutions/Repositories.scala
@@ -9,8 +9,6 @@ import controllers.generic._
 import models._
 import play.api.i18n.{MessagesApi, Messages}
 import defines.{PermissionType, EntityType, ContentTypes}
-import play.api.libs.iteratee.Enumerator
-import play.api.mvc.{Result, ResponseHeader}
 import utils.MovedPageLookup
 import views.{MarkdownRenderer, Helpers}
 import utils.search._
@@ -279,13 +277,4 @@ case class Repositories @Inject()(
   }
 
   def updateIndexPost(id: String) = updateChildItemsPost(SearchConstants.HOLDER_ID, id)
-
-  def exportEag(id: String) = OptionalUserAction.async { implicit request =>
-    val params = request.queryString.filterKeys(_ == "lang")
-    userBackend.stream(s"${EntityType.Repository}/$id/eag", params = params).map { case (head, body) =>
-      Status(head.status)
-        .chunked(body.andThen(Enumerator.eof))
-        .withHeaders(head.headers.map(s => (s._1, s._2.head)).toSeq: _*)
-    }
-  }
 }

--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -9,7 +9,6 @@ import models._
 import controllers.generic._
 import play.api.i18n.{MessagesApi, Messages}
 import defines.{ContentTypes,EntityType,PermissionType}
-import play.api.libs.iteratee.Enumerator
 import utils.MovedPageLookup
 import views.{MarkdownRenderer, Helpers}
 import utils.search._
@@ -370,15 +369,6 @@ case class DocumentaryUnits @Inject()(
   def manageAccessPoints(id: String, descriptionId: String) = {
     WithDescriptionAction(id, descriptionId).apply { implicit request =>
       Ok(views.html.admin.documentaryUnit.editAccessPoints(request.item, request.description))
-    }
-  }
-
-  def exportEad(id: String) = OptionalUserAction.async { implicit request =>
-    val params = request.queryString.filterKeys(_ == "lang")
-    userBackend.stream(s"${EntityType.DocumentaryUnit}/$id/ead", params = params).map { case (head, body) =>
-      Status(head.status)
-        .chunked(body.andThen(Enumerator.eof))
-        .withHeaders(head.headers.map(s => (s._1, s._2.head)).toSeq: _*)
     }
   }
 }

--- a/modules/admin/app/views/admin/documentaryUnit/adminActions.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/adminActions.scala.html
@@ -26,6 +26,6 @@
         <a href="@controllers.admin.routes.ApiController.getItem(item.isA, item.id)">@Messages("item.export.json")</a>
     }
     @views.html.admin.common.sidebarAction() {
-        <a href="@controllers.units.routes.DocumentaryUnits.exportEad(item.topLevel.id)">@Messages("documentaryUnit.export.ead")</a>
+        <a href="@controllers.portal.routes.DocumentaryUnits.export(item.topLevel.id)">@Messages("documentaryUnit.export.ead")</a>
     }
 }

--- a/modules/admin/app/views/admin/historicalAgent/adminActions.scala.html
+++ b/modules/admin/app/views/admin/historicalAgent/adminActions.scala.html
@@ -20,7 +20,6 @@
         <a href="@controllers.admin.routes.ApiController.getItem(item.isA, item.id)">@Messages("item.export.json")</a>
     }
     @views.html.admin.common.sidebarAction() {
-        <a href="@controllers.authorities.routes.HistoricalAgents.exportEac(item.id)">@Messages("historicalAgent.export.eac")
-        </a>
+        <a href="@controllers.portal.routes.HistoricalAgents.export(item.id)">@Messages("historicalAgent.export.eac")</a>
     }
 }

--- a/modules/admin/app/views/admin/repository/adminActions.scala.html
+++ b/modules/admin/app/views/admin/repository/adminActions.scala.html
@@ -29,7 +29,7 @@
         <a href="@controllers.admin.routes.ApiController.getItem(item.isA, item.id)">@Messages("item.export.json")</a>
     }
     @views.html.admin.common.sidebarAction() {
-        <a href="@controllers.institutions.routes.Repositories.exportEag(item.id)">@Messages("repository.export.eag")
+        <a href="@controllers.portal.routes.Repositories.export(item.id)">@Messages("repository.export.eag")
         </a>
     }
 }

--- a/modules/admin/conf/authorities.routes
+++ b/modules/admin/conf/authorities.routes
@@ -18,4 +18,3 @@ GET     /:id/link                      @controllers.authorities.HistoricalAgents
 GET     /:id/link/:toType              @controllers.authorities.HistoricalAgents.linkAnnotateSelect(id: String, toType: EntityType.Value)
 GET     /:id/link/:toType/:to          @controllers.authorities.HistoricalAgents.linkAnnotate(id: String, toType: EntityType.Value, to: String)
 POST    /:id/link/:toType/:to          @controllers.authorities.HistoricalAgents.linkAnnotatePost(id: String, toType: EntityType.Value, to: String)
-GET     /:id/eac                       @controllers.authorities.HistoricalAgents.exportEac(id: String)

--- a/modules/admin/conf/institutions.routes
+++ b/modules/admin/conf/institutions.routes
@@ -25,5 +25,4 @@ GET         /:id/link/:toType/:to                     @controllers.institutions.
 POST        /:id/link/:toType/:to                     @controllers.institutions.Repositories.linkAnnotatePost(id: String, toType: EntityType.Value, to: String)
 GET         /:id/reindex                              @controllers.institutions.Repositories.updateIndex(id: String)
 POST        /:id/reindex                              @controllers.institutions.Repositories.updateIndexPost(id: String)
-GET         /:id/eag                                  @controllers.institutions.Repositories.exportEag(id: String)
 

--- a/modules/admin/conf/units.routes
+++ b/modules/admin/conf/units.routes
@@ -25,7 +25,6 @@ POST    /:id/permissions/:userType/:userId         @controllers.units.Documentar
 GET     /:id/scope/add                             @controllers.units.DocumentaryUnits.addScopedPermissions(id: String)
 GET     /:id/scope/:userType/:userId               @controllers.units.DocumentaryUnits.setScopedPermissions(id: String, userType: EntityType.Value, userId: String)
 POST    /:id/scope/:userType/:userId               @controllers.units.DocumentaryUnits.setScopedPermissionsPost(id: String, userType: EntityType.Value, userId: String)
-GET     /:id/ead                                   @controllers.units.DocumentaryUnits.exportEad(id: String)
 
 GET     /:id/link                                  @controllers.units.DocumentaryUnits.linkTo(id: String)
 GET     /:id/link/:toType                          @controllers.units.DocumentaryUnits.linkAnnotateSelect(id: String, toType: EntityType.Value)

--- a/modules/portal/app/controllers/portal/HistoricalAgents.scala
+++ b/modules/portal/app/controllers/portal/HistoricalAgents.scala
@@ -6,10 +6,12 @@ import backend.rest.cypher.Cypher
 import com.google.inject.{Inject, Singleton}
 import controllers.generic.Search
 import controllers.portal.base.{Generic, PortalController}
+import defines.EntityType
 import models.HistoricalAgent
 import play.api.cache.CacheApi
 import play.api.i18n.MessagesApi
 import play.api.libs.concurrent.Execution.Implicits._
+import play.api.libs.iteratee.Enumerator
 import utils.MovedPageLookup
 import utils.search._
 import views.MarkdownRenderer
@@ -46,5 +48,15 @@ case class HistoricalAgents @Inject()(
 
   def browse(id: String) = GetItemAction(id).apply { implicit request =>
     Ok(views.html.historicalAgent.show(request.item, request.annotations, request.links, request.watched))
+  }
+
+  def export(id: String) = OptionalUserAction.async { implicit request =>
+    val format = "eac"
+    val params = request.queryString.filterKeys(_ == "lang")
+    userBackend.stream(s"${EntityType.HistoricalAgent}/$id/$format", params = params).map { case (head, body) =>
+      Status(head.status)
+        .chunked(body.andThen(Enumerator.eof))
+        .withHeaders(head.headers.map(s => (s._1, s._2.head)).toSeq: _*)
+    }
   }
 }

--- a/modules/portal/conf/portal.routes
+++ b/modules/portal/conf/portal.routes
@@ -43,11 +43,15 @@ GET         /countries/:id/search                 @controllers.portal.Countries.
 GET         /institutions                         @controllers.portal.Repositories.searchAll
 GET         /institutions/:id                     @controllers.portal.Repositories.browse(id: String)
 GET         /institutions/:id/search              @controllers.portal.Repositories.search(id: String)
+GET         /institutions/:id/export              @controllers.portal.Repositories.export(id: String)
 GET         /units                                @controllers.portal.DocumentaryUnits.searchAll
 GET         /units/:id                            @controllers.portal.DocumentaryUnits.browse(id: String)
 GET         /units/:id/search                     @controllers.portal.DocumentaryUnits.search(id: String)
+GET         /units/:id/export                     @controllers.portal.DocumentaryUnits.export(id: String)
+
 GET         /authorities                          @controllers.portal.HistoricalAgents.searchAll
 GET         /authorities/:id                      @controllers.portal.HistoricalAgents.browse(id: String)
+GET         /authorities/:id/export               @controllers.portal.HistoricalAgents.export(id: String)
 GET         /keywords                             @controllers.portal.Concepts.searchAll
 GET         /keywords/:id                         @controllers.portal.Concepts.browse(id: String)
 GET         /links/:id                            @controllers.portal.Links.browse(id: String)

--- a/test/integration/admin/DocumentaryUnitViewsSpec.scala
+++ b/test/integration/admin/DocumentaryUnitViewsSpec.scala
@@ -89,14 +89,6 @@ class DocumentaryUnitViewsSpec extends IntegrationTestRunner {
       val show = FakeRequest(docRoutes.get("r1")).withUser(privilegedUser).call()
       status(show) must equalTo(NOT_FOUND)
     }
-
-    "allow EAD export" in new ITestApp {
-      val ead = FakeRequest(docRoutes.exportEad("c1")).withUser(privilegedUser).call()
-      status(ead) must equalTo(OK)
-      contentType(ead) must beSome.which { ct =>
-        ct must equalTo("text/xml")
-      }
-    }
   }
 
   "Documentary unit access functionality" should {

--- a/test/integration/admin/EntityViewsSpec.scala
+++ b/test/integration/admin/EntityViewsSpec.scala
@@ -135,13 +135,6 @@ class EntityViewsSpec extends IntegrationTestRunner {
       contentAsString(show) must contain(
         controllers.units.routes.DocumentaryUnits.get("c1").url)
     }
-
-    "allow exporting EAC" in new ITestApp {
-      val exportReq = FakeRequest(histAgentRoutes.exportEac("a1"))
-        .withUser(privilegedUser).withCsrf.call()
-      status(exportReq) must equalTo(OK)
-      contentType(exportReq) must equalTo(Some("text/xml"))
-    }
   }
 
   "UserProfile views" should {

--- a/test/integration/admin/RepositoryViewsSpec.scala
+++ b/test/integration/admin/RepositoryViewsSpec.scala
@@ -10,7 +10,6 @@ class RepositoryViewsSpec extends IntegrationTestRunner {
 
   private val repoRoutes = controllers.institutions.routes.Repositories
   private val countryRoutes = controllers.countries.routes.Countries
-  
 
   // Mock user who belongs to admin
   val userProfile = UserProfile(
@@ -155,15 +154,6 @@ class RepositoryViewsSpec extends IntegrationTestRunner {
       val show = FakeRequest(repoRoutes.get("r1")).withUser(unprivilegedUser).call()
       status(show) must equalTo(OK)
       contentAsString(show) must not contain "New Content for r1"
-    }
-  }
-
-  "Repository export functionality" should {
-    "allow exporting EAG" in new ITestApp {
-      val exportReq = FakeRequest(repoRoutes.exportEag("r1"))
-        .withUser(privilegedUser).withCsrf.call()
-      status(exportReq) must equalTo(OK)
-      contentType(exportReq) must equalTo(Some("text/xml"))
     }
   }
 }

--- a/test/integration/portal/PortalSpec.scala
+++ b/test/integration/portal/PortalSpec.scala
@@ -68,16 +68,40 @@ class PortalSpec extends IntegrationTestRunner {
       status(doc) must equalTo(OK)
     }
 
+    "export docs as EAD" in new ITestApp {
+      val ead = FakeRequest(controllers.portal.routes.DocumentaryUnits.export("c4")).call()
+      status(ead) must equalTo(OK)
+      contentType(ead) must beSome.which { ct =>
+        ct must equalTo("text/xml")
+      }
+    }
+
     "view repositories" in new ITestApp {
       val doc = FakeRequest(controllers.portal.routes.Repositories.browse("r1")).call()
       status(doc) must equalTo(OK)
+    }
+
+    "export repositories as EAG" in new ITestApp {
+      val eag = FakeRequest(controllers.portal.routes.Repositories.export("r1")).call()
+      status(eag) must equalTo(OK)
+      contentType(eag) must beSome.which { ct =>
+        ct must equalTo("text/xml")
+      }
     }
 
     "view historical agents" in new ITestApp {
       val doc = FakeRequest(controllers.portal.routes.HistoricalAgents.browse("a1")).call()
       status(doc) must equalTo(OK)
     }
-    
+
+    "export historical agents as EAC" in new ITestApp {
+      val eac = FakeRequest(controllers.portal.routes.HistoricalAgents.export("a1")).call()
+      status(eac) must equalTo(OK)
+      contentType(eac) must beSome.which { ct =>
+        ct must equalTo("text/xml")
+      }
+    }
+
     "view item history" in new ITestApp {
       val history = FakeRequest(portalRoutes.itemHistory("c4")).call()
       status(history) must equalTo(OK)


### PR DESCRIPTION
Not yet exposed/linked to on the interface (yet.)

Currently, whilst the URLs are uniform (/export), the formats for each type respectively are hard-coded.