### PR TITLE
Catch and rethrow backend/search errors with wrapped exceptions.

### DIFF
--- a/app/ErrorHandler.scala
+++ b/app/ErrorHandler.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 import scala.concurrent.Future.{successful => immediate}
 
 import controllers.renderError
-import views.html.errors.{permissionDenied, itemNotFound, serverTimeout, fatalError, pageNotFound, genericError}
+import views.html.errors._
 
 class ErrorHandler @Inject() (
   env: Environment,
@@ -64,7 +64,9 @@ with SessionPreferences[SessionPrefs] {
         renderError("errors.permissionDenied", permissionDenied(Some(e)))))
       case e: ItemNotFound => immediate(NotFound(
         renderError("errors.itemNotFound", itemNotFound(e.value))))
-      case e: java.net.ConnectException => immediate(InternalServerError(
+      case e: utils.search.SearchEngineOffline => immediate(InternalServerError(
+        renderError("errors.searchEngineError", searchEngineError())))
+      case e: backend.rest.BackendOffline => immediate(InternalServerError(
         renderError("errors.databaseError", serverTimeout())))
       case e: BadJson => sys.error(e.getMessageWithContext(request))
 

--- a/modules/backend/src/main/scala/backend/ServiceException.scala
+++ b/modules/backend/src/main/scala/backend/ServiceException.scala
@@ -1,0 +1,12 @@
+package backend
+
+import java.io.IOException
+
+/**
+  * Indicates that there was an error attempting to communicate with
+  * a service.
+  *
+  * @param msg   a custom message
+  * @param cause the underlying cause
+  */
+abstract class ServiceException(msg: String, cause: Throwable) extends IOException(msg, cause)

--- a/modules/backend/src/main/scala/backend/rest/BackendOffline.scala
+++ b/modules/backend/src/main/scala/backend/rest/BackendOffline.scala
@@ -1,0 +1,5 @@
+package backend.rest
+
+import backend.ServiceException
+
+case class BackendOffline(msg: String, cause: Throwable) extends ServiceException(msg, cause)

--- a/modules/core/app/utils/search/SearchEngineOffline.scala
+++ b/modules/core/app/utils/search/SearchEngineOffline.scala
@@ -1,0 +1,13 @@
+package utils.search
+
+import java.io.IOException
+
+import backend.ServiceException
+
+/**
+  * Indicates that we could not reach the search engine.
+  *
+  * @param msg a message
+  * @param cause the underlying cause
+  */
+case class SearchEngineOffline(msg: String, cause: Throwable) extends ServiceException(msg, cause)

--- a/modules/core/app/utils/search/package.scala
+++ b/modules/core/app/utils/search/package.scala
@@ -1,5 +1,7 @@
 package utils
 
+import java.io.IOException
+
 import defines.EnumUtils
 
 package object search {

--- a/modules/portal/app/controllers/portal/PortalData.scala
+++ b/modules/portal/app/controllers/portal/PortalData.scala
@@ -1,10 +1,12 @@
 package controllers.portal
 
+import java.time.ZonedDateTime
 import javax.inject.{Inject, Singleton}
-import play.api.cache.{Cached, CacheApi}
-import play.api.http.{ContentTypes, MimeTypes}
+
+import play.api.cache.{CacheApi, Cached}
+import play.api.http.{ContentTypes, HeaderNames, MimeTypes}
 import play.api.i18n.MessagesApi
-import play.api.mvc.{Controller, Action}
+import play.api.mvc.{Action, Controller}
 
 
 
@@ -56,6 +58,7 @@ case class PortalData @Inject()(
           controllers.portal.routes.javascript.Portal.externalFeed
         )
       ).as(MimeTypes.JAVASCRIPT)
+        .withHeaders(HeaderNames.EXPIRES -> "arse")
     }
   }
 

--- a/modules/portal/app/views/errors/searchEngineError.scala.html
+++ b/modules/portal/app/views/errors/searchEngineError.scala.html
@@ -1,0 +1,7 @@
+@(maintenance: Boolean = false)(implicit req: RequestHeader, messages: Messages)
+
+@if(maintenance) {
+    <p class="alert alert-info">@Messages("errors.databaseMaintenance.explanation")</p>
+} else {
+    <p class="alert alert-error">@Messages("errors.searchEngineError.explanation")</p>
+}

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -78,6 +78,9 @@ errors.maintenance.explanation=The EHRI Portal is currently offline while we und
 errors.databaseError=Database Error
 errors.databaseError.explanation=I''m afraid it looks like our database server has gone down.     \
   There''s not much we can do without it, so please try again later.
+errors.searchEngineError=Search Error
+errors.searchEngineError.explanation=I''m afraid it looks like our search engine has gone down.     \
+  There''s not much we can do without it, so please try again later.
 errors.databaseMaintenance=Database Temporarily Offline
 errors.databaseMaintenance.explanation=The EHRI database is currently offline for routine maintenance. \
   It should be back soon so please try again shortly.

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
@@ -1,5 +1,6 @@
 package eu.ehri.project.search.solr
 
+import java.net.ConnectException
 import javax.inject.Inject
 
 import defines.EntityType
@@ -8,10 +9,11 @@ import models.UserProfile
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.{Configuration, Logger}
 import utils.Page
+
 import scala.concurrent.Future
 import utils.search._
 import utils.search.SearchHit
-import play.api.http.{MimeTypes, HeaderNames}
+import play.api.http.{HeaderNames, MimeTypes}
 
 
 /**
@@ -48,6 +50,9 @@ case class SolrSearchConfig(
     ws.url(solrSelectUrl)
       .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.FORM)
       .post(query)
+      .recover {
+        case e: ConnectException => throw SearchEngineOffline(solrSelectUrl, e)
+      }
   }
 
   /**

--- a/test/integration/portal/PortalSpec.scala
+++ b/test/integration/portal/PortalSpec.scala
@@ -141,7 +141,7 @@ class PortalSpec extends IntegrationTestRunner {
     "fetch external pages" in new ITestApp {
       val faq = FakeRequest(portalRoutes.externalPage("faq")).call()
       status(faq) must equalTo(OK)
-      contentAsString(faq) must contain(mockdata.externalPages.get("faq").get.toString())
+      contentAsString(faq) must contain(mockdata.externalPages("faq").toString())
     }
 
     "return 404 for external pages with a malformed id (bug #635)" in new ITestApp {


### PR DESCRIPTION
This allows us to provide better error messages, no longer conflating the cause when the DB or the search engine is down.

Some additional tweaks to test code to make some vals protected.