### PR TITLE
Add the global CORS filter and /api set as a path prefix.

### DIFF
--- a/app/Filters.scala
+++ b/app/Filters.scala
@@ -1,10 +1,10 @@
 import javax.inject.Inject
-import play.api.http.HttpFilters
+
+import play.api.http.DefaultHttpFilters
+import play.filters.cors.CORSFilter
 import play.filters.csrf.CSRFFilter
 
-class Filters @Inject() (
-  csrfFilter: CSRFFilter
-) extends HttpFilters {
-
-  val filters = Seq(csrfFilter)
-}
+class Filters @Inject()(
+  csrfFilter: CSRFFilter,
+  corsFilter: CORSFilter
+) extends DefaultHttpFilters(csrfFilter, corsFilter)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -33,6 +33,10 @@ play {
       }
       contentType.blackList = ["application/x-www-form-urlencoded", "multipart/form-data", "text/plain"]
     }
+
+    cors {
+      pathPrefixes = ["/api"]
+    }
   }
 
   i18n {

--- a/test/integration/api/v1/ApiV1Spec.scala
+++ b/test/integration/api/v1/ApiV1Spec.scala
@@ -72,6 +72,22 @@ class ApiV1Spec extends IntegrationTestRunner {
           "scopeAndContent" must_== JsDefined(JsString("Some description text for c4"))
     }
 
+    "send CORS headers" in new ITestApp {
+      // `/api` is configured as a prefix in play.filters.cors.pathPrefixes
+      val testOrigin = "http://example.com"
+      val testHost = "localhost"
+
+      val api = FakeRequest(apiRoutes.search())
+        .withHeaders(HeaderNames.HOST -> testHost, HeaderNames.ORIGIN -> testOrigin)
+        .call()
+      header(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, api) must_== Some(testOrigin)
+
+      val nonApi = FakeRequest(GET, "/")
+        .withHeaders(HeaderNames.HOST -> testHost, HeaderNames.ORIGIN -> testOrigin)
+        .call()
+      header(HeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, nonApi) must_== None
+    }
+
     "contain the right metadata" in new ITestApp {
       val fetch = FakeRequest(apiRoutes.fetch("r1")).call()
       status(fetch) must_== OK


### PR DESCRIPTION
Allows cross-origin API calls without JSONP.