### PR TITLE
Add CVOC Concept identifier (ergo, script code) as an optional field

### DIFF
--- a/modules/admin/app/views/admin/concept/descriptionForm.scala.html
+++ b/modules/admin/app/views/admin/concept/descriptionForm.scala.html
@@ -1,8 +1,9 @@
 @(desc: play.api.data.Field)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, prefix: String, messages: Messages, md: views.MarkdownRenderer)
 
-@import ConceptF._
+@import Entity.IDENTIFIER
+@import models.ConceptF._
 @import views.html.formHelpers._
-@import Description._
+@import models.base.Description._
 
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
@@ -15,7 +16,7 @@
 
 
     @choiceInput(desc(LANG_CODE), LANG_CODE, views.Helpers.languagePairList, blank=true)
-
+    @choiceInput(desc(IDENTIFIER), IDENTIFIER, views.Helpers.scriptPairList, blank=true)
     @formHelpers.lineInput(desc, PREFLABEL)
     @formHelpers.inlineNameSet(desc, ALTLABEL)
     @formHelpers.inlineTextSet(desc, SCOPENOTE, rows = 4)

--- a/modules/core/app/models/ConceptDescription.scala
+++ b/modules/core/app/models/ConceptDescription.scala
@@ -10,19 +10,20 @@ import play.api.data.Forms._
 import utils.forms._
 import backend.{Entity, Writable}
 
-import Description._
-import models.base.Description.CREATION_PROCESS
+import models.base.Description._
+
 
 object ConceptDescriptionF {
 
   import eu.ehri.project.definitions.Ontology
-  import Entity._
-  import ConceptF._
+  import backend.Entity._
+  import models.ConceptF._
 
   implicit val conceptDescriptionFormat: Format[ConceptDescriptionF] = (
     (__ \ TYPE).formatIfEquals(EntityType.ConceptDescription) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ LANG_CODE).format[String] and
+    (__ \ DATA \ IDENTIFIER).formatNullable[String] and
     (__ \ DATA \ PREFLABEL).format[String] and
     (__ \ DATA \ ALTLABEL).formatSeqOrSingleNullable[String] and
     (__ \ DATA \ DEFINITION).formatSeqOrSingleNullable[String] and
@@ -44,6 +45,7 @@ case class ConceptDescriptionF(
   isA: EntityType.Value = EntityType.ConceptDescription,
   id: Option[String],
   languageCode: String,
+  identifier: Option[String] = None,
   name: String,
   altLabels: Option[Seq[String]] = None,
   definition: Option[Seq[String]] = None,
@@ -73,6 +75,7 @@ object ConceptDescription {
     ISA -> ignored(EntityType.ConceptDescription),
     ID -> optional(nonEmptyText),
     LANG_CODE -> nonEmptyText,
+    IDENTIFIER -> optional(nonEmptyText),
     PREFLABEL -> nonEmptyText,
     ALTLABEL -> optional(seq(nonEmptyText)),
     DEFINITION -> optional(seq(nonEmptyText)),

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -1077,6 +1077,7 @@ historicalAgent.maintenanceNotes=Maintenance Notes
 #
 cvocConcept.descriptions=Descriptions
 cvocConcept.languageCode=Language
+cvocConcept.identifier=Script (optional)
 cvocConcept.name=Preferred Label
 cvocConcept.altLabel=Alt. Label(s)
 cvocConcept.scopeNote=Scope Note


### PR DESCRIPTION
This exists on the EHRI thesaurus, so it should be editable.