### PR TITLE
Fix spellcheck by adapting the Solr response parser for Solr 6.

### DIFF
--- a/app/AppModule.scala
+++ b/app/AppModule.scala
@@ -12,7 +12,7 @@ import backend.sql.{SqlCypherQueryService, SqlFeedbackService}
 import com.google.inject.AbstractModule
 import eu.ehri.project.indexing.index.Index
 import eu.ehri.project.indexing.index.impl.SolrIndex
-import eu.ehri.project.search.solr.{JsonResponseHandler, ResponseHandler, SolrSearchEngine}
+import eu.ehri.project.search.solr.{SolrJsonResponseHandler, ResponseHandler, SolrSearchEngine}
 import global.{AppGlobalConfig, GlobalConfig, GlobalEventHandler}
 import indexing.SearchToolsIndexMediator
 import models.{GuideService, SqlGuideService}
@@ -29,7 +29,7 @@ class AppModule extends AbstractModule {
     bind(classOf[AccountManager]).to(classOf[auth.sql.SqlAccountManager])
     bind(classOf[GlobalConfig]).to(classOf[AppGlobalConfig])
     bind(classOf[Index]).toProvider(classOf[SolrIndexProvider])
-    bind(classOf[ResponseHandler]).to(classOf[JsonResponseHandler])
+    bind(classOf[ResponseHandler]).to(classOf[SolrJsonResponseHandler])
     bind(classOf[SearchIndexMediator]).to(classOf[SearchToolsIndexMediator])
     bind(classOf[SearchEngine]).to(classOf[SolrSearchEngine])
     bind(classOf[SearchItemResolver]).to(classOf[GidSearchResolver])

--- a/modules/solr/src/test/resources/solrQueryResponse1.json
+++ b/modules/solr/src/test/resources/solrQueryResponse1.json
@@ -129,7 +129,9 @@
       "purpusly",
       {
         "numFound": 1,
-        "suggestions": [
+        "startOffset": 0,
+        "endOffset": 8,
+        "suggestion": [
           {
             "word": "purposely",
             "freq": 1
@@ -139,15 +141,18 @@
       "mispeled",
       {
         "numFound": 1,
-        "suggestions": [
+        "startOffset": 9,
+        "endOffset": 18,
+        "suggestion": [
           {
             "word": "mispelled",
             "freq": 1
           }
         ]
-      },
-      "correctlySpelled",
-      false,
+      }
+    ],
+    "correctlySpelled": false,
+    "collations": [
       "collation",
       "purposely mispelled"
     ]

--- a/modules/solr/src/test/scala/eu/ehri/project/search/solr/SolrQueryParserSpec.scala
+++ b/modules/solr/src/test/scala/eu/ehri/project/search/solr/SolrQueryParserSpec.scala
@@ -12,7 +12,7 @@ class SolrQueryParserSpec extends PlaySpecification with ResourceUtils {
   private def jsonResponseString: String = resourceAsString("solrQueryResponse1.json")
 
   "Solr JSON Query Parser" should {
-    val jsonHandler = JsonResponseHandler(app)
+    val jsonHandler = SolrJsonResponseHandler(app)
     "parse the correct number of docs with the right IDs" in {
       val qp = jsonHandler.getResponseParser(jsonResponseString)
       val docs = qp.items
@@ -55,7 +55,7 @@ class SolrQueryParserSpec extends PlaySpecification with ResourceUtils {
       }
 
       val doc1 = qp.items.head
-      doc1.highlights.get("place_t").get must equalTo(Seq("Active in the Netherlands, <em>Amsterdam</em>."))
+      doc1.highlights("place_t") must equalTo(Seq("Active in the Netherlands, <em>Amsterdam</em>."))
     }
 
     "parse collated spellcheck data correctly" in {


### PR DESCRIPTION
Also: rename the Solr JSON response parser.

Fixes #821.