### PR TITLE
Add tab-separated value support to note, watch lists, and Cypher data.

### DIFF
--- a/modules/admin/app/views/admin/cypherQueries/list.scala.html
+++ b/modules/admin/app/views/admin/cypherQueries/list.scala.html
@@ -21,12 +21,11 @@
                         </li>
                     </ul>
                     <ul class="list-item-actions">
-                        <li><a
-                            title="@Messages("download.format.json")"
-                            href="@controllers.cypher.routes.CypherQueries.executeQuery(oid)">JSON</a></li>
-                        <li><a
-                            title="@Messages("download.format.csv")"
-                            href="@controllers.cypher.routes.CypherQueries.executeQuery(oid)?format=csv">CSV</a></li>
+                        @for(fmt <- Seq(DataFormat.Json, DataFormat.Csv, DataFormat.Tsv)) {
+                            <li><a
+                                title="@Messages(s"download.format.$fmt")"
+                                    href="@controllers.cypher.routes.CypherQueries.executeQuery(oid, fmt)">@fmt</a></li>
+                        }
                         @if(userOpt.exists(_.isAdmin)) {
                             <li><a
                                 title="@Messages("cypherQuery.update.description")"

--- a/modules/admin/conf/cypher.routes
+++ b/modules/admin/conf/cypher.routes
@@ -9,4 +9,4 @@ GET         /update/:id         @controllers.cypher.CypherQueries.updateQuery(id
 POST        /update/:id         @controllers.cypher.CypherQueries.updateQueryPost(id: String)
 GET         /delete/:id         @controllers.cypher.CypherQueries.deleteQuery(id: String)
 POST        /delete/:id         @controllers.cypher.CypherQueries.deleteQueryPost(id: String)
-GET         /execute/:id        @controllers.cypher.CypherQueries.executeQuery(id: String)
+GET         /execute/:id        @controllers.cypher.CypherQueries.executeQuery(id: String, format: controllers.DataFormat.Value ?= controllers.DataFormat.Json)

--- a/modules/backend/src/main/scala/backend/rest/RestAnnotations.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestAnnotations.scala
@@ -14,13 +14,13 @@ import backend.Annotations
  */
 trait RestAnnotations extends Annotations with RestDAO {
 
-  val eventHandler: EventHandler
+  def eventHandler: EventHandler
   implicit def apiUser: ApiUser
   implicit def executionContext: ExecutionContext
 
-  import Constants.ACCESSOR_PARAM
+  import backend.rest.Constants.ACCESSOR_PARAM
 
-  private def requestUrl = s"$baseUrl/${EntityType.Annotation}"
+  private def requestUrl = enc(baseUrl, EntityType.Annotation)
 
   override def getAnnotationsForItem[A: Readable](id: String): Future[Page[A]] = {
     val url = enc(requestUrl, "for", id)

--- a/modules/backend/src/main/scala/backend/rest/RestContext.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestContext.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
  * @author Mike Bryant (http://github.com/mikesname)
  */
 trait RestContext {
-  val eventHandler: EventHandler
+  def eventHandler: EventHandler
   implicit def apiUser: ApiUser
   implicit def executionContext: ExecutionContext
 }

--- a/modules/backend/src/main/scala/backend/rest/RestEvents.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestEvents.scala
@@ -13,7 +13,7 @@ import defines.EntityType
  */
 trait RestEvents extends Events with RestDAO with RestContext {
 
-  private def requestUrl = s"$baseUrl/${EntityType.SystemEvent}"
+  private def requestUrl = enc(baseUrl,  EntityType.SystemEvent)
 
   override def history[A: Readable](id: String, params: RangeParams, filters: SystemEventParams = SystemEventParams.empty): Future[RangePage[Seq[A]]] = {
     val url: String = enc(requestUrl, "aggregateFor", id)

--- a/modules/backend/src/main/scala/backend/rest/RestPermissions.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestPermissions.scala
@@ -12,9 +12,9 @@ import backend._
 
 trait RestPermissions extends Permissions with RestDAO with RestContext {
 
-  import Constants._
+  import backend.rest.Constants._
 
-  private def requestUrl = s"$baseUrl/permission"
+  private def requestUrl = enc(baseUrl, EntityType.Permission)
 
   def listPermissionGrants[A: Readable](userId: String, params: PageParams): Future[Page[A]] =
     listWithUrl(enc(requestUrl, "list", userId), params)

--- a/modules/backend/src/main/scala/defines/ContentTypes.scala
+++ b/modules/backend/src/main/scala/defines/ContentTypes.scala
@@ -1,20 +1,22 @@
 package defines
 
+import eu.ehri.project.definitions.Entities
+
 object ContentTypes extends Enumeration() {
   type Type = Value
-  val HistoricalAgent = Value("historicalAgent")
-  val DocumentaryUnit = Value("documentaryUnit")
-  val Repository = Value("repository")
-  val SystemEvent = Value("systemEvent")
-  val UserProfile = Value("userProfile")
-  val Group = Value("group")
-  val Annotation = Value("annotation")
-  val Concept = Value("cvocConcept")
-  val Vocabulary = Value("cvocVocabulary")
-  val AuthoritativeSet = Value("authoritativeSet")
-  val Link = Value("link")
-  val Country = Value("country")
-  val VirtualUnit = Value("virtualUnit")
+  val HistoricalAgent = Value(Entities.HISTORICAL_AGENT)
+  val DocumentaryUnit = Value(Entities.DOCUMENTARY_UNIT)
+  val Repository = Value(Entities.REPOSITORY)
+  val SystemEvent = Value(Entities.SYSTEM_EVENT)
+  val UserProfile = Value(Entities.USER_PROFILE)
+  val Group = Value(Entities.GROUP)
+  val Annotation = Value(Entities.ANNOTATION)
+  val Concept = Value(Entities.CVOC_CONCEPT)
+  val Vocabulary = Value(Entities.CVOC_VOCABULARY)
+  val AuthoritativeSet = Value(Entities.AUTHORITATIVE_SET)
+  val Link = Value(Entities.LINK)
+  val Country = Value(Entities.COUNTRY)
+  val VirtualUnit = Value(Entities.VIRTUAL_UNIT)
 
   implicit val _format = defines.EnumUtils.enumFormat(this)
 }

--- a/modules/backend/src/main/scala/defines/EntityType.scala
+++ b/modules/backend/src/main/scala/defines/EntityType.scala
@@ -1,38 +1,40 @@
 package defines
 
+import eu.ehri.project.definitions.Entities._
+
 object EntityType extends Enumeration {
   // Allow these enums to be converted to strings implicitly,
   // since the binding relies on to/from string behaviour.
-  import language.implicitConversions
+  import scala.language.implicitConversions
   implicit def enumToString(e: Enumeration#Value): String = e.toString
 
   type Type = Value
-  val DocumentaryUnit = Value("documentaryUnit")
-  val DocumentaryUnitDescription = Value("documentDescription")
-  val Repository = Value("repository")
-  val RepositoryDescription = Value("repositoryDescription")
-  val HistoricalAgent = Value("historicalAgent")
-  val HistoricalAgentDescription = Value("historicalAgentDescription")
-  val SystemEvent = Value("systemEvent")
-  val UserProfile = Value("userProfile")
-  val Group = Value("group")
-  val ContentType = Value("contentType")
-  val DatePeriod = Value("datePeriod")
-  val Address = Value("address")
-  val PermissionGrant = Value("permissionGrant")
-  val Permission = Value("permission")
-  val Annotation = Value("annotation")
-  val Concept = Value("cvocConcept")
-  val ConceptDescription = Value("cvocConceptDescription")
-  val Vocabulary = Value("cvocVocabulary")
-  val AuthoritativeSet = Value("authoritativeSet")
-  val AccessPoint = Value("relationship")
-  val Link = Value("link")
-  val Country = Value("country")
-  val UnknownProperty = Value("property")
-  val MaintenanceEvent = Value("maintenanceEvent")
-  val VirtualUnit = Value("virtualUnit")
-  val Version = Value("version")
+  val DocumentaryUnit = Value(DOCUMENTARY_UNIT)
+  val DocumentaryUnitDescription = Value(DOCUMENT_DESCRIPTION)
+  val Repository = Value(REPOSITORY)
+  val RepositoryDescription = Value(REPOSITORY_DESCRIPTION)
+  val HistoricalAgent = Value(HISTORICAL_AGENT)
+  val HistoricalAgentDescription = Value(HISTORICAL_AGENT_DESCRIPTION)
+  val SystemEvent = Value(SYSTEM_EVENT)
+  val UserProfile = Value(USER_PROFILE)
+  val Group = Value(GROUP)
+  val ContentType = Value(CONTENT_TYPE)
+  val DatePeriod = Value(DATE_PERIOD)
+  val Address = Value(ADDRESS)
+  val PermissionGrant = Value(PERMISSION_GRANT)
+  val Permission = Value(PERMISSION)
+  val Annotation = Value(ANNOTATION)
+  val Concept = Value(CVOC_CONCEPT)
+  val ConceptDescription = Value(CVOC_CONCEPT_DESCRIPTION)
+  val Vocabulary = Value(CVOC_VOCABULARY)
+  val AuthoritativeSet = Value(AUTHORITATIVE_SET)
+  val AccessPoint = Value(ACCESS_POINT)
+  val Link = Value(LINK)
+  val Country = Value(COUNTRY)
+  val UnknownProperty = Value(UNKNOWN_PROPERTY)
+  val MaintenanceEvent = Value(MAINTENANCE_EVENT)
+  val VirtualUnit = Value(VIRTUAL_UNIT)
+  val Version = Value(VERSION)
 
   implicit val _format = defines.EnumUtils.enumFormat(this)
 }

--- a/modules/portal/app/controllers/DataFormat.scala
+++ b/modules/portal/app/controllers/DataFormat.scala
@@ -11,4 +11,5 @@ object DataFormat extends BindableEnum {
   val Xml = Value("xml")
   val Html = Value("html")
   val Csv = Value("csv")
+  val Tsv = Value("tsv")
 }

--- a/modules/portal/app/controllers/portal/users/UserProfiles.scala
+++ b/modules/portal/app/controllers/portal/users/UserProfiles.scala
@@ -123,11 +123,12 @@ case class UserProfiles @Inject()(
       format match {
         case DataFormat.Text => Ok(views.txt.userProfile.watchedItems(watchList))
           .as(MimeTypes.TEXT)
-        case DataFormat.Csv => Ok(writeCsv(
+        case DataFormat.Csv | DataFormat.Tsv => Ok(writeCsv(
           List("Item", "URL"),
-          watchList.items.map(a => ExportWatchItem.fromItem(a).toCsv)))
-          .as("text/csv")
-          .withHeaders(HeaderNames.CONTENT_DISPOSITION -> s"attachment; filename=${request.user.id}_watched.csv")
+          watchList.items.map(a => ExportWatchItem.fromItem(a).toCsv),
+            sep = if (format == DataFormat.Csv) ',' else '\t'))
+          .as(s"text/$format; charset=utf-8")
+          .withHeaders(HeaderNames.CONTENT_DISPOSITION -> s"attachment; filename=${request.user.id}_watched.$format")
         case DataFormat.Json =>
           Ok(Json.toJson(watchList.items.map(ExportWatchItem.fromItem)))
             .as(MimeTypes.JSON)
@@ -180,11 +181,12 @@ case class UserProfiles @Inject()(
         case DataFormat.Text =>
           Ok(views.txt.userProfile.annotations(itemsOnly).body.trim)
             .as(MimeTypes.TEXT)
-        case DataFormat.Csv => Ok(writeCsv(
+        case DataFormat.Csv | DataFormat.Tsv => Ok(writeCsv(
             List("Item", "Field", "Note", "Time", "URL"),
-            itemsOnly.items.map(a => ExportAnnotation.fromAnnotation(a).toCsv)))
-          .as("text/csv")
-          .withHeaders(HeaderNames.CONTENT_DISPOSITION -> s"attachment; filename=${request.user.id}_notes.csv")
+            itemsOnly.items.map(a => ExportAnnotation.fromAnnotation(a).toCsv),
+              sep = if (format == DataFormat.Csv) ',' else '\t'))
+          .as(s"text/$format; charset=utf-8")
+          .withHeaders(HeaderNames.CONTENT_DISPOSITION -> s"attachment; filename=${request.user.id}_notes.$format")
         case DataFormat.Json =>
           Ok(Json.toJson(itemsOnly.items.map(ExportAnnotation.fromAnnotation)))
             .as(MimeTypes.JSON)

--- a/modules/portal/app/models/CypherQuery.scala
+++ b/modules/portal/app/models/CypherQuery.scala
@@ -12,13 +12,13 @@ import utils.CsvHelpers
 import scala.concurrent.{ExecutionContext, Future}
 
 case class ResultFormat(columns: Seq[String], data: Seq[Seq[JsValue]]) {
-  def toCsv(quote: Boolean = false): String =
+  def toCsv(sep: Char = ',', quote: Boolean = false): String =
     CsvHelpers.writeCsv(columns, data.map(_.collect {
       case JsString(s) => s
       case JsNumber(i) => i.toString()
       case JsNull => ""
       case JsBoolean(b) => b.toString
-    }.toArray), quote)
+    }.toArray), sep = sep, quote = quote)
 }
 object ResultFormat {
   implicit val _reads = Json.reads[ResultFormat]

--- a/modules/portal/app/utils/CsvHelpers.scala
+++ b/modules/portal/app/utils/CsvHelpers.scala
@@ -8,10 +8,10 @@ import com.opencsv.CSVWriter
  * @author Mike Bryant (http://github.com/mikesname)
  */
 trait CsvHelpers {
-  def writeCsv(headers: Seq[String], data: Seq[Array[String]], quote: Boolean = true): String = {
+  def writeCsv(headers: Seq[String], data: Seq[Array[String]], sep: Char = ',', quote: Boolean = true): String = {
     val buffer = new StringWriter()
-    val csvWriter = if (quote) new CSVWriter(buffer)
-      else new CSVWriter(buffer, ',', CSVWriter.NO_QUOTE_CHARACTER)
+    val csvWriter = if (quote) new CSVWriter(buffer, sep)
+      else new CSVWriter(buffer, sep, CSVWriter.NO_QUOTE_CHARACTER)
     try {
       csvWriter.writeNext(headers.toArray)
       for (item <- data) {

--- a/modules/portal/app/views/userProfile/annotationList.scala.html
+++ b/modules/portal/app/views/userProfile/annotationList.scala.html
@@ -11,7 +11,7 @@
     @common.pagination(annotations.page)
     <div class="list-export-options">
         <span class="glyphicon glyphicon-download"></span>
-        @for(fmt <- Seq(DataFormat.Text, DataFormat.Csv, DataFormat.Json)) {
+        @for(fmt <- Seq(DataFormat.Text, DataFormat.Csv, DataFormat.Tsv, DataFormat.Json)) {
             <a class="download-link" target="_blank" title="@Messages("download.format." + fmt)"
                     href="@controllers.portal.users.routes.UserProfiles.annotations(format = fmt)&limit=1000">
                 @fmt

--- a/modules/portal/app/views/userProfile/itemWatchList.scala.html
+++ b/modules/portal/app/views/userProfile/itemWatchList.scala.html
@@ -8,7 +8,7 @@
         @common.pagination(result.page)
         <div class="list-export-options">
             <span class="glyphicon glyphicon-download"></span>
-            @for(fmt <- Seq(DataFormat.Text, DataFormat.Csv, DataFormat.Json)) {
+            @for(fmt <- Seq(DataFormat.Text, DataFormat.Csv, DataFormat.Tsv, DataFormat.Json)) {
                 <a class="alt" target="_blank" title="@Messages("download.format." + fmt.toString)" href="@controllers.portal.users.routes.UserProfiles.watching(format = fmt)&limit=-1">
                 @fmt
                 </a>

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -103,6 +103,7 @@ truncated.items.remaining={0,choice,0#|1#and 1 more...|1<and {0,number,integer} 
 download=Download
 download.format.txt=Download as plain text
 download.format.csv=Download as CSV
+download.format.tsv=Download as TSV
 download.format.json=Download as JSON
 
 #

--- a/modules/portal/conf/messages.de
+++ b/modules/portal/conf/messages.de
@@ -78,6 +78,7 @@ truncated.items.remaining={0,choice,0#|1#und 1 weiteres...|1<und {0,number,integ
 download=Herunterladen
 download.format.txt=Als Plain Text herunterladen
 download.format.csv=Als CSV herunterladen
+download.format.tsv=Als TSV herunterladen
 download.format.json=Als JSON herunterladen
 profile.preferences=Einstellungen
 profile.preferences.updated=Einstellungen aktualisiert

--- a/modules/portal/conf/messages.fr
+++ b/modules/portal/conf/messages.fr
@@ -78,6 +78,7 @@ truncated.items.remaining={0,choice,0#|1#et 1 de plus...|1<et {0,number,integer}
 download=Télécharger
 download.format.txt=Télécharger sous forme de texte
 download.format.csv=Télécharger sous format CSV
+download.format.tsv=Télécharger sous format TSV
 download.format.json=Télécharger sous format JSON
 profile.preferences=Préférences
 profile.preferences.updated=Préférences mises à jour

--- a/modules/portal/conf/messages.pl
+++ b/modules/portal/conf/messages.pl
@@ -78,6 +78,7 @@ truncated.items.remaining={0,choice,0#|1#jeszcze 1...|1<jeszcze {0,number,intege
 download=Pobierz
 download.format.txt=Pobierz jako zwykły tekst
 download.format.csv=Pobierz jako plik CSV
+download.format.tsv=Pobierz jako plik TSV
 download.format.json=Pobierz jako plik JSON
 profile.preferences=Preferencje
 profile.preferences.updated=Zaktualizowano preferencje


### PR DESCRIPTION
Also, remove some hard-coded entity name strings which will break when we rename them.