### PR TITLE
Allow constraining access point suggestions to specific vocabs/sets.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -230,6 +230,15 @@ ehri {
           maxImageSize: 5000000 // bytes
         }
     }
+
+    admin {
+        accessPoints {
+            # Constrain access point suggestions to specific
+            # vocabularies/authority sets by adding their IDs
+            # the the holders list
+            holders: []
+        }
+    }
 }
 
 # system-specific overrides and extensions

--- a/modules/admin/app/assets/js/access-points.js
+++ b/modules/admin/app/assets/js/access-points.js
@@ -22,7 +22,7 @@ $(document).ready(function () {
       }
     };
 
-    var search = function (types, searchTerm, page, callback) {
+    var search = function (types, holders, searchTerm, page, callback) {
       var params = "?limit=10&q=" + searchTerm;
       if (types && types.length > 0) {
         if (Array.isArray(types)) {
@@ -33,6 +33,13 @@ $(document).ready(function () {
           params = params + "&st[]=" + types;
         }
       }
+      if (holders && holders.length > 0) {
+        if (Array.isArray(holders)) {
+          params = params + "&f[]=holderId:(" + holders.join(" ") + ")";
+        } else {
+          params = params + "&f[]=holderId:" + holders;
+        }
+      }
       if (page > 0) {
         params = params + "&page=" + page;
       }
@@ -40,16 +47,17 @@ $(document).ready(function () {
     };
 
     var limitTypes = function (element) {
-      var $types = element.parents(".input-group").first().find(".type.active");
-      if ($types === "undefined" || $types.length == 0) {
-        return []
-      } else {
-        var data = [];
-        $types.each(function () {
-          data.push($(this).data("value"))
-        });
-        return data
-      }
+      return element.parents(".input-group")
+          .find(".type-filters > .type.active")
+          .map(function(i, elem) { return $(elem).data("value"); })
+          .get();
+    };
+
+    var limitHolders = function (element) {
+      return element.parents(".input-group")
+          .find(".holder-filters > .holder.active")
+          .map(function(i, elem) { return $(elem).data("value"); })
+          .get();
     };
 
     var searchTerm = function (element) {
@@ -65,9 +73,10 @@ $(document).ready(function () {
         return page(element);
       },
       search: function (element) {
-        return search(this.limitTypes(element), this.searchTerm(element), this.page(element));
+        return search(this.limitTypes(element), this.limitHolders(element), this.searchTerm(element), this.page(element));
       },
       limitTypes: limitTypes,
+      limitHolders: limitHolders,
       detail: function (type, id, callback) {
         return $.get($service.getItem(type, id).url, {
           headers: ajaxHeaders
@@ -401,7 +410,7 @@ $(document).ready(function () {
         });
   });
 
-  $(".dropdown-menu.filters").on("click", function (e) {
+  $("ul.type-filters, ul.holder-filters").on("click", function (e) {
     e.stopPropagation()
   });
 

--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -365,11 +365,17 @@ case class DocumentaryUnits @Inject()(
     }
   }
 
-  def manageAccessPoints(id: String, descriptionId: String) = {
+  def manageAccessPoints(id: String, descriptionId: String) =
     WithDescriptionAction(id, descriptionId).apply { implicit request =>
-      Ok(views.html.admin.documentaryUnit.editAccessPoints(request.item, request.description))
+      // Holder IDs for vocabularies and authoritative sets to which
+      // access point suggestions will be constrainted. If this is empty
+      // all available vocabs/auth sets will be used.
+      val holders = app.configuration
+        .getStringSeq("ehri.admin.accessPoints.holders")
+        .getOrElse(Seq.empty)
+      Ok(views.html.admin.documentaryUnit.editAccessPoints(request.item,
+        request.description, holderIds = holders))
     }
-  }
 }
 
 

--- a/modules/admin/app/views/admin/documentaryUnit/editAccessPoints.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/editAccessPoints.scala.html
@@ -1,4 +1,4 @@
-@(item: DocumentaryUnit, desc: DocumentaryUnitDescriptionF)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, flash: Flash)
+@(item: DocumentaryUnit, desc: DocumentaryUnitDescriptionF, holderIds: Seq[String] = Seq.empty)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, flash: Flash)
 
     @extrascripts = {
         @helper.javascriptRouter("adminJsRoutes")(
@@ -20,7 +20,8 @@
         <script src="@controllers.portal.routes.PortalAssets.versioned("js/bootstrap.confirmation.js")"></script>
         <script src="@controllers.admin.routes.AdminAssets.versioned("js/access-points.js")"></script>
         <style type="text/css">
-            ul.filters { display: none; }
+            ul.type-filters { display: none; }
+            ul.holder-filters { display: none; }
             .modal-dialog { width: 80%;}
             .model { display:none; }
             .new-access-point { display: none; }
@@ -70,7 +71,12 @@
                                     <input class="form-control quicksearch" name="@accessPointType.toString" type="text" placeholder="@Messages("accessPoint.name")" autofocus="autofocus" />
                                      <div class="input-group-btn">
                                         <button class="btn btn-success add-access-text" title="@Messages("accessPoints.newTextAccessPoint.description")"><span class="glyphicon glyphicon-plus-sign"></span></button>
-                                        <ul class="dropdown-menu filters pull-right">
+                                         <ul class="dropdown-menu holder-filters pull-right">
+                                             @holderIds.map { holderId =>
+                                                 <li data-value="@holderId" class="active holder"><a>@holderId</a></li>
+                                             }
+                                         </ul>
+                                        <ul class="dropdown-menu type-filters pull-right">
                                             <li class="dropdown-header">@Messages("contentTypes")</li>
                                             @accessPointType match {
                                                 case AccessPointType.CreatorAccess | AccessPointType.PersonAccess => {

--- a/modules/core/app/controllers/generic/Search.scala
+++ b/modules/core/app/controllers/generic/Search.scala
@@ -222,7 +222,6 @@ trait Search extends CoreActionBuilders {
     val sp = SearchParams.form.bindFromRequest
       .value.getOrElse(SearchParams.empty)
       .setDefault(params)
-
     searchEngine.config.setParams(sp).withFilters(filters).filter().map(_.page)
   }
 }

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
@@ -64,6 +64,7 @@ case class SolrSearchConfig(
       .withExtraParams(extraParams)
       .simpleFilterQuery()
 
+    logger.trace(fullSearchUrl(queryRequest))
     dispatch(queryRequest).map { response =>
       val parser = handler.getResponseParser(response.body)
       val items = parser.items.map(i => FilterHit(


### PR DESCRIPTION
This is accomplished via a config value which takes their IDs.
A few small extra tweaks.

Fixes #722.