### PR TITLE
Use an actor instead of a concurrent channel as the index message sink

### DIFF
--- a/modules/core/app/utils/search/SearchIndexMediator.scala
+++ b/modules/core/app/utils/search/SearchIndexMediator.scala
@@ -1,7 +1,7 @@
 package utils.search
 
+import akka.actor.ActorRef
 import defines.EntityType
-import play.api.libs.iteratee.Concurrent
 
 import scala.concurrent.Future
 
@@ -20,11 +20,11 @@ trait SearchIndexMediatorHandle {
    * Provide a concurrent channel through which to
    * pass update events.
    *
-   * @param channel the channel
+   * @param actorRef an actor to which to post messages
    * @param formatter a formatter for event strings
    * @return
    */
-  def withChannel(channel: Concurrent.Channel[String], formatter: String => String = identity[String]): SearchIndexMediatorHandle = this
+  def withChannel(actorRef: ActorRef, formatter: String => String = identity[String]): SearchIndexMediatorHandle = this
 
   /**
    * Index a single item by id.

--- a/modules/portal/app/indexing/SearchToolsIndexMediator.scala
+++ b/modules/portal/app/indexing/SearchToolsIndexMediator.scala
@@ -3,6 +3,7 @@ package indexing
 import java.util.Properties
 import javax.inject.Inject
 
+import akka.actor.ActorRef
 import backend.rest.Constants
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import defines.EntityType
@@ -13,7 +14,6 @@ import eu.ehri.project.indexing.converter.impl.JsonConverter
 import eu.ehri.project.indexing.index.Index
 import eu.ehri.project.indexing.sink.impl.{CallbackSink, IndexJsonSink}
 import play.api.Logger
-import play.api.libs.iteratee.Concurrent
 import utils.search.{SearchIndexMediator, SearchIndexMediatorHandle}
 
 import scala.collection.JavaConverters._
@@ -35,7 +35,7 @@ case class SearchToolsIndexMediator @Inject()(
  * is more convenient for deployment.
  */
 case class SearchToolsIndexMediatorHandle(
-  chan: Option[Concurrent.Channel[String]] = None,
+  chan: Option[ActorRef] = None,
   processFunc: String => String = identity[String]
 )(implicit index: Index,
   config: play.api.Configuration,
@@ -45,8 +45,8 @@ case class SearchToolsIndexMediatorHandle(
 
   val serviceBaseUrl: String = utils.serviceBaseUrl("ehridata", config)
 
-  override def withChannel(channel: Concurrent.Channel[String], formatter: String => String) =
-    copy(chan = Some(channel), processFunc = formatter)
+  override def withChannel(actorRef: ActorRef, formatter: String => String) =
+    copy(chan = Some(actorRef), processFunc = formatter)
 
   private def indexProperties(extra: Map[String,Any] = Map.empty): Properties = {
     val props = new Properties()
@@ -60,7 +60,7 @@ case class SearchToolsIndexMediatorHandle(
     val builder = new Builder[JsonNode, JsonNode]
       .addSink(new IndexJsonSink(index, new IndexJsonSink.EventHandler {
         override def handleEvent(event: Any): Unit = {
-          chan.foreach(_.push(processFunc(event.toString)))
+          chan.foreach(_ ! processFunc(event.toString))
         }
       }))
       .addConverter(new JsonConverter)
@@ -71,13 +71,13 @@ case class SearchToolsIndexMediatorHandle(
            logger.trace(writer.writeValueAsString(node))
            count += 1
            if (count % 100 == 0) {
-             chan.foreach(_.push(processFunc(s"Items processed: $count")))
+             chan.foreach(_ ! processFunc(s"Items processed: $count"))
            }
          }
          override def finish(): Unit = {
            val msg: String = s"Total items processed: $count"
            logger.debug(msg)
-           chan.foreach(_.push(processFunc(msg)))
+           chan.foreach(_ ! processFunc(msg))
          }
        }))
 


### PR DESCRIPTION
This fixes the deprecation messages resulting from using the old API.