### PR TITLE
Fix JSON export (again).

### DIFF
--- a/modules/admin/app/controllers/admin/Data.scala
+++ b/modules/admin/app/controllers/admin/Data.scala
@@ -53,7 +53,7 @@ case class Data @Inject()(
   }
 
   def getItemRawJson(entityType: defines.EntityType.Value, id: String) = OptionalUserAction.async { implicit request =>
-    userBackend.query(s"classes/$entityType/$id").map { r =>
+    userBackend.query(s"$entityType/$id").map { r =>
       Ok(r.json)
     }
   }


### PR DESCRIPTION
This time it was broken because a backported change from the Play 2.5 branch pointed to the wrong backend WS path.