### PR TITLE
Lookup emails case-insensitively.

### DIFF
--- a/modules/core/app/auth/sql/SqlAccountManager.scala
+++ b/modules/core/app/auth/sql/SqlAccountManager.scala
@@ -176,7 +176,8 @@ case class SqlAccountManager @Inject()(implicit db: Database, actorSystem: Actor
 
 
   private def getByEmail(email: String)(implicit conn: Connection): Option[Account] =
-    SQL"SELECT * FROM users WHERE users.email = $email".as(userParser.singleOpt)
+    // NB: this query would be better if it used the index (or a computed index)
+    SQL"SELECT * FROM users WHERE lower(users.email) = lower($email)".as(userParser.singleOpt)
 
   private def getById(id: String)(implicit conn: Connection): Option[Account] =
     SQL"SELECT * FROM users WHERE users.id = $id".as(userParser.singleOpt)

--- a/test/auth/MockAccountManager.scala
+++ b/test/auth/MockAccountManager.scala
@@ -68,10 +68,10 @@ case class MockAccountManager @Inject()() extends AccountManager {
     immediate(mockdata.accountFixtures.get(id))
 
   override def findByEmail(email: String): Future[Option[Account]] =
-    immediate(mockdata.accountFixtures.values.find(_.email == email))
+    immediate(mockdata.accountFixtures.values.find(_.email.toLowerCase == email.toLowerCase))
 
   override def findAllById(ids: Seq[String]): Future[Seq[Account]] =
-    immediate(mockdata.accountFixtures.filterKeys(id => ids.contains(id)).map(_._2).toSeq)
+    immediate(mockdata.accountFixtures.filterKeys(id => ids.contains(id)).values.toSeq)
 
   override def authenticateById(id: String, pw: String, verifiedOnly: Boolean = false): Future[Option[Account]] = immediate {
     for {
@@ -83,7 +83,7 @@ case class MockAccountManager @Inject()() extends AccountManager {
 
   override def authenticateByEmail(email: String, pw: String, verifiedOnly: Boolean = false): Future[Option[Account]] = immediate {
     for {
-      acc <- mockdata.accountFixtures.values.find(_.email == email)
+      acc <- mockdata.accountFixtures.values.find(_.email.toLowerCase() == email.toLowerCase)
       hashed <- acc.password
       if hashed.check(pw) && (if(verifiedOnly) acc.verified else true)
     } yield acc

--- a/test/auth/SqlAccountManagerSpec.scala
+++ b/test/auth/SqlAccountManagerSpec.scala
@@ -100,10 +100,15 @@ class SqlAccountManagerSpec extends PlaySpecification {
       await(accounts.findAll(PageParams(limit = 2))).size must equalTo(2)
     }
 
-    "find accounts by id and email" in withFixtures { implicit db =>
+    "find accounts by id" in withFixtures { implicit db =>
       db.withConnection { implicit connection =>
         await(accounts.findById(mockdata.privilegedUser.id)) must beSome
-        await(accounts.findByEmail(mockdata.privilegedUser.email)) must beSome
+      }
+    }
+
+    "find accounts by email, case insensitively" in withFixtures { implicit db =>
+      db.withConnection { implicit connection =>
+        await(accounts.findByEmail(mockdata.privilegedUser.email.toUpperCase())) must beSome
       }
     }
 

--- a/test/integration/portal/AccountsSpec.scala
+++ b/test/integration/portal/AccountsSpec.scala
@@ -33,7 +33,9 @@ class AccountsSpec extends IntegrationTestRunner {
       )
     ) {
       val data: Map[String, Seq[String]] = Map(
-        SignupData.EMAIL -> Seq(privilegedUser.email),
+        // NB: Using toUpperCase here to test case insentitivity
+        // on email login (bug #816)
+        SignupData.EMAIL -> Seq(privilegedUser.email.toUpperCase),
         SignupData.PASSWORD -> Seq(testPassword),
         TIMESTAMP -> Seq(org.joda.time.DateTime.now.toString),
         BLANK_CHECK -> Seq(""),


### PR DESCRIPTION
Previously this relied on MySQL behaviour to work as expected.

Fixes #816.