### PR TITLE
More admin cleanups.

### DIFF
--- a/modules/admin/app/controllers/admin/AdminSearch.scala
+++ b/modules/admin/app/controllers/admin/AdminSearch.scala
@@ -108,10 +108,8 @@ case class AdminSearch @Inject()(
 
   def search = OptionalUserAction.async { implicit request =>
     find[AnyModel](
-      defaultParams = SearchParams(
-        sort = Some(SearchOrder.Score),
-        entities = searchTypes.toList
-      ),
+      defaultParams = SearchParams(sort = Some(SearchOrder.Score)),
+      entities = searchTypes.toList,
       facetBuilder = entityFacets
     ).map { result =>
       render {

--- a/modules/admin/app/views/admin/authoritativeSet/show.scala.html
+++ b/modules/admin/app/views/admin/authoritativeSet/show.scala.html
@@ -30,9 +30,6 @@
         @views.html.admin.common.sidebarAction(user.hasPermission(ContentTypes.AuthoritativeSet, PermissionType.Grant)) {
             <a href="@controllers.sets.routes.AuthoritativeSets.managePermissions(item.id)">@Messages("permissions.manage")</a>
         }
-        @views.html.admin.common.sidebarAction() {
-            <a href="@controllers.sets.routes.AuthoritativeSets.history(item.id)">@Messages("item.history")</a>
-        }
         @views.html.admin.common.sidebarAction(user.isAdmin) {
             <a href="@controllers.sets.routes.AuthoritativeSets.updateIndex(item.id)">@Messages("search.index.update")</a>
         }

--- a/modules/admin/app/views/admin/concept/adminActions.scala.html
+++ b/modules/admin/app/views/admin/concept/adminActions.scala.html
@@ -16,7 +16,4 @@
     @views.html.admin.common.sidebarAction() {
         <a href="@controllers.admin.routes.Data.getItemRawJson(item.isA, item.id)">@Messages("item.export.json")</a>
     }
-    @views.html.admin.common.sidebarAction() {
-        <a href="@controllers.keywords.routes.Concepts.history(item.id)">@Messages("item.history")</a>
-    }
 }

--- a/modules/admin/app/views/admin/country/adminActions.scala.html
+++ b/modules/admin/app/views/admin/country/adminActions.scala.html
@@ -13,7 +13,4 @@
     @views.html.admin.common.sidebarAction(user.hasPermission(ContentTypes.Country, PermissionType.Grant)) {
         <a href="@controllers.countries.routes.Countries.managePermissions(item.id)">@Messages("permissions.manage")</a>
     }
-    @views.html.admin.common.sidebarAction() {
-        <a href="@controllers.countries.routes.Countries.history(item.id)">@Messages("item.history")</a>
-    }
 }

--- a/modules/admin/app/views/admin/group/show.scala.html
+++ b/modules/admin/app/views/admin/group/show.scala.html
@@ -60,8 +60,5 @@
         @views.html.admin.common.sidebarAction(user.hasPermission(ContentTypes.Group, PermissionType.Delete)) {
             <a href="@controllers.groups.routes.Groups.delete(item.id)">@Messages("group.delete")</a>
         }
-        @views.html.admin.common.sidebarAction() {
-            <a href="@controllers.groups.routes.Groups.history(item.id)">@Messages("item.history")</a>
-        }
     }
 }

--- a/modules/admin/app/views/admin/historicalAgent/adminActions.scala.html
+++ b/modules/admin/app/views/admin/historicalAgent/adminActions.scala.html
@@ -14,9 +14,6 @@
         <a href="@controllers.authorities.routes.HistoricalAgents.managePermissions(item.id)">@Messages("permissions.manage")</a>
     }
     @views.html.admin.common.sidebarAction() {
-        <a href="@controllers.authorities.routes.HistoricalAgents.history(item.id)">@Messages("item.history")</a>
-    }
-    @views.html.admin.common.sidebarAction() {
         <a href="@controllers.admin.routes.Data.getItemRawJson(item.isA, item.id)">@Messages("item.export.json")</a>
     }
     @views.html.admin.common.sidebarAction() {

--- a/modules/admin/app/views/admin/repository/adminActions.scala.html
+++ b/modules/admin/app/views/admin/repository/adminActions.scala.html
@@ -19,9 +19,6 @@
     @views.html.admin.common.sidebarAction(user.hasPermission(ContentTypes.Repository, PermissionType.Grant)) {
         <a href="@controllers.institutions.routes.Repositories.managePermissions(item.id)">@Messages("permissions.manage")</a>
     }
-    @views.html.admin.common.sidebarAction() {
-        <a  href="@controllers.institutions.routes.Repositories.history(item.id)">@Messages("item.history")</a>
-    }
     @views.html.admin.common.sidebarAction(user.isAdmin) {
         <a href="@controllers.institutions.routes.Repositories.updateIndex(item.id)">@Messages("search.index.update")</a>
     }

--- a/modules/admin/app/views/admin/vocabulary/show.scala.html
+++ b/modules/admin/app/views/admin/vocabulary/show.scala.html
@@ -34,9 +34,6 @@
         @sidebarAction(user.hasPermission(defines.ContentTypes.Vocabulary, defines.PermissionType.Grant)) {
             <a href="@controllers.vocabularies.routes.Vocabularies.managePermissions(item.id)">@Messages("permissions.manage")</a>
         }
-        @sidebarAction() {
-            <a href="@controllers.vocabularies.routes.Vocabularies.history(item.id)">@Messages("item.history")</a>
-        }
         @views.html.admin.common.sidebarAction(user.isAdmin) {
             <a href="@controllers.vocabularies.routes.Vocabularies.updateIndex(item.id)">@Messages("search.index.update")</a>
         }


### PR DESCRIPTION
 - remove superfluous sidebar actions (history link already exists in the recent-action panel)
 - fix entity type restriction in global search facet