### PR TITLE
Better monitoring of search.

### DIFF
--- a/modules/admin/conf/admin.routes
+++ b/modules/admin/conf/admin.routes
@@ -34,7 +34,7 @@ GET         /movedItems                         @controllers.admin.Utils.addMove
 POST        /movedItems                         @controllers.admin.Utils.addMovedItemsPost
 
 # Monitoring
-GET         /monitor/_check                     @controllers.admin.Utils.checkDb
+GET         /monitor/_check                     @controllers.admin.Utils.checkServices
 GET         /monitor/_checkUserSync             @controllers.admin.Utils.checkUserSync
 
 # API

--- a/modules/backend/src/main/scala/backend/DataApi.scala
+++ b/modules/backend/src/main/scala/backend/DataApi.scala
@@ -44,6 +44,13 @@ trait DataApiHandle {
   def withEventHandler(eventHandler: EventHandler): DataApiHandle
 
   /**
+    * Get a service status
+    *
+    * @return a status message
+    */
+  def status(): Future[String]
+
+  /**
    * Pass a query directly through to the backend API.
    *
    * @param urlPart the URL backend path

--- a/modules/core/app/utils/search/SearchEngine.scala
+++ b/modules/core/app/utils/search/SearchEngine.scala
@@ -103,10 +103,21 @@ trait SearchEngineConfig {
    */
   def setMode(mode: SearchMode.Value): SearchEngineConfig
 
-
+  /**
+    * Run a quick filter
+    */
   def filter()(implicit userOpt: Option[UserProfile]): Future[SearchResult[FilterHit]]
 
+  /**
+    * Run a full search
+    */
   def search()(implicit userOpt: Option[UserProfile]): Future[SearchResult[SearchHit]]
+
+  /**
+    * Check service status
+    * @return a status message
+    */
+  def status(): Future[String]
 }
 
 trait SearchEngine {

--- a/test/integration/admin/UtilsSpec.scala
+++ b/test/integration/admin/UtilsSpec.scala
@@ -13,9 +13,10 @@ import play.api.test.FakeRequest
 class UtilsSpec extends IntegrationTestRunner with FakeMultipartUpload {
 
   "Utils" should {
-    "return a successful ping of the EHRI REST service" in new ITestApp {
-      val ping = FakeRequest(controllers.admin.routes.Utils.checkDb()).call()
+    "return a successful ping of the EHRI REST service and search engine" in new ITestApp {
+      val ping = FakeRequest(controllers.admin.routes.Utils.checkServices()).call()
       status(ping) must equalTo(OK)
+      contentAsString(ping) must_== "ehri\tok\nsolr\tok"
     }
 
     "check user sync correctly" in new ITestApp {

--- a/test/utils/search/MockSearchEngineConfig.scala
+++ b/test/utils/search/MockSearchEngineConfig.scala
@@ -106,6 +106,8 @@ case class MockSearchEngineConfig(
     }
   }
 
+  override def status() = Future.successful("ok")
+
   override def withIdFilters(ids: Seq[String]): SearchEngineConfig = copy(idFilters = idFilters ++ ids)
 
   override def withFacets(f: Seq[AppliedFacet]): SearchEngineConfig = copy(facets = facets ++ f)


### PR DESCRIPTION
Add status() methods to data and search services and monitor both in the monitoring URI. This should alert us when Solr is down.