### PR TITLE
Add a UI to backend find/replace web service function.

### DIFF
--- a/modules/admin/app/models/admin/FindReplaceTask.scala
+++ b/modules/admin/app/models/admin/FindReplaceTask.scala
@@ -1,0 +1,35 @@
+package models.admin
+
+import defines.{ContentTypes, EntityType}
+import play.api.data.Form
+import play.api.data.Forms._
+
+case class FindReplaceTask(
+  parentType: ContentTypes.Value,
+  subType: EntityType.Value,
+  property: String,
+  find: String,
+  replace: String,
+  log: Option[String]
+)
+
+object FindReplaceTask {
+
+  val PARENT_TYPE = "type"
+  val SUB_TYPE = "subtype"
+  val PROPERTY = "property"
+  val FIND = "from"
+  val REPLACE = "to"
+  val LOG_MSG = "logMessage"
+
+  val form: Form[FindReplaceTask] = Form(
+    mapping(
+      PARENT_TYPE -> nonEmptyText.transform[ContentTypes.Value](ContentTypes.withName, _.toString),
+      SUB_TYPE -> nonEmptyText.transform[EntityType.Value](EntityType.withName, _.toString),
+      PROPERTY -> nonEmptyText,
+      FIND -> nonEmptyText,
+      REPLACE -> nonEmptyText,
+      LOG_MSG -> optional(nonEmptyText)
+    )(FindReplaceTask.apply)(FindReplaceTask.unapply)
+  )
+}

--- a/modules/admin/app/views/admin/Helpers.scala
+++ b/modules/admin/app/views/admin/Helpers.scala
@@ -27,9 +27,14 @@ object Helpers {
     ("s1", "-"),
     ("contentTypes.SystemEvent",      controllers.events.routes.SystemEvents.list().url),
     ("s2", "-"),
-    ("cypherQuery.list",           controllers.cypher.routes.CypherQueries.listQueries().url),
+    ("cypherQuery.list",           controllers.cypher.routes.CypherQueries.listQueries().url)
+  )
+
+  val adminMenu = Seq(
     ("s3", "-"),
-    ("search.index.update",            controllers.admin.routes.AdminSearch.updateIndex().url)
+    ("search.index.update",            controllers.admin.routes.AdminSearch.updateIndex().url),
+    ("admin.utils.findReplace", controllers.admin.routes.Utils.findReplace().url),
+    ("admin.utils.regenerateIds", controllers.admin.routes.Utils.regenerateIds().url)
   )
 
   def linkTo(isA: defines.EntityType.Value, id: String): Call = {

--- a/modules/admin/app/views/admin/findReplace.scala.html
+++ b/modules/admin/app/views/admin/findReplace.scala.html
@@ -1,0 +1,78 @@
+@(f: Form[models.admin.FindReplaceTask], foundOpt: Option[Seq[(String, String, String)]], findAction: Call, replaceAction: Call)(implicit userOpt: Option[UserProfile], request: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, flash: Flash)
+
+@implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
+
+@import models.admin.FindReplaceTask._
+
+@views.html.admin.layout.noSidebar(Messages("admin.utils.findReplace")) {
+
+    <p>@Messages("admin.utils.findReplace.description")</p>
+    @if(foundOpt.isEmpty) {
+        <p class="alert alert-danger">@Messages("admin.utils.findReplace.warning")</p>
+    }
+
+    @defining("admin.utils.findReplace") { implicit fieldPrefix =>
+        @helper.form(action = findAction, 'class -> "entity-form form-horizontal") {
+            @formHelpers.csrfToken()
+
+            @defining("") { implicit fieldPrefix =>
+                @formHelpers.enumChoiceInput(f(PARENT_TYPE), defines.ContentTypes, PARENT_TYPE, blank = true)
+                @formHelpers.enumChoiceInput(f(SUB_TYPE), defines.EntityType, SUB_TYPE, blank = true)
+            }
+            @formHelpers.lineInput(f(""), PROPERTY)
+            @formHelpers.textInput(f(""), FIND)
+            @formHelpers.textInput(f(""), REPLACE)
+            @formHelpers.lineInput(f(""), LOG_MSG)
+
+            <div class="form-group">
+                <input type="submit" class="btn btn-warning" value="@Messages("admin.utils.findReplace.find")" />
+            </div>
+        }
+
+        @foundOpt.map { found =>
+            @if(found.isEmpty) {
+                <h3>@Messages("admin.utils.findReplace.notFound")</h3>
+            } else {
+                <hr/>
+
+                <h3>@Messages("admin.utils.findReplace.found", found.size)</h3>
+                @helper.form(action = replaceAction, 'class -> "entity-form form-horizontal") {
+                    @formHelpers.csrfToken()
+                    @formHelpers.hiddenInput(f(PARENT_TYPE))
+                    @formHelpers.hiddenInput(f(SUB_TYPE))
+                    @formHelpers.hiddenInput(f(PROPERTY))
+                    @formHelpers.hiddenInput(f(FIND))
+                    @formHelpers.hiddenInput(f(REPLACE))
+                    @formHelpers.hiddenInput(f(LOG_MSG))
+
+                    <table class="table table-bordered table-condensed table-striped small">
+                        <thead>
+                            <tr>
+                                <th>Item</th>
+                                <th>Subitem</th>
+                                <th>Current Text</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        @found.map { case (pid, cid, textValue) =>
+                        <tr>
+                            <td><a target="_blank"
+                                    href="@controllers.admin.routes.Data.getItem(pid)">@pid</a></td>
+                            <td>@cid</td>
+                            <td>@textValue</td>
+                        </tr>
+                        }
+                        </tbody>
+                    </table>
+
+                    <div class="form-group">
+                        <input type="submit" onclick="return confirm('Are you sure?')"
+                            class="btn btn-danger"
+                            value="@Messages("admin.utils.findReplace.replace", found.size)" />
+                    </div>
+                }
+            }
+        }
+    }
+}
+

--- a/modules/admin/app/views/admin/layout/adminNavBar.scala.html
+++ b/modules/admin/app/views/admin/layout/adminNavBar.scala.html
@@ -3,6 +3,15 @@
 @activeIfCurrent(url: String, text: String) = {
     <li class="@{if(request.path.startsWith(url)) "active" else ""}"><a href="@url">@Html(text)</a></li>
 }
+
+@dropdownMenu(key: String, url: String) = {
+    @if(url == "-") {
+        <li role="presentation" class="divider"></li>
+    } else {
+        @activeIfCurrent(url, Messages(key))
+    }
+}
+
 @defining(utils.SessionPrefs()) { implicit prefs =>
     @views.html.layout.topNavBar {
         <ul class="nav navbar-nav navbar-left">
@@ -18,10 +27,11 @@
 
                 <ul class="dropdown-menu" role="menu" aria-labelledby="more-menu">
                     @views.admin.Helpers.moreMenu.map { case (key, url) =>
-                        @if(url == "-") {
-                            <li role="presentation" class="divider"></li>
-                        } else {
-                            @activeIfCurrent(url, Messages(key))
+                        @dropdownMenu(key, url)
+                    }
+                    @if(userOpt.exists(_.isAdmin)) {
+                        @views.admin.Helpers.adminMenu.map { case (key, url) =>
+                            @dropdownMenu(key, url)
                         }
                     }
                 </ul>

--- a/modules/admin/conf/admin.routes
+++ b/modules/admin/conf/admin.routes
@@ -31,6 +31,10 @@ POST        /movedItems                         @controllers.admin.Utils.addMove
 GET         /regenerate                         @controllers.admin.Utils.regenerateIds
 POST        /regenerate                         @controllers.admin.Utils.regenerateIdsPost
 
+# Find and replace
+GET         /findReplace                        @controllers.admin.Utils.findReplace
+POST        /findReplace                        @controllers.admin.Utils.findReplacePost(commit: Boolean ?= false)
+
 # Monitoring
 GET         /monitor/_check                     @controllers.admin.Utils.checkServices
 GET         /monitor/_checkUserSync             @controllers.admin.Utils.checkUserSync

--- a/modules/admin/conf/messages
+++ b/modules/admin/conf/messages
@@ -210,6 +210,32 @@ admin.utils.regenerateIds.scanning=Scanning items with stale IDs...
 admin.utils.regenerateIds.description=Items that require ID regeneration.
 admin.utils.regenerateIds.noIdsFound=No IDs requiring regeneration found.
 
+#
+# Find and replace
+#
+admin.utils.findReplace=Find and Replace
+admin.utils.findReplace.found=Items found: {0}
+admin.utils.findReplace.notFound=No items found
+admin.utils.findReplace.done=Items updated: {0}
+admin.utils.findReplace.find=Find
+admin.utils.findReplace.replace={0,choice,0#Replace {0} Values|1#Replace 1 Value|1<Replace {0,number,integer} Values}
+admin.utils.findReplace.description=Find and replace text across a particular property of an item type.\
+  Note: you can only change up to 100 items at a time.
+admin.utils.findReplace.warning=Don''t do this unless you're sure you know what you''re doing, since \
+  it is a sharp tool.
+admin.utils.findReplace.type=Parent item type
+admin.utils.findReplace.type.description=The top-level content item, e.g. a Repository.
+admin.utils.findReplace.subtype=Dependent item type
+admin.utils.findReplace.subtype.description=The property-holding item type, e.g. a Repository description.
+admin.utils.findReplace.property=Property
+admin.utils.findReplace.property.description=The property name.
+admin.utils.findReplace.from=Text to find
+admin.utils.findReplace.from.description=The current text to find.
+admin.utils.findReplace.to=Replacement text
+admin.utils.findReplace.to.description=The replacement text.
+admin.utils.findReplace.logMessage=Log message
+admin.utils.findReplace.logMessage.description=Describe why you are making this change.
+
 # Admin search index
 search.index.update=Refresh Search Index
 search.index.update.for=Refresh searching index for {0}

--- a/modules/backend/src/main/scala/defines/ContentTypes.scala
+++ b/modules/backend/src/main/scala/defines/ContentTypes.scala
@@ -1,12 +1,13 @@
 package defines
 
 import eu.ehri.project.definitions.Entities
+import play.api.libs.json.Format
 
 object ContentTypes extends Enumeration() {
   type Type = Value
-  val HistoricalAgent = Value(Entities.HISTORICAL_AGENT)
   val DocumentaryUnit = Value(Entities.DOCUMENTARY_UNIT)
   val Repository = Value(Entities.REPOSITORY)
+  val HistoricalAgent = Value(Entities.HISTORICAL_AGENT)
   val SystemEvent = Value(Entities.SYSTEM_EVENT)
   val UserProfile = Value(Entities.USER_PROFILE)
   val Group = Value(Entities.GROUP)
@@ -18,5 +19,5 @@ object ContentTypes extends Enumeration() {
   val Country = Value(Entities.COUNTRY)
   val VirtualUnit = Value(Entities.VIRTUAL_UNIT)
 
-  implicit val _format = defines.EnumUtils.enumFormat(this)
+  implicit val _format: Format[ContentTypes.Value] = defines.EnumUtils.enumFormat(this)
 }

--- a/modules/backend/src/main/scala/defines/EntityType.scala
+++ b/modules/backend/src/main/scala/defines/EntityType.scala
@@ -1,6 +1,7 @@
 package defines
 
 import eu.ehri.project.definitions.Entities._
+import play.api.libs.json.Format
 
 object EntityType extends Enumeration {
 
@@ -32,5 +33,5 @@ object EntityType extends Enumeration {
   val VirtualUnit = Value(VIRTUAL_UNIT)
   val Version = Value(VERSION)
 
-  implicit val _format = defines.EnumUtils.enumFormat(this)
+  implicit val _format: Format[EntityType.Value] = defines.EnumUtils.enumFormat(this)
 }

--- a/modules/core/app/controllers/generic/Indexable.scala
+++ b/modules/core/app/controllers/generic/Indexable.scala
@@ -56,7 +56,7 @@ trait Indexable[MT] extends Controller with CoreActionBuilders with ControllerHe
    */
   def updateItemPost(id: String) = AdminAction { implicit request =>
     val source = Source.actorRef[String](1000, OverflowStrategy.dropTail).mapMaterializedValue { chan =>
-      searchIndexer.handle.withChannel(chan, wrapMsg).indexId(id).onComplete {
+      searchIndexer.handle.withChannel(chan, wrapMsg).indexIds(id).onComplete {
         case Success(()) => finishSuccess(chan)
         case Failure(t) => finishError(chan, t)
       }

--- a/modules/core/app/global/GlobalEventHandler.scala
+++ b/modules/core/app/global/GlobalEventHandler.scala
@@ -22,13 +22,13 @@ case class GlobalEventHandler @Inject()(searchIndexer: SearchIndexMediator) exte
     }
   }
 
-  def handleCreate(id: String) = logFailure(id, searchIndexer.handle.indexId)
-  def handleUpdate(id: String) = logFailure(id, searchIndexer.handle.indexId)
+  def handleCreate(id: String) = logFailure(id, id => searchIndexer.handle.indexIds(id))
+  def handleUpdate(id: String) = logFailure(id, id => searchIndexer.handle.indexIds(id))
 
   // Special case - block when deleting because otherwise we get ItemNotFounds
   // after redirects because the item is still in the search index but not in
   // the database.
   def handleDelete(id: String) = logFailure(id, id => Future.successful[Unit] {
-    concurrent.Await.result(searchIndexer.handle.clearId(id), Duration(1, TimeUnit.MINUTES))
+    concurrent.Await.result(searchIndexer.handle.clearIds(id), Duration(1, TimeUnit.MINUTES))
   })
 }

--- a/modules/core/app/utils/search/SearchIndexMediator.scala
+++ b/modules/core/app/utils/search/SearchIndexMediator.scala
@@ -12,66 +12,66 @@ trait SearchIndexMediator {
 }
 
 /**
- * Interface to an indexer service.
- */
+  * Interface to an indexer service.
+  */
 trait SearchIndexMediatorHandle {
 
   /**
-   * Provide a concurrent channel through which to
-   * pass update events.
-   *
-   * @param actorRef an actor to which to post messages
-   * @param formatter a formatter for event strings
-   * @return
-   */
+    * Provide a concurrent channel through which to
+    * pass update events.
+    *
+    * @param actorRef  an actor to which to post messages
+    * @param formatter a formatter for event strings
+    * @return
+    */
   def withChannel(actorRef: ActorRef, formatter: String => String = identity[String]): SearchIndexMediatorHandle = this
 
   /**
-   * Index a single item by id.
-   *
-   * @param id the id of the item
-   */
-  def indexId(id: String): Future[Unit]
+    * Index single items by id.
+    *
+    * @param ids the ids of the items
+    */
+  def indexIds(ids: String*): Future[Unit]
 
   /**
-   * Index all items of a given set of types.
-   *
-   * @param entityTypes types to index
-   */
+    * Index all items of a given set of types.
+    *
+    * @param entityTypes types to index
+    */
   def indexTypes(entityTypes: Seq[EntityType.Value]): Future[Unit]
 
   /**
-   * Index all children of a given item.
-   *
-   * @param entityType the types to clear
-   * @param id the id of the parent
-   */
+    * Index all children of a given item.
+    *
+    * @param entityType the types to clear
+    * @param id         the id of the parent
+    */
   def indexChildren(entityType: EntityType.Value, id: String): Future[Unit]
 
   /**
-   * Clear the index of all items.
-   */
+    * Clear the index of all items.
+    */
   def clearAll(): Future[Unit]
 
   /**
-   * Clear the index of all items of a given type.
-   *
-   * @param entityTypes the types to clear
-   */
+    * Clear the index of all items of a given type.
+    *
+    * @param entityTypes the types to clear
+    */
   def clearTypes(entityTypes: Seq[EntityType.Value]): Future[Unit]
 
   /**
-   * Clear a given item from the index.
-   *
-   * @param id the id of the item to delete
-   */
-  def clearId(id: String): Future[Unit]
+    * Clear a given item from the index.
+    *
+    * @param ids the ids of the items to delete
+    */
+  def clearIds(ids: String*): Future[Unit]
 
   /**
-   * Clear a given item from the index.
-   *
-   * @param key the item key
-   * @param value the item value
-   */
+    * Clear a given item from the index.
+    *
+    * @param key   the item key
+    * @param value the item value
+    */
   def clearKeyValue(key: String, value: String): Future[Unit]
 }

--- a/modules/portal/app/indexing/CmdlineIndexMediator.scala
+++ b/modules/portal/app/indexing/CmdlineIndexMediator.scala
@@ -87,13 +87,13 @@ case class CmdlineIndexMediatorHandle(
     play.api.Logger.logger.debug("Index: {}", cmd.mkString(" "))
     val process: Process = cmd.run(logger)
     if (process.exitValue() != 0) {
-      throw new IndexingError("Exit code was " + process.exitValue() + "\nLast output: \n"
+      throw IndexingError("Exit code was " + process.exitValue() + "\nLast output: \n"
         + (if(logger.errBuffer.remainingCapacity > 0) "" else "... (truncated)\n")
         + logger.lastMessages.mkString("\n"))
     }
   }
 
-  def indexId(id: String): Future[Unit] = runProcess(idxArgs ++ Seq("@" + id, "--pretty"))
+  def indexIds(ids: String*): Future[Unit] = runProcess((idxArgs ++ ids.map(id => s"@$id")) :+ "--pretty")
 
   def indexTypes(entityTypes: Seq[EntityType.Value]): Future[Unit]
         = runProcess(idxArgs ++ entityTypes.map(_.toString))
@@ -106,7 +106,7 @@ case class CmdlineIndexMediatorHandle(
   def clearTypes(entityTypes: Seq[EntityType.Value]): Future[Unit]
         = runProcess(clearArgs ++ entityTypes.flatMap(s => Seq("--clear-type", s.toString)))
 
-  def clearId(id: String): Future[Unit] = runProcess(clearArgs ++ Seq("--clear-id", id))
+  def clearIds(ids: String*): Future[Unit] = runProcess(clearArgs ++ ids.flatMap(id => Seq("--clear-id", id)))
 
   def clearKeyValue(key: String, value: String): Future[Unit]
         = runProcess(clearArgs ++ Seq("--clear-key-value", s"$key=$value"))

--- a/modules/portal/app/indexing/SearchToolsIndexMediator.scala
+++ b/modules/portal/app/indexing/SearchToolsIndexMediator.scala
@@ -87,9 +87,9 @@ case class SearchToolsIndexMediatorHandle(
     builder.build()
   }
 
-  override def indexId(id: String): Future[Unit] = Future {
-    logger.debug(s"Indexing: $id")
-    indexHelper("@" + id).run()
+  override def indexIds(ids: String*): Future[Unit] = Future {
+    logger.debug(s"Indexing: $ids")
+    indexHelper(ids.map(id => s"@$id"): _*).run()
   }
 
   override def indexChildren(entityType: EntityType.Value, id: String): Future[Unit] = Future {
@@ -117,8 +117,8 @@ case class SearchToolsIndexMediatorHandle(
     index.deleteAll(true)
   }
 
-  override def clearId(id: String): Future[Unit] = Future {
-    logger.debug(s"Clear id: $id")
-    index.deleteItem(id, true)
+  override def clearIds(ids: String*): Future[Unit] = Future {
+    logger.debug(s"Clear ids: $ids")
+    index.deleteItems(ids.asJava, true)
   }
 }

--- a/test/backend/RestApiSpec.scala
+++ b/test/backend/RestApiSpec.scala
@@ -49,9 +49,9 @@ class RestApiSpec extends RestApiRunner with PlaySpecification {
     app.injector.instanceOf[DataApi].withContext(apiUser)
 
   def testEventHandler = new EventHandler {
-    def handleCreate(id: String) = mockIndexer.handle.indexId(id)
-    def handleUpdate(id: String) = mockIndexer.handle.indexId(id)
-    def handleDelete(id: String) = mockIndexer.handle.clearId(id)
+    def handleCreate(id: String) = mockIndexer.handle.indexIds(id)
+    def handleUpdate(id: String) = mockIndexer.handle.indexIds(id)
+    def handleDelete(id: String) = mockIndexer.handle.clearIds(id)
   }
 
   /**

--- a/test/utils/search/MockSearchIndexMediator.scala
+++ b/test/utils/search/MockSearchIndexMediator.scala
@@ -15,9 +15,9 @@ case class MockSearchIndexMediator(eventBuffer: collection.mutable.ListBuffer[St
  */
 case class MockSearchIndexMediatorHandle(eventBuffer: collection.mutable.ListBuffer[String]) extends SearchIndexMediatorHandle {
 
-  def indexId(id: String) = {
-    eventBuffer += id
-    Logger.logger.info("Indexing: " + id)
+  def indexIds(ids: String*) = {
+    ids.foreach(id => eventBuffer += id)
+    Logger.logger.info("Indexing: " + ids)
     Future.successful(())
   }
   def indexTypes(entityTypes: Seq[EntityType.Value]) = {
@@ -40,9 +40,9 @@ case class MockSearchIndexMediatorHandle(eventBuffer: collection.mutable.ListBuf
     Logger.logger.info("Clearing entity types: " + entityTypes)
     Future.successful(())
   }
-  def clearId(id: String) = {
-    eventBuffer += id
-    Logger.logger.info("Clearing id: " + id)
+  def clearIds(ids: String*) = {
+    ids.foreach(id => eventBuffer += id)
+    Logger.logger.info("Clearing id: " + ids)
     Future.successful(())
   }
   def clearKeyValue(key: String, value: String) = {


### PR DESCRIPTION
This is admin only since it's a pretty sharp tool which requires knowing a bit about the database schema (specifically, the key names for item attributes.)

Also refactor the admin menu a bit to accommodate new features.

Also in this patch: small tweak to the index mediator API to better accommodate reindexing multiple items by ID.