### PR TITLE
Fix updating profile info when removing data.

### DIFF
--- a/modules/core/app/models/DocumentaryUnitDescription.scala
+++ b/modules/core/app/models/DocumentaryUnitDescription.scala
@@ -9,9 +9,8 @@ import eu.ehri.project.definitions.Ontology
 import utils.forms._
 import play.api.data.Form
 import play.api.data.Forms._
-import defines.EnumUtils._
-import backend.{Entity, Readable, Writable}
-import Description._
+import backend.{Entity, Writable}
+import models.base.Description._
 
 case class IsadGIdentity(
   name: String,

--- a/modules/portal/app/controllers/portal/users/UserProfiles.scala
+++ b/modules/portal/app/controllers/portal/users/UserProfiles.scala
@@ -223,7 +223,7 @@ case class UserProfiles @Inject()(
 
   private def profileDataForm(implicit userOpt: Option[UserProfile]): Form[ProfileData] = {
     userOpt.map { user =>
-      ProfileData.form.fill(ProfileData.fromUser(user))
+      ProfileData.form.fill(ProfileData.fromUser(user.model))
     } getOrElse {
       ProfileData.form
     }
@@ -261,7 +261,8 @@ case class UserProfiles @Inject()(
       errForm => immediate(
         BadRequest(views.html.userProfile.editProfile(errForm, imageForm, accountPrefsForm))
       ),
-      profile => userBackend.patch[UserProfile](request.user.id, Json.toJson(profile).as[JsObject]).map { userProfile =>
+      profile => userBackend.update[UserProfile, UserProfileF](
+          request.user.id, profile.toUser(request.user.model)).map { userProfile =>
         Redirect(profileRoutes.profile())
           .flashing("success" -> Messages("profile.update.confirmation"))
       }

--- a/modules/portal/app/models/ProfileData.scala
+++ b/modules/portal/app/models/ProfileData.scala
@@ -1,7 +1,5 @@
 package models
 
-import play.api.libs.json.{Json, Writes}
-
 /**
  * Class representing the parts of a users profile editable
  * via the UI. This is basically everything, with the exception
@@ -19,23 +17,42 @@ case class ProfileData(
   institution: Option[String] = None,
   role: Option[String] = None,
   interests: Option[String] = None
-)
+) {
+
+  def toUser(user: UserProfileF): UserProfileF = user.copy(
+      name = name,
+      location = location,
+      languages = languages,
+      about = about,
+      url = url,
+      workUrl = workUrl,
+      title = title,
+      institution = institution,
+      role = role,
+      interests = interests
+    )
+}
 
 object ProfileData {
 
-  def fromUser(user: UserProfile): ProfileData = new ProfileData(
-    user.model.name, user.model.location, user.model.languages,
-    user.model.about, user.model.url, user.model.workUrl,
-    user.model.title, user.model.institution, user.model.role,
-    user.model.interests
+  def fromUser(user: UserProfileF): ProfileData = new ProfileData(
+    user.name,
+    user.location,
+    user.languages,
+    user.about,
+    user.url,
+    user.workUrl,
+    user.title,
+    user.institution,
+    user.role,
+    user.interests
   )
 
   import play.api.data.Forms._
   import play.api.data.Form
-  import UserProfileF.{LOCATION => USERLOC, _}
+  import models.UserProfileF.{LOCATION => USERLOC, _}
   import utils.forms.isValidUrl
 
-  implicit val writes: Writes[ProfileData] = Json.format[ProfileData]
   val form: Form[ProfileData] = Form(
     mapping(
       NAME -> nonEmptyText,

--- a/test/integration/portal/UserProfilesSpec.scala
+++ b/test/integration/portal/UserProfilesSpec.scala
@@ -100,6 +100,14 @@ class UserProfilesSpec extends IntegrationTestRunner with FakeMultipartUpload {
       status(prof) must equalTo(OK)
       contentAsString(prof) must contain(testName)
       contentAsString(prof) must contain(testInterest)
+
+      // Ensure about text can be cleared
+      val update2 = FakeRequest(profileRoutes.updateProfilePost())
+        .withUser(privilegedUser).withCsrf.callWith(data
+        .updated(UserProfileF.INTERESTS, Seq("")))
+      status(update2) must equalTo(SEE_OTHER)
+      val prof2 = FakeRequest(profileRoutes.profile()).withUser(privilegedUser).call()
+      contentAsString(prof2) must not contain testInterest
     }
 
     "prevent script injection" in new ITestApp {


### PR DESCRIPTION
The current PATCH semantics are a bit broken since null values get removed before the data merged, which prevents removing values. This provides a workaround for the immediate case of updating user profiles by merging the patch data on the client side and using update instead of patch.