### PR TITLE
Support for generic facets and virtual units in the API

### DIFF
--- a/modules/api/app/models/api/v1/JsonApiV1.scala
+++ b/modules/api/app/models/api/v1/JsonApiV1.scala
@@ -167,8 +167,8 @@ object JsonApiV1 {
   case class DocumentaryUnitLinks(
     self: String,
     search: String,
-    holder: Option[String],
-    parent: Option[String]
+    holder: Option[String] = None,
+    parent: Option[String] = None
   )
 
   object DocumentaryUnitLinks {
@@ -176,8 +176,8 @@ object JsonApiV1 {
   }
 
   case class DocumentaryUnitRelations(
-    holder: Option[JsValue],
-    parent: Option[JsValue]
+    holder: Option[JsValue] = None,
+    parent: Option[JsValue] = None
   )
 
   object DocumentaryUnitRelations {

--- a/modules/api/conf/api.routes
+++ b/modules/api/conf/api.routes
@@ -2,9 +2,9 @@
 
 GET         /                 @controllers.api.ApiHome.index
 GET        /v1                @controllers.api.v1.ApiV1Home.index()
-GET        /v1/search         @controllers.api.v1.ApiV1.search(q: Option[String] ?= None, `type`: Seq[defines.EntityType.Value] ?= Seq.empty, page: Int ?= 1, limit: Int ?= 20)
+GET        /v1/search         @controllers.api.v1.ApiV1.search(q: Option[String] ?= None, `type`: Seq[defines.EntityType.Value] ?= Seq.empty, page: Int ?= 1, limit: Int ?= 20, facet: Seq[String] ?= Nil)
 GET        /v1/:id            @controllers.api.v1.ApiV1.fetch(id: String)
-GET        /v1/:id/search     @controllers.api.v1.ApiV1.searchIn(id: String, q: Option[String] ?= None, `type`: Seq[defines.EntityType.Value] ?= Seq.empty, page: Int ?= 1, limit: Int ?= 2)
+GET        /v1/:id/search     @controllers.api.v1.ApiV1.searchIn(id: String, q: Option[String] ?= None, `type`: Seq[defines.EntityType.Value] ?= Seq.empty, page: Int ?= 1, limit: Int ?= 2, facet: Seq[String] ?= Nil)
 GET        /graphql           @controllers.api.graphql.GraphQL.index()
 POST       /graphql           @controllers.api.graphql.GraphQL.query()
 GET        /graphql/ui        @controllers.api.graphql.GraphQL.graphiql()

--- a/modules/core/app/models/VirtualUnit.scala
+++ b/modules/core/app/models/VirtualUnit.scala
@@ -117,8 +117,8 @@ case class VirtualUnit(
     else includedUnits.headOption.map(_.toStringLang(messages)).getOrElse(id)
   }
 
-  def allDescriptions: Seq[DocumentaryUnitDescriptionF]
-    = includedUnits.flatMap(_.descriptions) ++ model.descriptions
+  def allDescriptions: Seq[DocumentaryUnitDescriptionF] =
+    includedUnits.flatMap(_.descriptions) ++ model.descriptions
 
   def asDocumentaryUnit: DocumentaryUnit = new DocumentaryUnit(
     new DocumentaryUnitF(

--- a/modules/core/app/utils/search/SearchParams.scala
+++ b/modules/core/app/utils/search/SearchParams.scala
@@ -65,6 +65,7 @@ case class SearchParams(
   reverse: Option[Boolean] = Some(false),
   entities: Seq[EntityType.Value] = Nil,
   fields: Seq[SearchField.Value] = Nil,
+  facets: Seq[String] = Nil,
   excludes: Option[List[String]] = None,
   filters: Option[List[String]] = None
 ) {
@@ -93,6 +94,7 @@ case class SearchParams(
       reverse = reverse orElse d.reverse,
       entities = if (entities.isEmpty) d.entities else entities,
       fields = if (fields.isEmpty) d.fields else fields,
+      facets = if (facets.isEmpty) d.facets else facets,
       excludes = excludes orElse d.excludes,
       filters = filters orElse d.filters
     )
@@ -105,6 +107,7 @@ object SearchParams {
   val SORT = "sort"
   val QUERY = "q"
   val FIELD = "qf"
+  val FACET = "facet"
   val ENTITY = "st"
   val EXCLUDE = "ex"
   val FILTERS = "f"
@@ -133,6 +136,7 @@ object SearchParams {
       REVERSE -> optional(boolean),
       ENTITY -> tolerantSeq(EntityType),
       FIELD -> tolerantSeq(SearchField),
+      FACET -> seq(nonEmptyText),
       EXCLUDE -> optional(list(nonEmptyText)),
       FILTERS -> optional(list(nonEmptyText))
     )(SearchParams.apply)(SearchParams.unapply)

--- a/modules/core/test/utils/search/FacetSpec.scala
+++ b/modules/core/test/utils/search/FacetSpec.scala
@@ -29,5 +29,16 @@ class FacetSpec extends PlaySpecification {
       val withoutFacet: String = pathWithoutFacet(testFacetClass, "fr", "/foobar", qs)
       withoutFacet must equalTo("/foobar?lang=de")
     }
+
+    "allow adding generic facet to a query" in {
+      val withFacet: String = pathWithGenericFacet(testFacetClass, "en", "/foobar", qs)
+      withFacet must equalTo("/foobar?lang=de&lang=fr&facet=lang%3Aen")
+    }
+
+    "allow removing generic facets from a query" in {
+      val withoutFacet: String = pathWithoutFacet(testFacetClass, "fr", "/foobar",
+        ListMap("facet" -> Seq("lang:de", "lang:fr")))
+      withoutFacet must equalTo("/foobar?facet=lang%3Ade")
+    }
   }
 }

--- a/modules/portal/app/controllers/base/SearchVC.scala
+++ b/modules/portal/app/controllers/base/SearchVC.scala
@@ -1,25 +1,39 @@
 package controllers.base
 
 import backend.rest.cypher.Cypher
+import controllers.generic.Search
 import models.VirtualUnit
 import models.base.AnyModel
 import play.api.Logger
 import play.api.cache.CacheApi
-import play.api.mvc.Controller
+import play.api.mvc.{Controller, RequestHeader}
+import utils.search.SearchConstants._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
+import scala.concurrent.Future.{successful => immediate}
 
 
 /**
  * Helpers for searching virtual collections
  */
 trait SearchVC {
-  this: CoreActionBuilders =>
+  this: Search =>
 
   protected implicit def cache: CacheApi
   protected def cypher: Cypher
 
   private def logger: Logger = Logger(getClass)
+
+  /**
+    * Filters for searching a virtual collection, depending on
+    * whether or not there is a current query. If no query is
+    * given the filters will fetch items at the child level only.
+    * Otherwise they will return filters for items at all depths
+    * in the virtual collection.
+    */
+  protected def vcSearchFilters(item: AnyModel)(implicit request: RequestHeader): Future[Map[String,Any]] =
+    if (!hasActiveQuery(request)) buildChildSearchFilter(item)
+    else buildDescendentSearchFilter(item)
 
   /**
    * Fetch a list of descendant IDs for a given virtual collection
@@ -72,23 +86,35 @@ trait SearchVC {
     }
   }
 
-  protected def buildChildSearchFilter(item: AnyModel): Map[String,Any] = {
-    // Nastiness. We want a Solr query that will allow searching
-    // both the child virtual collections of a VU as well as the
-    // physical documentary units it includes. Since there is no
-    // connection from the DU to VUs it belongs to (and creating
-    // one is not feasible) we need to do this badness:
-    // - load the VU from the graph along with its included DUs
-    // - query for anything that has the VUs parent ID *or* anything
-    // with an itemId among its included DUs
-    import utils.search.SearchConstants._
-    logger.debug(s"Building child search for: ${item.id}")
+  protected def buildDescendentSearchFilter(item: AnyModel): Future[Map[String, Any]] =
     item match {
-      case v: VirtualUnit =>
-        val pq = v.includedUnits.map(_.id)
-        if (pq.isEmpty) Map(s"$PARENT_ID:${v.id}" -> Unit)
-        else Map(s"$PARENT_ID:${v.id} OR $ITEM_ID:(${pq.mkString(" ")})" -> Unit)
-      case d => Map(s"$PARENT_ID:${d.id}" -> Unit)
+      case v: VirtualUnit => vcDescendantIds(item.id).map { seq =>
+        if (seq.isEmpty) Map(ITEM_ID -> "__NO_VALID_ID__")
+        else Map(s"$ITEM_ID:(${seq.mkString(" ")}) OR $ANCESTOR_IDS:(${seq.mkString(" ")})" -> Unit)
+      }
+      // otherwise, for documentary units, we can just query
+      // all ancestors
+      case d => immediate(Map(s"$ANCESTOR_IDS:${item.id}" -> Unit))
     }
-  }
+
+  protected def buildChildSearchFilter(item: AnyModel): Future[Map[String,Any]] =
+    immediate {
+      // Nastiness. We want a Solr query that will allow searching
+      // both the child virtual collections of a VU as well as the
+      // physical documentary units it includes. Since there is no
+      // connection from the DU to VUs it belongs to (and creating
+      // one is not feasible) we need to do this badness:
+      // - load the VU from the graph along with its included DUs
+      // - query for anything that has the VUs parent ID *or* anything
+      // with an itemId among its included DUs
+      import utils.search.SearchConstants._
+      logger.debug(s"Building child search for: ${item.id}")
+      item match {
+        case v: VirtualUnit =>
+          val pq = v.includedUnits.map(_.id)
+          if (pq.isEmpty) Map(s"$PARENT_ID:${v.id}" -> Unit)
+          else Map(s"$PARENT_ID:${v.id} OR $ITEM_ID:(${pq.mkString(" ")})" -> Unit)
+        case d => Map(s"$PARENT_ID:${d.id}" -> Unit)
+      }
+    }
 }

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
@@ -150,5 +150,5 @@ case class SolrSearchConfig(
 }
 
 case class SolrSearchEngine @Inject()(handler: ResponseHandler, conf: Configuration, ws: WSClient) extends SearchEngine {
-  def config = new SolrSearchConfig(handler)(conf, ws)
+  def config = SolrSearchConfig(handler)(conf, ws)
 }


### PR DESCRIPTION
Changes to expand the scope of the API:

 - generic facets are now supported for search via `facet=class:value`
 - added a language-of-description facet to the API
 - added support for fetching/searching virtual collections in the API

Misc. changes to other VC code.