### PR TITLE
Fix issues with redirecting moved pages.

### DIFF
--- a/app/AppModule.scala
+++ b/app/AppModule.scala
@@ -17,7 +17,7 @@ import global.{AppGlobalConfig, GlobalConfig, GlobalEventHandler}
 import indexing.SearchToolsIndexMediator
 import models.{GuideService, SqlGuideService}
 import utils.search.{SearchEngine, SearchIndexMediator, SearchItemResolver}
-import utils.{DbMovedPageLookup, MovedPageLookup}
+import utils.{SqlMovedPageLookup, MovedPageLookup}
 import views.{MarkdownRenderer, PegDownMarkdownRendererProvider}
 
 private class SolrIndexProvider @Inject()(config: play.api.Configuration) extends Provider[Index] {
@@ -40,7 +40,7 @@ class AppModule extends AbstractModule {
     bind(classOf[HelpdeskService]).to(classOf[EhriHelpdesk])
     bind(classOf[IdGenerator]).to(classOf[CypherIdGenerator])
     bind(classOf[OAuth2Flow]).to(classOf[WebOAuth2Flow])
-    bind(classOf[MovedPageLookup]).to(classOf[DbMovedPageLookup])
+    bind(classOf[MovedPageLookup]).to(classOf[SqlMovedPageLookup])
     bind(classOf[FileStorage]).to(classOf[S3FileStorage])
     bind(classOf[HtmlPages]).to(classOf[GoogleDocsHtmlPages])
     bind(classOf[GuideService]).to(classOf[SqlGuideService])

--- a/conf/evolutions/postgres/1.sql
+++ b/conf/evolutions/postgres/1.sql
@@ -1,4 +1,4 @@
- --- !Ups
+ #--- !Ups
 
 CREATE TABLE users (
     id          VARCHAR(50) NOT NULL PRIMARY KEY,

--- a/modules/admin/app/views/admin/movedItemsForm.scala.html
+++ b/modules/admin/app/views/admin/movedItemsForm.scala.html
@@ -13,9 +13,9 @@
         </div>
 
         <div class="form-group">
-            <label class="control-label" for="id_csv">Select the user CSV file...</label>
+            <label class="control-label" for="id_tsv">Select the user TSV file...</label>
             <div class="control-elements">
-                <input class="form-control" type="file" name="csv" id="id_csv" />
+                <input class="form-control" type="file" name="tsv" id="id_tsv" />
             </div>
         </div>
         <div class="form-group">

--- a/test/helpers/FakeMultipartUpload.scala
+++ b/test/helpers/FakeMultipartUpload.scala
@@ -47,9 +47,10 @@ trait FakeMultipartUpload {
   }
 
   /** shortcut for generating a MultipartFormData with one file part which more fields can be added to */
-  def fileUpload(key: String, file: File, contentType: String): MultipartFormData[TemporaryFile] = {
+  def fileUpload(key: String, file: File, contentType: String, data: Map[String, Seq[String]] = Map.empty):
+  MultipartFormData[TemporaryFile] = {
     MultipartFormData(
-      dataParts = Map(),
+      dataParts = data,
       files = Seq(FilePart[TemporaryFile](key, file.getName, Some(contentType), TemporaryFile(file))),
       badParts = Seq()
     )
@@ -57,8 +58,9 @@ trait FakeMultipartUpload {
 
   /** shortcut for a request body containing a single file attachment */
   case class WrappedFakeRequest[A](fr: FakeRequest[A]) {
-    def withFileUpload(key: String, file: File, contentType: String) = {
-      fr.withMultipartFormDataBody(fileUpload(key, file, contentType)).withHeaders(
+    def withFileUpload(key: String, file: File, contentType: String, data: Map[String, Seq[String]] = Map.empty) = {
+      val mfd = fileUpload(key, file, contentType, data)
+      fr.withMultipartFormDataBody(mfd).withHeaders(
         HeaderNames.CONTENT_TYPE -> s"multipart/form-data; boundary=$boundary"
       )
     }

--- a/test/integration/admin/UtilsSpec.scala
+++ b/test/integration/admin/UtilsSpec.scala
@@ -1,12 +1,16 @@
 package integration.admin
 
+import java.io.File
+
 import helpers._
+import mockdata._
+import org.apache.commons.io.FileUtils
 import play.api.test.FakeRequest
 
 /**
  * Spec to test various page views operate as expected.
  */
-class UtilsSpec extends IntegrationTestRunner {
+class UtilsSpec extends IntegrationTestRunner with FakeMultipartUpload {
 
   "Utils" should {
     "return a successful ping of the EHRI REST service" in new ITestApp {
@@ -21,6 +25,31 @@ class UtilsSpec extends IntegrationTestRunner {
       // graph DB fixtures, so the sync check should (correcly)
       // highlight this.
       contentAsString(check) must contain("joeblogs")
+    }
+
+    "allow uploading moved items" in new ITestApp {
+
+      val f = File.createTempFile("/upload", ".csv")
+      f.deleteOnExit()
+      FileUtils.writeStringToFile(f, "ιταλία\tc1\nfoo\tc4", "UTF-8")
+
+      val result = FakeRequest(controllers.admin.routes.Utils.addMovedItemsPost())
+        .withFileUpload("tsv", f, "text/tsv", Map("path-prefix" -> Seq("/units/")))
+        .withUser(privilegedUser)
+        .withCsrf
+        .call()
+      status(result) must_== OK
+
+      // We've added two items...
+      val redirects = movedPages.toList.takeRight(2)
+      redirects.headOption must beSome.which { case (from, to) =>
+        from must_== "/units/" + java.net.URLEncoder.encode("ιταλία", "UTF-8")
+        to must_== "/units/c1"
+      }
+      redirects.lastOption must beSome.which { case (from, to) =>
+        from must_== "/units/foo"
+        to must_== "/units/c4"
+      }
     }
   }
 }


### PR DESCRIPTION
Page URL is now properly encoded in DB, as it is received in the request. When uploading moved items, encoding is now done before insert. Added a test.

Additional changes:

 - fixed an issue with the Postgres evolution
 - renamed the SQL moved page implementation
 - allow file upload tester to have additional form data

Fixes #804.