### PR TITLE
Start migrating from Joda Time to java.time API.

### DIFF
--- a/modules/admin/app/controllers/cypher/CypherQueries.scala
+++ b/modules/admin/app/controllers/cypher/CypherQueries.scala
@@ -18,6 +18,7 @@ import utils.PageParams
 import views.MarkdownRenderer
 import scala.concurrent.Future.{successful => immediate}
 
+
 @Singleton
 case class CypherQueries @Inject()(
   implicit config: play.api.Configuration,

--- a/modules/admin/app/controllers/users/UserProfiles.scala
+++ b/modules/admin/app/controllers/users/UserProfiles.scala
@@ -1,26 +1,31 @@
 package controllers.users
 
-import auth.{HashedPassword, AccountManager}
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+import auth.{AccountManager, HashedPassword}
 import controllers.core.auth.AccountHelpers
-import org.joda.time.DateTime
 import play.api.cache.CacheApi
 import play.api.http.HeaderNames
 import play.api.libs.concurrent.Execution.Implicits._
 import controllers.generic._
 import models._
-import play.api.i18n.{MessagesApi, Messages}
-import defines.{EntityType, PermissionType, ContentTypes}
-import utils.{CsvHelpers, PageParams, MovedPageLookup}
+import play.api.i18n.{Messages, MessagesApi}
+import defines.{ContentTypes, EntityType, PermissionType}
+import utils.{CsvHelpers, MovedPageLookup, PageParams}
 import utils.search._
 import javax.inject._
+
 import backend.DataApi
-import play.api.data.{FormError, Forms, Form}
+import play.api.data.{Form, FormError, Forms}
 import views.MarkdownRenderer
+
 import scala.concurrent.Future.{successful => immediate}
 import play.api.libs.json.Json
+
 import scala.concurrent.Future
 import play.api.mvc.Request
-import backend.rest.{ValidationError, DataHelpers}
+import backend.rest.{DataHelpers, ValidationError}
 import play.api.mvc.Result
 import play.api.libs.json.JsObject
 import controllers.base.AdminController
@@ -212,7 +217,8 @@ case class UserProfiles @Inject()(
       accounts <- accounts.findAll(PageParams.empty.withoutLimit)
       users <- userDataApi.list[UserProfile](PageParams.empty.withoutLimit)
     } yield {
-      val exportDate = DateTime.now().toString("YMMdd")
+      val datePattern: DateTimeFormatter = DateTimeFormatter.ofPattern("YMMdd")
+      val exportDate = ZonedDateTime.now().format(datePattern)
       val headers = Seq(
         "name", "email", "location", "url", "institution", "role", "about", "interests", "created"
       )
@@ -229,7 +235,7 @@ case class UserProfiles @Inject()(
           user.model.role.getOrElse(""),
           user.model.about.getOrElse(""),
           user.model.interests.getOrElse(""),
-          account.created.map(_.toString("YMMdd")).getOrElse("")
+          account.created.map(_.format(datePattern)).getOrElse("")
         )
       }
       Ok(writeCsv(headers, data))

--- a/modules/backend/src/main/scala/backend/rest/cypher/Cypher.scala
+++ b/modules/backend/src/main/scala/backend/rest/cypher/Cypher.scala
@@ -1,8 +1,7 @@
 package backend.rest.cypher
 
-import play.api.libs.iteratee.Enumerator
 import play.api.libs.json.{Reads, JsValue}
-import play.api.libs.ws.{StreamedResponse, WSResponseHeaders, WSResponse}
+import play.api.libs.ws.StreamedResponse
 
 import scala.concurrent.Future
 

--- a/modules/backend/src/main/scala/utils/params.scala
+++ b/modules/backend/src/main/scala/utils/params.scala
@@ -1,12 +1,13 @@
 package utils
 
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 import play.api.mvc.RequestHeader
 import play.api.data.Form
 import play.api.data.Forms._
 import backend.rest.Constants._
-import defines.{EnumUtils, EntityType, EventType}
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
+import defines.{EntityType, EventType}
 import utils.SystemEventParams.{Aggregation, ShowType}
 
 object Ranged {
@@ -73,8 +74,8 @@ case class SystemEventParams(
   users: Seq[String] = Nil,
   eventTypes: Seq[EventType.Value] = Nil,
   itemTypes: Seq[EntityType.Value] = Nil,
-  from: Option[DateTime] = None,
-  to: Option[DateTime] = None,
+  from: Option[LocalDateTime] = None,
+  to: Option[LocalDateTime] = None,
   show: Option[ShowType.Value] = None,
   aggregation: Option[Aggregation.Value] = None) {
   import utils.SystemEventParams._
@@ -83,8 +84,8 @@ case class SystemEventParams(
     .filterNot(_.isEmpty).map(u => USERS -> u) ++
       eventTypes.map(et => EVENT_TYPE -> et.toString) ++
       itemTypes.map(et => ITEM_TYPE -> et.toString) ++
-      from.map(f => FROM -> fmt.print(f)).toSeq ++
-      to.map(t => TO -> fmt.print(t)).toSeq ++
+      from.map(f => FROM -> fmt.format(f)).toSeq ++
+      to.map(t => TO -> fmt.format(t)).toSeq ++
       show.map(f => SHOW -> f.toString).toSeq ++
       aggregation.map(f => AGGREGATION -> f.toString)
 }
@@ -92,7 +93,7 @@ case class SystemEventParams(
 object SystemEventParams {
 
   import defines.EnumUtils.enumMapping
-  private val fmt = ISODateTimeFormat.dateTime
+  private val fmt = DateTimeFormatter.ISO_LOCAL_DATE_TIME
 
   def empty: SystemEventParams = new SystemEventParams()
 
@@ -117,8 +118,8 @@ object SystemEventParams {
       USERS -> seq(text),
       EVENT_TYPE -> seq(enumMapping(EventType)),
       ITEM_TYPE -> seq(enumMapping(EntityType)),
-      FROM -> optional(jodaDate(pattern = DATE_PATTERN)),
-      TO -> optional(jodaDate(pattern = DATE_PATTERN)),
+      FROM -> optional(localDateTime(pattern = DATE_PATTERN)),
+      TO -> optional(localDateTime(pattern = DATE_PATTERN)),
       SHOW -> optional(enumMapping(ShowType)),
       AGGREGATION -> optional(enumMapping(Aggregation))
     )(SystemEventParams.apply)(SystemEventParams.unapply)

--- a/modules/core/app/defines/binders/package.scala
+++ b/modules/core/app/defines/binders/package.scala
@@ -1,43 +1,47 @@
 package defines
 
-import org.joda.time.DateTime
-import org.joda.time.format.{ISODateTimeFormat, DateTimeFormatter}
+import java.time.format.{DateTimeFormatter, DateTimeParseException}
+import java.time.{LocalDate, LocalDateTime, YearMonth}
+
 import play.api.mvc.QueryStringBindable
 
 /**
- * The implicit values in this package allow the Play routes
- * to bind/unbind enumeration values, without those enums having
- * to be specifically aware of Play functionality.
- *
- * These values are imported into the generated routes files by
- * the build.
- */
+  * The implicit values in this package allow the Play routes
+  * to bind/unbind enumeration values, without those enums having
+  * to be specifically aware of Play functionality.
+  *
+  * These values are imported into the generated routes files by
+  * the build.
+  */
 package object binders {
   implicit val entityTypeBinder = EnumerationBinders.bindableEnum(EntityType)
   implicit val entityTypeQueryBinder = EnumerationBinders.queryStringBinder(EntityType)
 
-  private val fullDateTimeFmt: DateTimeFormatter = ISODateTimeFormat.dateTime()
-  private val partialDateTimeFmt: DateTimeFormatter = ISODateTimeFormat.date()
+  private val fullDateTimeFmt: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
 
   implicit def dateTimeQueryBinder(implicit stringBinder: QueryStringBindable[String]) =
-    new QueryStringBindable[DateTime] {
-      def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, DateTime]] = {
+    new QueryStringBindable[LocalDateTime] {
+      def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, LocalDateTime]] = {
         stringBinder.bind(key, params).collect {
           case Right(ds) if !ds.trim.isEmpty => try {
-            Right(fullDateTimeFmt.parseDateTime(ds))
+            Right(LocalDateTime.parse(ds))
           } catch {
-            case e: IllegalArgumentException => try {
-              Right(partialDateTimeFmt.parseDateTime(ds))
+            case e: DateTimeParseException => try {
+              Right(LocalDate.parse(ds).atStartOfDay())
             } catch {
-              case e: IllegalArgumentException =>
-                Left(s"Invalid date format: $ds")
+              case e: DateTimeParseException => try {
+                Right(YearMonth.parse(ds).atDay(1).atStartOfDay())
+              } catch {
+                case e: DateTimeParseException =>
+                  Left(s"Invalid date format: $ds")
+              }
             }
           }
         }
       }
 
-      def unbind(key: String, value: DateTime): String = {
-        stringBinder.unbind(key, fullDateTimeFmt.print(value))
+      def unbind(key: String, value: LocalDateTime): String = {
+        stringBinder.unbind(key, fullDateTimeFmt.format(value))
       }
     }
 }

--- a/modules/core/app/models/Account.scala
+++ b/modules/core/app/models/Account.scala
@@ -1,7 +1,7 @@
 package models
 
+import java.time.ZonedDateTime
 import auth.HashedPassword
-import org.joda.time.DateTime
 
 case class Account(
   id: String,
@@ -10,8 +10,8 @@ case class Account(
   staff: Boolean = false,
   active: Boolean = true,
   allowMessaging: Boolean = true,
-  created: Option[DateTime] = None,
-  lastLogin: Option[DateTime] = None,
+  created: Option[ZonedDateTime] = None,
+  lastLogin: Option[ZonedDateTime] = None,
   password: Option[HashedPassword] = None,
   isLegacy: Boolean = false
 ) {

--- a/modules/core/app/models/PermissionGrant.scala
+++ b/modules/core/app/models/PermissionGrant.scala
@@ -1,8 +1,9 @@
 package models
 
-import models.base.{AnyModel, Model, MetaModel, Accessor}
-import org.joda.time.DateTime
-import defines.{PermissionType,EntityType}
+import java.time.ZonedDateTime
+
+import models.base.{Accessor, AnyModel, MetaModel, Model}
+import defines.{EntityType, PermissionType}
 import models.json._
 import play.api.libs.json._
 import play.api.libs.json.JsObject
@@ -24,7 +25,7 @@ object PermissionGrantF {
   implicit val permissionGrantReads: Reads[PermissionGrantF] = (
     (__ \ TYPE).readIfEquals(EntityType.PermissionGrant) and
     (__ \ ID).readNullable[String] and
-    (__ \ DATA \ TIMESTAMP).readNullable[String].map(_.map(new DateTime(_))) and
+    (__ \ DATA \ TIMESTAMP).readNullable[String].map(_.map(ZonedDateTime.parse(_))) and
     (__ \ RELATIONSHIPS \ PERM_REL \\ ID).read[String].map(PermissionType.withName)
   )(PermissionGrantF.apply _)
 
@@ -36,7 +37,7 @@ object PermissionGrantF {
 case class PermissionGrantF(
   isA: EntityType.Value = EntityType.PermissionGrant,
   id: Option[String],
-  timestamp: Option[DateTime],
+  timestamp: Option[ZonedDateTime],
   permission: PermissionType.Value
 ) extends Model
 

--- a/modules/core/app/models/SystemEvent.scala
+++ b/modules/core/app/models/SystemEvent.scala
@@ -1,8 +1,9 @@
 package models
 
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
 import models.base._
-import org.joda.time.DateTime
-import org.joda.time.format.{ISODateTimeFormat, DateTimeFormat}
 import defines.{ContentTypes, EntityType, EventType}
 import models.json._
 import play.api.libs.json._
@@ -26,9 +27,9 @@ object SystemEventF {
     (__ \ ID).formatNullable[String] and
     // NB: Default Joda DateTime format is less flexible then
     // using the constructor from a string
-    (__ \ DATA \ TIMESTAMP).format[String].inmap(
-      s => new DateTime(s),
-      (dt: DateTime) => dt.toString
+    (__ \ DATA \ TIMESTAMP).format[String].inmap[ZonedDateTime](
+      s => ZonedDateTime.parse(s),
+      dt => DateTimeFormatter.ISO_DATE_TIME.format(dt)
     ) and
     (__ \ DATA \ LOG_MESSAGE).formatNullable[String] and
     (__ \ DATA \ EVENT_PROP).formatNullable[EventType.Value]
@@ -42,11 +43,11 @@ object SystemEventF {
 case class SystemEventF(
   isA: EntityType.Value = EntityType.SystemEvent,
   id: Option[String],
-  timestamp: DateTime,
+  timestamp: ZonedDateTime,
   logMessage: Option[String] = None,
   eventType: Option[EventType.Value] = None
 ) extends Model {
-  lazy val datetime = ISODateTimeFormat.dateTime.withZoneUTC.print(timestamp)
+  lazy val datetime = DateTimeFormatter.ISO_DATE_TIME.format(timestamp)
 }
 
 object SystemEvent {
@@ -82,7 +83,7 @@ case class SystemEvent(
   with MetaModel[SystemEventF]
   with Holder[AnyModel] {
 
-  def time = DateTimeFormat.forPattern(SystemEventF.FORMAT).print(model.timestamp)
+  def time = DateTimeFormatter.ISO_INSTANT.format(model.timestamp)
 
   /**
    * If the event is of a certain type (link, annotate) the effective

--- a/modules/core/app/utils/forms/TimeCheckForm.scala
+++ b/modules/core/app/utils/forms/TimeCheckForm.scala
@@ -1,7 +1,9 @@
 package utils.forms
 
+import java.time.format.DateTimeParseException
+
 import play.api.Logger
-import play.api.data.validation.{Invalid, Valid, Constraint}
+import play.api.data.validation.{Constraint, Invalid, Valid}
 
 /**
  * A form with a time-check field, i.e. that should not
@@ -25,18 +27,20 @@ object TimeCheckForm {
    */
   def formSubmissionTime[T <: TimeCheckForm](implicit config: play.api.Configuration): Constraint[T] = {
     Constraint("constraints.timeCheckSeconds") { data =>
-      import org.joda.time.{DateTime, Seconds}
+      import java.time.ZonedDateTime
+      import java.time.temporal.ChronoUnit
+
       config.getInt("ehri.signup.timeCheckSeconds").map { delay =>
         try {
-          val renderTime: DateTime = new DateTime(data.timestamp)
-          val timeDiff: Int = Seconds.secondsBetween(renderTime, DateTime.now()).getSeconds
-          if (timeDiff > delay) Valid
+          val renderTime: ZonedDateTime = ZonedDateTime.parse(data.timestamp)
+          val diff: Long = renderTime.until(ZonedDateTime.now, ChronoUnit.SECONDS)
+          if (diff > delay) Valid
           else {
             logger.error(s"Bad timestamp on signup with delay $delay")
             Invalid("constraints.timeCheckSeconds.failed")
           }
         } catch {
-          case e: IllegalArgumentException => Invalid("constraints.timeCheckSeconds.failed")
+          case e: DateTimeParseException => Invalid("constraints.timeCheckSeconds.failed")
         }
       }.getOrElse(Valid)
     }

--- a/modules/core/app/views/Helpers.scala
+++ b/modules/core/app/views/Helpers.scala
@@ -17,9 +17,12 @@ object Helpers {
     val p = new PrettyTime(messages.lang.toLocale)
     p.format(d)
   }
-  def relativeDate(d: org.joda.time.DateTime)(implicit messages: Messages): String = relativeDate(d.toDate)
-  def relativeDate(d: Option[org.joda.time.DateTime])(implicit messages: Messages): String =
-    d.fold("")(dt => relativeDate(dt.toDate))
+
+  def relativeDate(d: java.time.ZonedDateTime)(implicit messages: Messages): String =
+    relativeDate(java.util.Date.from(d.toInstant))
+
+  def relativeDate(d: Option[java.time.ZonedDateTime])(implicit messages: Messages): String =
+    d.fold("")(d => relativeDate(d))
 
   /**
    * Get the field prefix for an entity type. This is just the entity type

--- a/modules/core/test/defines/BindersSpec.scala
+++ b/modules/core/test/defines/BindersSpec.scala
@@ -1,0 +1,23 @@
+package defines
+
+import java.time.LocalDateTime
+
+import play.api.test.PlaySpecification
+
+class BindersSpec extends PlaySpecification {
+  "Binder" should {
+    val binder = defines.binders.dateTimeQueryBinder
+
+    "allow binding from partial dates in queries" in {
+      binder.bind("date", Map("date" -> Seq("1949-10"))) must_== Some(Right(LocalDateTime.parse("1949-10-01T00:00")))
+      binder.bind("date", Map("date" -> Seq("1949-10-01"))) must_== Some(Right(LocalDateTime.parse("1949-10-01T00:00")))
+      binder.bind("date", Map("date" -> Seq("1949-10-01T10:10:10"))) must_== Some(Right(LocalDateTime.parse("1949-10-01T10:10:10")))
+    }
+
+    "give an error with invalid dates" in {
+      binder.bind("date", Map("date" -> Seq("foo"))) must beSome.which { d =>
+        d must_== Left("Invalid date format: foo")
+      }
+    }
+  }
+}

--- a/modules/core/test/models/DatePeriodSpec.scala
+++ b/modules/core/test/models/DatePeriodSpec.scala
@@ -1,0 +1,26 @@
+package models
+
+import play.api.test.PlaySpecification
+
+class DatePeriodSpec extends PlaySpecification {
+  "DatePeriod validation" should {
+    "accept date, month, and year formats" in {
+      DatePeriod.dateValidator("1944-01-01") must beTrue
+      DatePeriod.dateValidator("1944-01") must beTrue
+      DatePeriod.dateValidator("1944") must beTrue
+
+      DatePeriod.dateValidator("1944-13") must beFalse
+      DatePeriod.dateValidator("1944-") must beFalse
+      DatePeriod.dateValidator("1944-01-32") must beFalse
+      DatePeriod.dateValidator("test") must beFalse
+    }
+  }
+
+  "DatePeriod" should {
+    "correctly render year periods" in {
+      val dp = DatePeriodF(id = None, startDate = Some("1944-01"))
+      dp.years must_== "1944"
+      dp.copy(endDate = Some("1945")).years must_== "1944-1945"
+    }
+  }
+}

--- a/modules/portal/app/backend/sql/SqlCypherQueryService.scala
+++ b/modules/portal/app/backend/sql/SqlCypherQueryService.scala
@@ -1,13 +1,12 @@
 package backend.sql
 
+import java.time.ZonedDateTime
 import javax.inject.{Inject, Singleton}
 
 import akka.actor.ActorSystem
 import backend.CypherQueryService
 import models.CypherQuery
-import org.joda.time.DateTime
 import play.api.db.Database
-import anorm.JodaParameterMetaData._
 import anorm._
 import utils.{Page, PageParams}
 
@@ -68,7 +67,7 @@ case class SqlCypherQueryService @Inject()(
 
   override def create(data: CypherQuery): Future[String] = Future {
     val query = data.copy(objectId = data.objectId.orElse(Some(utils.db.newObjectId(10))),
-      createdAt = data.createdAt.orElse(Some(DateTime.now())))
+      createdAt = data.createdAt.orElse(Some(ZonedDateTime.now())))
     db.withConnection { implicit conn =>
       SQL"""INSERT INTO cypher_queries
         (id, user_id, name, query, description, public, created, updated)

--- a/modules/portal/app/backend/sql/SqlFeedbackService.scala
+++ b/modules/portal/app/backend/sql/SqlFeedbackService.scala
@@ -2,15 +2,14 @@ package backend.sql
 
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
+import java.time.ZonedDateTime
 import javax.inject.{Inject, Singleton}
 
 import akka.actor.ActorSystem
-import anorm.JodaParameterMetaData._
 import anorm._
 import backend.FeedbackService
 import models.{Feedback, FeedbackContext}
 import org.apache.commons.io.IOUtils
-import org.joda.time.DateTime
 import play.api.db.Database
 import play.api.libs.json.{JsError, JsSuccess, Json}
 
@@ -19,6 +18,7 @@ import scala.languageFeature.postfixOps
 import utils.{Page, PageParams}
 
 import scala.concurrent.{ExecutionContext, Future}
+
 
 @Singleton
 case class SqlFeedbackService @Inject ()(implicit db: Database, actorSystem: ActorSystem) extends FeedbackService {
@@ -94,7 +94,7 @@ case class SqlFeedbackService @Inject ()(implicit db: Database, actorSystem: Act
     db.withConnection { implicit conn =>
       val feedback = data.copy(objectId = data.objectId
           .orElse(Some(utils.db.newObjectId(10))),
-        createdAt = data.createdAt.orElse(Some(DateTime.now)))
+        createdAt = data.createdAt.orElse(Some(ZonedDateTime.now)))
       SQL"""INSERT INTO feedback
         (id, user_id, name, email, text, type, copy, context, created, updated, mode)
         VALUES (

--- a/modules/portal/app/controllers/portal/social/Social.scala
+++ b/modules/portal/app/controllers/portal/social/Social.scala
@@ -1,10 +1,11 @@
 package controllers.portal.social
 
+import java.time.LocalDateTime
+
 import auth.AccountManager
 import backend.rest.cypher.Cypher
 import controllers.base.RecaptchaHelper
 import controllers.generic.Search
-import org.joda.time.DateTime
 import play.api.cache.CacheApi
 import play.api.libs.concurrent.Execution.Implicits._
 import models.{SystemEvent, UserProfile}
@@ -76,7 +77,7 @@ case class Social @Inject()(
     ))
   }
 
-  def userActivity(userId: String, from: Option[DateTime] = None, to: Option[DateTime] = None) = WithUserAction.async { implicit request =>
+  def userActivity(userId: String, from: Option[LocalDateTime] = None, to: Option[LocalDateTime] = None) = WithUserAction.async { implicit request =>
     // Show the profile home page of a defined user.
     // Activity is the default page
     val listParams = RangeParams.fromRequest(request)

--- a/modules/portal/app/controllers/portal/users/UserProfiles.scala
+++ b/modules/portal/app/controllers/portal/users/UserProfiles.scala
@@ -2,7 +2,6 @@ package controllers.portal.users
 
 import auth.AccountManager
 import controllers.generic.Search
-import org.joda.time.DateTime
 import play.api.cache.CacheApi
 import play.api.libs.concurrent.Execution.Implicits._
 import models._
@@ -18,6 +17,7 @@ import jp.t2v.lab.play2.auth.LoginLogout
 import play.api.libs.Files.TemporaryFile
 import java.io.File
 import scala.concurrent.Future
+import java.time.LocalDateTime
 import utils.search._
 import backend._
 
@@ -27,7 +27,6 @@ import play.api.mvc.MaxSizeExceeded
 import play.api.mvc.MultipartFormData.FilePart
 import controllers.DataFormat
 import play.api.http.{HeaderNames, MimeTypes}
-import org.joda.time.format.ISODateTimeFormat
 import models.base.AnyModel
 import net.coobird.thumbnailator.Thumbnails
 import controllers.portal.base.{PortalController, PortalAuthConfigImpl}
@@ -96,7 +95,7 @@ case class UserProfiles @Inject()(
     implicit val writes = Json.writes[ExportWatchItem]
   }
 
-  def activity(from: Option[DateTime] = None, to: Option[DateTime] = None) = WithUserAction.async { implicit request =>
+  def activity(from: Option[LocalDateTime] = None, to: Option[LocalDateTime] = None) = WithUserAction.async { implicit request =>
     // Show the profile home page of a defined user.
     // Activity is the default page
     val listParams = RangeParams.fromRequest(request)
@@ -162,8 +161,7 @@ case class UserProfiles @Inject()(
       annotation.target.map(_.toStringLang),
       annotation.model.field,
       annotation.model.body,
-      annotation.latestEvent
-        .map(_.model.timestamp.toString(ISODateTimeFormat.dateTime)),
+      annotation.latestEvent.map(_.time),
       annotation.target
         .map(t => views.p.Helpers.linkTo(t).absoluteURL(globalConfig.https) + "#" + annotation.id)
     )

--- a/modules/portal/app/models/CypherQuery.scala
+++ b/modules/portal/app/models/CypherQuery.scala
@@ -1,10 +1,11 @@
 package models
 
+import java.time.ZonedDateTime
+
 import backend.rest.cypher.CypherService
-import org.joda.time.DateTime
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.data.validation.{Valid, Invalid, Constraint}
+import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.libs.json._
 import play.api.libs.ws.StreamedResponse
 import utils.CsvHelpers
@@ -43,8 +44,8 @@ case class CypherQuery(
   query: String,
   description: Option[String] = None,
   public: Boolean = false,
-  createdAt: Option[DateTime] = None,
-  updatedAt: Option[DateTime] = None
+  createdAt: Option[ZonedDateTime] = None,
+  updatedAt: Option[ZonedDateTime] = None
 ) {
 
   def download(implicit cypher: CypherService, executionContext: ExecutionContext): Future[StreamedResponse] =
@@ -62,7 +63,6 @@ object CypherQuery {
   val DESCRIPTION = "description"
   val PUBLIC = "public"
 
-  implicit val isoJodaDateReads = Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
   implicit val _format: Format[CypherQuery] = Json.format[CypherQuery]
 
   // Mutation Cypher queries - if they add more and we don't update this
@@ -83,8 +83,8 @@ object CypherQuery {
       QUERY -> nonEmptyText.verifying(isReadOnly),
       DESCRIPTION -> optional(text),
       PUBLIC -> boolean,
-      "createdAt" -> ignored(Option.empty[DateTime]),
-      "updatedAt" -> ignored(Option.empty[DateTime])
+      "createdAt" -> ignored(Option.empty[ZonedDateTime]),
+      "updatedAt" -> ignored(Option.empty[ZonedDateTime])
     )(CypherQuery.apply)(CypherQuery.unapply)
   )
 }

--- a/modules/portal/app/models/EventSummary.scala
+++ b/modules/portal/app/models/EventSummary.scala
@@ -1,8 +1,9 @@
 package models
 
+import java.time.ZonedDateTime
+
 import defines.EventType
-import models.base.{AnyModel, Accessor}
-import org.joda.time.DateTime
+import models.base.{Accessor, AnyModel}
 
 /**
  * Summarise a set of events. Typically the events will be
@@ -12,12 +13,12 @@ import org.joda.time.DateTime
  */
 case class EventSummary(events: Seq[SystemEvent]) {
   lazy val user: Option[Accessor] = events.headOption.flatMap(_.actioner)
-  lazy val timestamp: Option[DateTime] = events.headOption.map(_.model.timestamp)
+  lazy val timestamp: Option[ZonedDateTime] = events.headOption.map(_.model.timestamp)
   lazy val eventTypes: Set[EventType.Value] = events.flatMap(_.effectiveType).toSet
   lazy val firstSubjects: Set[AnyModel] = events.flatMap(_.effectiveSubject).toSet
 
-  def from: Option[DateTime] = events.headOption.map(_.model.timestamp)
-  def to: Option[DateTime] = events.lastOption.map(_.model.timestamp)
+  def from: Option[ZonedDateTime] = events.headOption.map(_.model.timestamp)
+  def to: Option[ZonedDateTime] = events.lastOption.map(_.model.timestamp)
 
   def sameSubject: Boolean = firstSubjects.size == 1
   def sameType: Boolean = eventTypes.size == 1

--- a/modules/portal/app/models/Feedback.scala
+++ b/modules/portal/app/models/Feedback.scala
@@ -1,10 +1,11 @@
 package models
 
-import play.api.libs.json.{Reads, Format, Json}
+import java.time.ZonedDateTime
+
+import play.api.libs.json.{Format, Json, Reads}
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.Mode.Mode
-import org.joda.time.DateTime
 import defines.BindableEnum
 import defines.EnumUtils.enumMapping
 
@@ -17,8 +18,8 @@ case class Feedback(
   `type`: Option[Feedback.Type.Value] = Some(Feedback.Type.Site),
   copyMe: Option[Boolean] = Some(false),
   context: Option[FeedbackContext] = None,
-  createdAt: Option[DateTime] = None,
-  updatedAt: Option[DateTime] = None,
+  createdAt: Option[ZonedDateTime] = None,
+  updatedAt: Option[ZonedDateTime] = None,
   mode: Option[Mode] = Some(play.api.Mode.Dev)
 )
 
@@ -39,7 +40,6 @@ object Feedback {
   }
 
   implicit val modeFormat = defines.EnumUtils.enumFormat(play.api.Mode)
-  implicit val isoJodaDateReads = Reads.jodaDateReads("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
   implicit val _format: Format[Feedback] = Json.format[Feedback]
 
   implicit val form = Form(
@@ -52,8 +52,8 @@ object Feedback {
       TYPE -> optional(enumMapping(Type)),
       COPY_ME -> optional(boolean),
       "context" -> ignored(Option.empty[FeedbackContext]),
-      "createdAt" -> ignored(Option.empty[DateTime]),
-      "updatedAt" -> ignored(Option.empty[DateTime]),
+      "createdAt" -> ignored(Option.empty[ZonedDateTime]),
+      "updatedAt" -> ignored(Option.empty[ZonedDateTime]),
       "mode" -> ignored(Option.empty[play.api.Mode.Value])
     )(Feedback.apply)(Feedback.unapply)
   )

--- a/modules/portal/app/models/FeedbackContext.scala
+++ b/modules/portal/app/models/FeedbackContext.scala
@@ -2,7 +2,7 @@ package models
 
 import play.api.libs.json.{Format, Json}
 import play.api.mvc.RequestHeader
-import org.joda.time.format.ISODateTimeFormat
+
 
 case class FeedbackContext(
   path: String,
@@ -11,9 +11,6 @@ case class FeedbackContext(
 )
 
 object FeedbackContext {
-
-  private val dateTimeFormatter = ISODateTimeFormat.dateTime()
-
   def fromRequest(implicit request: RequestHeader): FeedbackContext = FeedbackContext(
     path = request.path,
     queryString = request.queryString,

--- a/modules/portal/app/models/RssItem.scala
+++ b/modules/portal/app/models/RssItem.scala
@@ -1,10 +1,12 @@
 package models
 
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
 import play.twirl.api.Html
 
 import scala.util.control.Exception._
+
 
 case class RssFeed(
   title: String,
@@ -17,11 +19,9 @@ case class RssItem(
   title: String,
   link: String,
   description: Html,
-  pubDate: Option[DateTime] = None
+  pubDate: Option[ZonedDateTime] = None
 )
 object RssFeed {
-  private val pat = DateTimeFormat.forPattern("EEE, dd MMM yyyy H:m:s Z")
-
   def apply(feedXml: String, numEntries: Int = 5): RssFeed = {
     val elem = scala.xml.XML.loadString(feedXml) \ "channel"
     new RssFeed(
@@ -29,12 +29,12 @@ object RssFeed {
       (elem \ "link").text,
       if ((elem \ "description").text.trim.isEmpty) None
         else Some((elem \ "description").text),
-      (elem \ "item").take(numEntries).map { item =>
-        new RssItem(
+      (elem \ "item").take(numEntries).map { item => RssItem(
           title = (item \ "title").text,
           link = (item \ "link").text,
           description = Html((item \ "description").text),
-          pubDate = allCatch.opt(DateTime.parse((item \ "pubDate").text, pat))
+          pubDate = allCatch.opt(ZonedDateTime.parse((item \ "pubDate").text,
+              DateTimeFormatter.RFC_1123_DATE_TIME))
         )
       }
     )

--- a/modules/portal/app/utils/DateFacetUtils.scala
+++ b/modules/portal/app/utils/DateFacetUtils.scala
@@ -1,9 +1,10 @@
 package utils
 
+import java.time.{ZoneId, ZonedDateTime}
+import java.time.format.DateTimeFormatter
 import javax.inject.{Inject, Singleton}
-import org.joda.time.DateTime
-import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
-import play.api.i18n.{MessagesApi, Messages}
+
+import play.api.i18n.{Messages, MessagesApi}
 import utils.search._
 
 /**
@@ -62,8 +63,7 @@ object DateFacetUtils {
 
   val dateQueryForm = Form(single(DATE_PARAM -> nonEmptyText))
 
-  def startDate(year: Int): String = formatter.print(new DateTime(year, 1, 1, 0, 0))
-  def endDate(year: Int): String = formatter.print(new DateTime(year, 12, 12, 23, 59))
-
-  val formatter: DateTimeFormatter = ISODateTimeFormat.dateTime().withZoneUTC()
+  val formatter = DateTimeFormatter.ISO_DATE_TIME
+  def startDate(year: Int): String = formatter.format(ZonedDateTime.of(year, 1, 1, 0, 0, 0, 0, ZoneId.of("Z")))
+  def endDate(year: Int): String = formatter.format(ZonedDateTime.of(year, 12, 12, 23, 59, 59, 0, ZoneId.of("Z")))
 }

--- a/modules/portal/app/views/account/signupForm.scala.html
+++ b/modules/portal/app/views/account/signupForm.scala.html
@@ -23,7 +23,7 @@
     @common.recaptcha(recaptchaKey)
 
     <div class="signup-check">
-        <input type="hidden" name="@TIMESTAMP" value="@org.joda.time.DateTime.now().toString" />
+        <input type="hidden" name="@TIMESTAMP" value="@java.time.ZonedDateTime.now().toString" />
         <input type="text" name="@BLANK_CHECK" title="[Leave this blank]" autocomplete="off" value="" />
     </div>
 

--- a/modules/portal/app/views/activity/eventSummary.scala.html
+++ b/modules/portal/app/views/activity/eventSummary.scala.html
@@ -15,7 +15,9 @@
 
                     @for(timestamp <- summary.timestamp; user <- summary.user) {
                         <a href="@controllers.portal.social.routes.Social.userActivity(
-                                userId = user.id, from = summary.from, to = summary.to)"
+                                userId = user.id,
+                                from = summary.from.map(_.toLocalDateTime),
+                                to = summary.to.map(_.toLocalDateTime))"
                             class="event-time" title="@timestamp">
                             <i class="glyphicon glyphicon-time"></i>
                             @views.Helpers.relativeDate(timestamp)

--- a/modules/portal/app/views/feedback/form.scala.html
+++ b/modules/portal/app/views/feedback/form.scala.html
@@ -19,7 +19,7 @@
         <textarea rows="4" class="form-control" name="text" placeholder="@Messages("feedback.message") " required=""></textarea>
 
         <div class="blank-check" style="display: none">
-            <input tabindex="-1" type="hidden" name="@TIMESTAMP" value="@org.joda.time.DateTime.now().toString" />
+            <input tabindex="-1" type="hidden" name="@TIMESTAMP" value="@java.time.ZonedDateTime.now().toString" />
             <input tabindex="-1" type="text" name="@BLANK_CHECK" title="[Leave this blank]" autocomplete="off" value="" />
         </div>
     </fieldset>

--- a/modules/portal/app/views/userProfile/userActivity.scala.html
+++ b/modules/portal/app/views/userProfile/userActivity.scala.html
@@ -1,14 +1,12 @@
 @(item: UserProfile, events: utils.RangePage[Seq[SystemEvent]], params: utils.RangeParams, eventParams: utils.SystemEventParams)(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: utils.SessionPrefs, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer)
 
-@import org.joda.time.format.DateTimeFormat
+@import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 
 <div class="user-profile-content">
     <h2 class="block-header UserProfile">
         @Messages("activity")
         @for(from <- eventParams.from; to <- eventParams.to) {
-            @defining(DateTimeFormat.shortDateTime()) { fmt =>
-                @fmt.print(to) - @fmt.print(from)
-            }
+            @ISO_LOCAL_DATE.format(to) - @ISO_LOCAL_DATE.format(from)
         }
     </h2>
     @views.html.activity.userActivityStream(item, events)

--- a/modules/portal/conf/profile.routes
+++ b/modules/portal/conf/profile.routes
@@ -1,6 +1,6 @@
 
 GET         /                    @controllers.portal.users.UserProfiles.profile
-GET         /activity            @controllers.portal.users.UserProfiles.activity(from: Option[org.joda.time.DateTime] ?= None, to: Option[org.joda.time.DateTime] ?= None)
+GET         /activity            @controllers.portal.users.UserProfiles.activity(from: Option[java.time.LocalDateTime] ?= None, to: Option[java.time.LocalDateTime] ?= None)
 POST        /accountPrefs        @controllers.portal.users.UserProfiles.updateAccountPrefsPost
 
 GET         /notes               @controllers.portal.users.UserProfiles.annotations(format: controllers.DataFormat.Value ?= controllers.DataFormat.Html)

--- a/modules/portal/conf/social.routes
+++ b/modules/portal/conf/social.routes
@@ -3,7 +3,7 @@
 GET         /                               @controllers.portal.social.Social.browseUsers
 GET         /:userId                        @controllers.portal.social.Social.userProfile(userId: String)
 GET         /:userId/watched       	        @controllers.portal.social.Social.userWatchList(userId: String)
-GET         /:userId/activity               @controllers.portal.social.Social.userActivity(userId: String, from: Option[org.joda.time.DateTime] ?= None, to: Option[org.joda.time.DateTime] ?= None)
+GET         /:userId/activity               @controllers.portal.social.Social.userActivity(userId: String, from: Option[java.time.LocalDateTime] ?= None, to: Option[java.time.LocalDateTime] ?= None)
 GET         /:userId/follow                 @controllers.portal.social.Social.followUser(userId: String)
 POST        /:userId/follow                 @controllers.portal.social.Social.followUserPost(userId: String)
 GET         /:userId/unfollow               @controllers.portal.social.Social.unfollowUser(userId: String)

--- a/test/auth/MockAccountManager.scala
+++ b/test/auth/MockAccountManager.scala
@@ -1,14 +1,15 @@
 package auth
 
+import java.time.ZonedDateTime
 import java.util.UUID
 import javax.inject.{Inject, Singleton}
 
 import models.{Account, OAuth2Association, OpenIDAssociation}
-import org.joda.time.DateTime
 import utils.PageParams
 
 import scala.concurrent.Future.{successful => immediate}
 import scala.concurrent.{ExecutionContext, Future}
+
 
 @Singleton
 case class MockAccountManager @Inject()() extends AccountManager {
@@ -34,7 +35,7 @@ case class MockAccountManager @Inject()() extends AccountManager {
       }
 
     def findAll: Future[Seq[OAuth2Association]] =
-      immediate(mockdata.oauth2AssociationFixtures.toSeq)
+      immediate(mockdata.oauth2AssociationFixtures)
 
     def findByProviderInfo(providerUserId: String, provider: String): Future[Option[OAuth2Association]] =
       immediate(mockdata.oauth2AssociationFixtures.find {
@@ -42,7 +43,7 @@ case class MockAccountManager @Inject()() extends AccountManager {
       })
 
     def findForAccount(id: String): Future[Seq[OAuth2Association]] =
-      immediate(mockdata.oauth2AssociationFixtures.filter(_.id == id).toSeq)
+      immediate(mockdata.oauth2AssociationFixtures.filter(_.id == id))
   }
 
   override def openId: OpenIdAssociationManager = new OpenIdAssociationManager {
@@ -58,7 +59,7 @@ case class MockAccountManager @Inject()() extends AccountManager {
     def findByUrl(url: String): Future[Option[OpenIDAssociation]] =
       immediate(mockdata.openIdAssociationFixtures.find(_.url == url))
 
-    def findAll: Future[Seq[OpenIDAssociation]] = immediate(mockdata.openIdAssociationFixtures.toSeq)
+    def findAll: Future[Seq[OpenIDAssociation]] = immediate(mockdata.openIdAssociationFixtures)
   }
 
   override def get(id: String): Future[Account] =
@@ -90,7 +91,7 @@ case class MockAccountManager @Inject()() extends AccountManager {
   }
 
   override def setLoggedIn(account: Account): Future[Account] =
-    immediate(updateWith(account.copy(lastLogin = Some(DateTime.now()))))
+    immediate(updateWith(account.copy(lastLogin = Some(ZonedDateTime.now()))))
 
   override def verify(account: Account, token: String): Future[Option[Account]] =
     immediate(Some(updateWith(account.copy(verified = true))))
@@ -106,7 +107,7 @@ case class MockAccountManager @Inject()() extends AccountManager {
   }
 
   override def create(account: Account): Future[Account] =
-    immediate(updateWith(account.copy(created = Some(DateTime.now()))))
+    immediate(updateWith(account.copy(created = Some(ZonedDateTime.now()))))
 
   override def update(account: Account): Future[Account] =
     immediate(updateWith(account))

--- a/test/auth/SqlAccountManagerSpec.scala
+++ b/test/auth/SqlAccountManagerSpec.scala
@@ -1,6 +1,7 @@
 package auth
 
 import java.sql.{SQLException, SQLIntegrityConstraintViolationException}
+import java.time.ZonedDateTime
 import java.util.UUID
 
 import akka.actor.ActorSystem
@@ -8,7 +9,6 @@ import anorm.SqlParser._
 import anorm._
 import auth.sql.SqlAccountManager
 import models.Account
-import org.joda.time.DateTime
 import play.api.db.Database
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.PlaySpecification
@@ -18,7 +18,7 @@ import helpers.withFixtures
 
 class SqlAccountManagerSpec extends PlaySpecification {
 
-  implicit val dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
+  implicit val dateTimeOrdering: Ordering[ZonedDateTime] = Ordering.fromLessThan(_ isBefore _)
   implicit val actorSystem = new GuiceApplicationBuilder().build().injector.instanceOf[ActorSystem]
 
   def accounts(implicit db: Database, actorSystem: ActorSystem): AccountManager = SqlAccountManager()(db, actorSystem)
@@ -41,7 +41,7 @@ class SqlAccountManagerSpec extends PlaySpecification {
     "create accounts with correct properties" in withFixtures { implicit db =>
       // "now" with fudge factor for crap DBs that don't support
       // fractional timestamps...
-      val now = DateTime.now().minusSeconds(1)
+      val now = ZonedDateTime.now().minusSeconds(1)
       val testAcc = Account(
         id = "test",
         email = "blah@example.com",

--- a/test/backend/MockCypherQueryService.scala
+++ b/test/backend/MockCypherQueryService.scala
@@ -2,7 +2,7 @@ package backend
 
 import backend.rest.ItemNotFound
 import models.CypherQuery
-import org.joda.time.DateTime
+import java.time.LocalDateTime
 import utils.{Page, PageParams}
 
 import scala.concurrent.Future
@@ -16,7 +16,7 @@ case class MockCypherQueryService(buffer: collection.mutable.HashMap[Int, Cypher
 
   override def update(id: String, cypherQuery: CypherQuery): Future[String] = {
     buffer += id.toInt -> cypherQuery
-    immediate(DateTime.now.toString)
+    immediate(LocalDateTime.now.toString)
   }
 
   override def delete(id: String): Future[Boolean] = {

--- a/test/integration/portal/AccountsSpec.scala
+++ b/test/integration/portal/AccountsSpec.scala
@@ -9,6 +9,7 @@ import play.api.test.{WithApplication, FakeRequest}
 import utils.forms.HoneyPotForm._
 import utils.forms.TimeCheckForm._
 
+
 class AccountsSpec extends IntegrationTestRunner {
   import mockdata.privilegedUser
 
@@ -37,7 +38,7 @@ class AccountsSpec extends IntegrationTestRunner {
         // on email login (bug #816)
         SignupData.EMAIL -> Seq(privilegedUser.email.toUpperCase),
         SignupData.PASSWORD -> Seq(testPassword),
-        TIMESTAMP -> Seq(org.joda.time.DateTime.now.toString),
+        TIMESTAMP -> Seq(java.time.ZonedDateTime.now.toString),
         BLANK_CHECK -> Seq(""),
         CSRF_TOKEN_NAME -> Seq(fakeCsrfString)
       )

--- a/test/integration/portal/FeedbackSpec.scala
+++ b/test/integration/portal/FeedbackSpec.scala
@@ -19,7 +19,7 @@ class FeedbackSpec extends IntegrationTestRunner {
 
     val fb = Map(
       TEXT -> Seq("it doesn't work"),
-      TIMESTAMP -> Seq(org.joda.time.DateTime.now.toString),
+      TIMESTAMP -> Seq(java.time.ZonedDateTime.now.toString),
       BLANK_CHECK -> Seq("")
     )
 

--- a/test/integration/portal/SignupSpec.scala
+++ b/test/integration/portal/SignupSpec.scala
@@ -1,8 +1,9 @@
 package integration.portal
 
+import java.time.ZonedDateTime
+
 import helpers.IntegrationTestRunner
 import models._
-import org.joda.time.DateTime
 import play.api.test.FakeRequest
 import play.api.i18n.Messages
 import play.api.i18n.Messages.Implicits._
@@ -29,7 +30,7 @@ class SignupSpec extends IntegrationTestRunner {
       SignupData.EMAIL -> Seq(testEmail),
       SignupData.PASSWORD -> Seq(testPassword),
       SignupData.CONFIRM -> Seq(testPassword),
-      TIMESTAMP -> Seq(org.joda.time.DateTime.now.toString),
+      TIMESTAMP -> Seq(ZonedDateTime.now.toString),
       BLANK_CHECK -> Seq(""),
       SignupData.AGREE_TERMS -> Seq(true.toString),
       CSRF_TOKEN_NAME -> Seq(fakeCsrfString)
@@ -69,7 +70,7 @@ class SignupSpec extends IntegrationTestRunner {
 
     "prevent signup with invalid time diff" in new ITestApp(specificConfig = Map("ehri.signup.timeCheckSeconds" -> 5)) {
       val badData = data
-        .updated(TIMESTAMP, Seq(org.joda.time.DateTime.now.toString))
+        .updated(TIMESTAMP, Seq(java.time.ZonedDateTime.now.toString))
       val signup = FakeRequest(accountRoutes.signupPost()).withCsrf.callWith(badData)
       println(redirectLocation(signup))
       status(signup) must equalTo(BAD_REQUEST)
@@ -120,8 +121,8 @@ class SignupSpec extends IntegrationTestRunner {
         val logout = FakeRequest(accountRoutes.logout()).withUser(u).call()
         status(logout) must equalTo(SEE_OTHER)
 
-        implicit val dateTimeOrdering: Ordering[DateTime] = Ordering.fromLessThan(_ isBefore _)
-        val time = DateTime.now()
+        implicit val dateTimeOrdering: Ordering[ZonedDateTime] = Ordering.fromLessThan(_ isBefore _)
+        val time = ZonedDateTime.now()
         val login = FakeRequest(accountRoutes.passwordLoginPost()).withCsrf.callWith(data2)
         status(login) must equalTo(SEE_OTHER)
         redirectLocation(login) must beSome.which { loc =>


### PR DESCRIPTION
This will ease pain with Play 2.6 and, as a bonus, cause some re-examination of the date/time parsing behaviour which may prove beneficial.