### PR TITLE
Remove group.sort Solr parameter.

### DIFF
--- a/conf/search.conf
+++ b/conf/search.conf
@@ -33,6 +33,7 @@ search {
         author: creatorNames
         keyword: accessPointNames
         address: addresses
+        lang: languageCode
     }
 
     // Max descendants. HACK: Search will currently

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrQueryBuilder.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrQueryBuilder.scala
@@ -183,7 +183,12 @@ case class SolrQueryBuilder(
 
     // Not yet supported by scalikesolr
     request.set("group.facet", true)
-    request.set("group.sort", s"${SearchConstants.LANGUAGE_CODE} desc")
+
+    // NB: There was previously a group sort by language code, but this
+    // had some pretty unexpected effects, sorting, e.g. Ukrainian items
+    // first, even when the search string was English. Until a more intuitive
+    // method of sorting groups is devised this is being disabled.
+    //request.set("group.sort", s"${SearchConstants.LANGUAGE_CODE} desc")
   }
 
   private def applyIdFilters(request: QueryRequest, ids: Seq[String]): Unit = {


### PR DESCRIPTION
Since there's no comment to tell us why this was added, it's being removed due to having weird effects on the quick filter (returning items in Ukrainian despite an English search string).

Also add a search field alias for the language code.