### PR TITLE
Migrate from OpenCSV to Jackson CSV

### DIFF
--- a/modules/admin/app/controllers/admin/Utils.scala
+++ b/modules/admin/app/controllers/admin/Utils.scala
@@ -16,7 +16,7 @@ import play.api.libs.json._
 import play.api.mvc.Action
 import backend.Backend
 import play.api.libs.ws.WSClient
-import utils.{MovedPageLookup, PageParams}
+import utils.{CsvHelpers, MovedPageLookup, PageParams}
 import backend.rest.cypher.Cypher
 import views.MarkdownRenderer
 
@@ -90,14 +90,13 @@ case class Utils @Inject()(
   }
 
   private def parseCsv(file: File): Seq[(String, String)] = {
-    import java.io.{InputStreamReader, FileInputStream}
-    import com.opencsv.CSVReader
+    import java.io.FileInputStream
     import scala.collection.JavaConverters._
+    import com.fasterxml.jackson.dataformat.csv.CsvSchema
 
-    val csvReader: CSVReader = new CSVReader(
-      new InputStreamReader(
-        new FileInputStream(file), "UTF-8"), '\t')
-    val all = csvReader.readAll()
+    val schema = CsvSchema.builder().setColumnSeparator('\t').build()
+    val all: java.util.List[Array[String]] = CsvHelpers.mapper
+      .reader(schema).readValue(new FileInputStream(file))
     (for {
       arr <- all.asScala
     } yield arr.toList).toSeq.collect {

--- a/modules/portal/app/models/CypherQuery.scala
+++ b/modules/portal/app/models/CypherQuery.scala
@@ -18,7 +18,7 @@ case class ResultFormat(columns: Seq[String], data: Seq[Seq[JsValue]]) {
       case JsNumber(i) => i.toString()
       case JsNull => ""
       case JsBoolean(b) => b.toString
-    }.toArray), sep = sep, quote = quote)
+    }.toArray), sep = sep)
 }
 object ResultFormat {
   implicit val _reads = Json.reads[ResultFormat]

--- a/modules/portal/test/utils/CsvHelpersSpec.scala
+++ b/modules/portal/test/utils/CsvHelpersSpec.scala
@@ -1,0 +1,21 @@
+package utils
+
+import play.api.test.PlaySpecification
+
+class CsvHelpersSpec extends PlaySpecification {
+
+  "CsvHelpers" should {
+    "only quote when necessary" in {
+      val csv = CsvHelpers.writeCsv(Seq("col1", "col2"), Seq(Array("val1", "val2, comma")))
+      csv must_== "col1,col2\nval1,\"val2, comma\"\n"
+    }
+
+    "not unnecessarily quote unicode values" in {
+      val csvNoQuotes = CsvHelpers.writeCsv(Seq("col1"), Seq(Array("a long string with some unicode: državno")))
+      csvNoQuotes must_== "col1\na long string with some unicode: državno\n"
+
+      val csvWithQuotes = CsvHelpers.writeCsv(Seq("col1"), Seq(Array("a long string with some unicode+comma: drža,vno")))
+      csvWithQuotes must_== "col1\n\"a long string with some unicode+comma: drža,vno\"\n"
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -103,7 +103,7 @@ object ApplicationBuild extends Build {
 
   val portalDependencies = Seq(
     "net.coobird" % "thumbnailator" % "[0.4, 0.5)",
-    "com.opencsv" % "opencsv" % "3.6",
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-csv" % "2.6.4",
 
     // EHRI indexing tools
     "ehri-project" % "index-data-converter" % "1.1.3-SNAPSHOT" exclude("log4j", "log4j") exclude ("org.slf4j",


### PR DESCRIPTION
Jackson does on-demand quoting, rather than quoting being either on or off for all values. It also has a slightly nicer API.

Fixes #697.