### PR TITLE
Fix unescaped URL path segments being passed to the backend.

### DIFF
--- a/modules/backend/src/main/scala/backend/rest/RestService.scala
+++ b/modules/backend/src/main/scala/backend/rest/RestService.scala
@@ -222,10 +222,13 @@ trait RestService {
   /**
    * Encode a bunch of URL parts.
    */
-  protected def enc(s: Any*) = {
+  protected def enc(base: String, s: Any*) = {
+    def clean(segment: Any): String =
+      segment.toString.replace("?", "%3F").replace("#", "%23")
     import java.net.URI
-    val url = new java.net.URL(s.mkString("/"))
-    val uri: URI = new URI(url.getProtocol, url.getUserInfo, url.getHost, url.getPort, url.getPath, url.getQuery, url.getRef)
+    val url = new java.net.URL((base +: s.map(clean)).mkString("/"))
+    val uri: URI = new URI(url.getProtocol, url.getUserInfo,
+      url.getHost, url.getPort, url.getPath, url.getQuery, url.getRef)
     uri.toString
   }
 

--- a/test/integration/admin/DocumentaryUnitViewsSpec.scala
+++ b/test/integration/admin/DocumentaryUnitViewsSpec.scala
@@ -89,6 +89,11 @@ class DocumentaryUnitViewsSpec extends IntegrationTestRunner {
       val show = FakeRequest(docRoutes.get("r1")).withUser(privilegedUser).call()
       status(show) must equalTo(NOT_FOUND)
     }
+
+    "throw a 404 when fetching items with a dodgily encoded id" in new ITestApp {
+      val show = FakeRequest(docRoutes.get("c1#desc-eng")).withUser(privilegedUser).call()
+      status(show) must equalTo(NOT_FOUND)
+    }
   }
 
   "Documentary unit access functionality" should {


### PR DESCRIPTION
Using escaped '?' and '#' in the external URL results in malformed URLs being sent to the backend. A nicer way to fix this would be to use a proper URIBuilder, such as that which comes with JAX RS, but
that's a big dependency.