### PR TITLE
Add relationship metadata on access points, unknown rels, and maint events

### DIFF
--- a/modules/core/app/models/ConceptDescription.scala
+++ b/modules/core/app/models/ConceptDescription.scala
@@ -9,7 +9,7 @@ import play.api.data.Form
 import play.api.data.Forms._
 import utils.forms._
 import backend.{Entity, Writable}
-
+import eu.ehri.project.definitions.Ontology
 import models.base.Description._
 
 
@@ -55,8 +55,11 @@ case class ConceptDescriptionF(
   latitude: Option[BigDecimal] = None,
   url: Option[String] = None,
   creationProcess: Description.CreationProcess.Value = Description.CreationProcess.Manual,
+  @models.relation(Ontology.HAS_ACCESS_POINT)
   accessPoints: Seq[AccessPointF] = Nil,
+  @models.relation(Ontology.HAS_MAINTENANCE_EVENT)
   maintenanceEvents: Seq[MaintenanceEventF] = Nil,
+  @models.relation(Ontology.HAS_UNKNOWN_PROPERTY)
   unknownProperties: Seq[Entity] = Nil
 ) extends Model with Persistable with Description {
 

--- a/modules/core/app/models/DocumentaryUnitDescription.scala
+++ b/modules/core/app/models/DocumentaryUnitDescription.scala
@@ -144,8 +144,11 @@ case class DocumentaryUnitDescriptionF(
   notes: Option[Seq[String]] = None,
   control: IsadGControl = IsadGControl(),
   creationProcess: CreationProcess.Value = CreationProcess.Manual,
+  @models.relation(Ontology.HAS_ACCESS_POINT)
   accessPoints: Seq[AccessPointF] = Nil,
+  @models.relation(Ontology.HAS_MAINTENANCE_EVENT)
   maintenanceEvents: Seq[MaintenanceEventF] = Nil,
+  @models.relation(Ontology.HAS_UNKNOWN_PROPERTY)
   unknownProperties: Seq[Entity] = Nil
 ) extends Model with Persistable with Description with Temporal {
   import models.IsadG._

--- a/modules/core/app/models/HistoricalAgentDescription.scala
+++ b/modules/core/app/models/HistoricalAgentDescription.scala
@@ -96,14 +96,16 @@ case class HistoricalAgentDescriptionF(
   name: String,
   otherFormsOfName: Option[Seq[String]] = None,
   parallelFormsOfName: Option[Seq[String]] = None,
-
   @models.relation(Ontology.ENTITY_HAS_DATE)
   dates: Seq[DatePeriodF] = Nil,
   details: IsaarDetail,
   control: IsaarControl,
   creationProcess: CreationProcess.Value = CreationProcess.Manual,
-  accessPoints: Seq[AccessPointF],
+  @models.relation(Ontology.HAS_ACCESS_POINT)
+  accessPoints: Seq[AccessPointF] = Nil,
+  @models.relation(Ontology.HAS_MAINTENANCE_EVENT)
   maintenanceEvents: Seq[MaintenanceEventF] = Nil,
+  @models.relation(Ontology.HAS_UNKNOWN_PROPERTY)
   unknownProperties: Seq[Entity] = Nil
 ) extends Model
   with Persistable

--- a/modules/core/app/models/RepositoryDescription.scala
+++ b/modules/core/app/models/RepositoryDescription.scala
@@ -113,14 +113,18 @@ case class RepositoryDescriptionF(
   name: String,
   otherFormsOfName: Option[Seq[String]] = None,
   parallelFormsOfName: Option[Seq[String]] = None,
-  @models.relation(Ontology.ENTITY_HAS_ADDRESS) addresses: Seq[AddressF] = Nil,
+  @models.relation(Ontology.ENTITY_HAS_ADDRESS)
+  addresses: Seq[AddressF] = Nil,
   details: IsdiahDetails,
   access: IsdiahAccess,
   services: IsdiahServices,
   control: IsdiahControl,
   creationProcess: CreationProcess.Value = CreationProcess.Manual,
+  @models.relation(Ontology.HAS_ACCESS_POINT)
   accessPoints: Seq[AccessPointF] = Nil,
+  @models.relation(Ontology.HAS_MAINTENANCE_EVENT)
   maintenanceEvents: Seq[MaintenanceEventF] = Nil,
+  @models.relation(Ontology.HAS_UNKNOWN_PROPERTY)
   unknownProperties: Seq[Entity] = Nil
 ) extends Model with Persistable with Description {
 

--- a/modules/core/app/models/base/Persistable.scala
+++ b/modules/core/app/models/base/Persistable.scala
@@ -105,9 +105,9 @@ object Persistable {
     }
 
     // And then the nested relationship errors
-    errorSet.relationships.foldLeft(nmap) { (m, kev) =>
-      val (rel, errorSets) = kev
-      val attrName = relmap.getOrElse(rel, sys.error(s"Unknown error map relationship for $this: $rel ($relmap)"))
+    errorSet.relationships.foldLeft(nmap) { case (m, (rel, errorSets)) =>
+      val attrName = relmap.getOrElse(rel, sys.error(
+        s"Unknown error map relationship for: $rel ($relmap)"))
       errorSets.zipWithIndex.foldLeft(m) { case (mm, (e1, e2)) => e1 match {
           case Some(es) => unfurlErrors(es, relmap, mm, Some(newpath), Some(attrName), Some(e2))
           case None => mm

--- a/test/integration/admin/EntityViewsSpec.scala
+++ b/test/integration/admin/EntityViewsSpec.scala
@@ -118,7 +118,7 @@ class EntityViewsSpec extends IntegrationTestRunner {
         "descriptions[0].languageCode" -> Seq("eng"),
         "descriptions[0].name" -> Seq("An Authority"),
         "descriptions[0].maintenanceEvents[0].source" -> Seq("Test Event"),
-        "descriptions[0].maintenanceEvents[0].eventType" -> Seq("CREATED"),
+        "descriptions[0].maintenanceEvents[0].eventType" -> Seq("created"),
         "descriptions[0].maintenanceEvents[0].order" -> Seq("0")
       )
       val cr = FakeRequest(histAgentRoutes.updatePost("a1"))
@@ -128,7 +128,7 @@ class EntityViewsSpec extends IntegrationTestRunner {
       val a1 = await(dataApi.get[HistoricalAgent]("a1"))
       a1.descriptions.flatMap(_.maintenanceEvents).headOption must beSome.which { me =>
         me.source must_== Some("Test Event")
-        me.eventType must_== Some("CREATED")
+        me.eventType must_== Some("created")
         me.order must_== Some(0)
       }
 


### PR DESCRIPTION
This fixes an error when those types have validation issues.