### PR TITLE
Replace method of extracting item stats from facets w/ JSON facets for Solr 6

### DIFF
--- a/modules/core/app/utils/search/FacetClass.scala
+++ b/modules/core/app/utils/search/FacetClass.scala
@@ -15,12 +15,6 @@ sealed trait FacetClass[+T <: Facet] {
   def minCount: Option[Int] = None
 
   /**
-    * Total number of unique facets, which may or may not be
-    * calculated in the request.
-    */
-  def total: Option[Int] = None
-
-  /**
    * This key is a valid facet value. By default any values
    * are accepted, except for query facets.
    */

--- a/modules/core/app/utils/search/FacetClass.scala
+++ b/modules/core/app/utils/search/FacetClass.scala
@@ -11,9 +11,14 @@ sealed trait FacetClass[+T <: Facet] {
   def sort: FacetSort.Value = FacetSort.Count
   def display: FacetDisplay.Value = FacetDisplay.List
   def displayLimit: Int = 10
-  def count: Int = facets.length
   def limit: Option[Int] = None
   def minCount: Option[Int] = None
+
+  /**
+    * Total number of unique facets, which may or may not be
+    * calculated in the request.
+    */
+  def total: Option[Int] = None
 
   /**
    * This key is a valid facet value. By default any values
@@ -95,7 +100,7 @@ case class QueryFacetClass(
 object FacetClass {
   implicit def facetClassWrites: Writes[FacetClass[Facet]] = Writes[FacetClass[Facet]] { fc =>
     Json.obj(
-      "count" -> JsNumber(fc.count),
+      "count" -> JsNumber(fc.facets.size),
       "param" -> Json.toJson(fc.param),
       "name" -> Json.toJson(fc.name),
       "key" -> Json.toJson(fc.key),

--- a/modules/core/app/utils/search/SearchResult.scala
+++ b/modules/core/app/utils/search/SearchResult.scala
@@ -9,7 +9,8 @@ case class SearchResult[+T](
   params: SearchParams,
   facets: Seq[AppliedFacet] = Seq.empty,
   facetClasses: Seq[FacetClass[Facet]] = Seq.empty,
-  spellcheck: Option[(String,String)] = None
+  spellcheck: Option[(String,String)] = None,
+  facetInfo: Map[String, Any] = Map.empty
 ) {
 
   /**

--- a/modules/core/app/utils/search/SearchResult.scala
+++ b/modules/core/app/utils/search/SearchResult.scala
@@ -9,8 +9,8 @@ case class SearchResult[+T](
   params: SearchParams,
   facets: Seq[AppliedFacet] = Seq.empty,
   facetClasses: Seq[FacetClass[Facet]] = Seq.empty,
-  spellcheck: Option[(String,String)] = None,
-  facetInfo: Map[String, Any] = Map.empty
+  facetInfo: Map[String, Any] = Map.empty,
+  spellcheck: Option[(String,String)] = None
 ) {
 
   /**

--- a/modules/portal/app/controllers/portal/Portal.scala
+++ b/modules/portal/app/controllers/portal/Portal.scala
@@ -189,16 +189,16 @@ case class Portal @Inject()(
   }
 
   private def getStats(implicit request: RequestHeader): Future[Stats] =
-    FutureCache.getOrElse("index:metrics", Duration(60 * 5, TimeUnit.SECONDS)) {
+    FutureCache.getOrElse("index:metrics", Duration(20, TimeUnit.MINUTES)) {
       // Assume no user for fetching global stats
       implicit val userOpt: Option[UserProfile] = None
       find[AnyModel](
         // we don't need results here because we're only using the facets
         defaultParams = SearchParams(count = Some(0)),
         facetBuilder = entityMetrics,
-        extra = Map("facet.limit" -> "-1"),
+        extra = Map("json.facet" -> Stats.query),
         entities = defaultSearchTypes
-      ).map(r => Stats(r.facetClasses))
+      ).map(r => Stats(r.facetInfo))
     }
 }
 

--- a/modules/portal/app/controllers/portal/Portal.scala
+++ b/modules/portal/app/controllers/portal/Portal.scala
@@ -196,7 +196,7 @@ case class Portal @Inject()(
         // we don't need results here because we're only using the facets
         defaultParams = SearchParams(count = Some(0)),
         facetBuilder = entityMetrics,
-        extra = Map("json.facet" -> Stats.query),
+        extra = Map("json.facet" -> Stats.analyticsQuery),
         entities = defaultSearchTypes
       ).map(r => Stats(r.facetInfo))
     }

--- a/modules/portal/app/utils/Stats.scala
+++ b/modules/portal/app/utils/Stats.scala
@@ -1,51 +1,100 @@
 package utils
 
 import defines.EntityType
-import models.Isaar
-import utils.search.{SearchConstants, Facet, FacetClass}
+import play.api.libs.json._
+import utils.search.{Facet, FacetClass, SearchConstants}
 
 /**
- * Class for holding useful stats for the data in our system.
- */
+  * Class for holding useful stats for the data in our system.
+  */
 case class Stats(
-  countryCount: Int,
-  repositoryCount: Int,
-  inCountryCount: Int,
-  documentaryUnitCount: Int,
-  inRepositoryCount: Int,
-  historicalAgentCount: Int,
-  corpCount: Int,
-  personCount: Int,
-  familyCount: Int
+  countryCount: Int = 0,
+  repositoryCount: Int = 0,
+  inCountryCount: Int = 0,
+  documentaryUnitCount: Int = 0,
+  inRepositoryCount: Int = 0
+)
+
+private case class BucketStat(
+  `val`: EntityType.Value,
+  count: Int
+)
+
+private object BucketStat {
+  implicit val reads = Json.reads[BucketStat]
+}
+
+private case class FacetInfo(
+  inRepositories: Int,
+  inCountries: Int,
+  totals: Map[EntityType.Value, Int]
 )
 
 object Stats {
 
+  val query = Json.stringify(
+    Json.obj(
+      "inRepositories" -> "unique(holderId)",
+      "inCountries" -> "unique(countryCode)",
+      "totals" -> Json.obj(
+        "terms" -> Json.obj(
+          "field" -> "type"
+        )
+      )
+    )
+  )
+
+  def apply(info: Map[String, Any]): Stats = {
+    val lookupReader: Reads[Seq[BucketStat]] = Reads { json =>
+      (json \ "buckets").validate[Seq[BucketStat]]
+    }
+
+    val parsed = FacetInfo(
+      inRepositories = info.get("inRepositories").flatMap {
+        case JsNumber(num) => Some(num.toIntExact)
+      }.getOrElse(0),
+      inCountries = info.get("inCountries").flatMap {
+        case JsNumber(num) => Some(num.toIntExact)
+      }.getOrElse(0),
+      totals = info.get("totals").flatMap {
+        case js: JsValue => js.validate(lookupReader).asOpt
+          .map(bs =>  bs.map(b => b.`val` -> b.count).toMap)
+      }.getOrElse {
+        println("FAILED")
+        Map.empty
+      }
+    )
+
+    Stats(
+      countryCount = parsed.totals.getOrElse(EntityType.Country, 0),
+      repositoryCount = parsed.totals.getOrElse(EntityType.Repository, 0),
+      documentaryUnitCount = parsed.totals.getOrElse(EntityType.DocumentaryUnit, 0),
+      inRepositoryCount = parsed.inRepositories,
+      inCountryCount = parsed.inCountries
+    )
+  }
+
   /**
-   * Extract the count of a particular facet within the given class.
-   */
+    * Extract the count of a particular facet within the given class.
+    */
   private def typeCount(facets: Seq[FacetClass[Facet]], key: String, facetName: Any): Int =
-    facets.find(_.key == key).flatMap(_.facets.find(_.value == facetName.toString).map(_.count)).getOrElse(0)
+  facets.find(_.key == key).flatMap(_.facets.find(_.value == facetName.toString).map(_.count)).getOrElse(0)
 
   /**
-   * Extract the total number of facets for a given class.
-   */
+    * Extract the total number of facets for a given class.
+    */
   private def allCount(facets: Seq[FacetClass[Facet]], key: String): Int =
-    facets.find(_.key == key).map(_.count).getOrElse(0)
+  facets.find(_.key == key).flatMap(_.total).getOrElse(0)
 
   /**
-   * Construct a Stats value from a list of facets.
-   */
+    * Construct a Stats value from a list of facets.
+    */
   def apply(facets: Seq[FacetClass[Facet]]): Stats = new Stats(
     countryCount = typeCount(facets, SearchConstants.TYPE, EntityType.Country),
     repositoryCount = typeCount(facets, SearchConstants.TYPE, EntityType.Repository),
     inCountryCount = allCount(facets, SearchConstants.COUNTRY_CODE),
     documentaryUnitCount = typeCount(facets, SearchConstants.TYPE, EntityType.DocumentaryUnit),
-    inRepositoryCount = allCount(facets, SearchConstants.HOLDER_ID),
-    historicalAgentCount = typeCount(facets, SearchConstants.TYPE, EntityType.HistoricalAgent),
-    corpCount = typeCount(facets, Isaar.ENTITY_TYPE, Isaar.HistoricalAgentType.CorporateBody),
-    personCount = typeCount(facets, Isaar.ENTITY_TYPE, Isaar.HistoricalAgentType.Person),
-    familyCount = typeCount(facets, Isaar.ENTITY_TYPE, Isaar.HistoricalAgentType.Family)
+    inRepositoryCount = allCount(facets, SearchConstants.HOLDER_ID)
   )
 }
 

--- a/modules/portal/app/utils/Stats.scala
+++ b/modules/portal/app/utils/Stats.scala
@@ -2,7 +2,6 @@ package utils
 
 import defines.EntityType
 import play.api.libs.json._
-import utils.search.{Facet, FacetClass, SearchConstants}
 
 /**
   * Class for holding useful stats for the data in our system.
@@ -19,13 +18,14 @@ private case class BucketStat(
   `val`: EntityType.Value,
   count: Int
 )
+
 private object BucketStat {
   implicit val reads = Json.reads[BucketStat]
 }
 
 object Stats {
 
-  val query = Json.stringify(
+  val analyticsQuery: String = Json.stringify(
     Json.obj(
       "inRepositories" -> "unique(holderId)",
       "inCountries" -> "unique(countryCode)",
@@ -47,7 +47,7 @@ object Stats {
       countryCount = totals.getOrElse(EntityType.Country, 0),
       repositoryCount = totals.getOrElse(EntityType.Repository, 0),
       documentaryUnitCount = totals.getOrElse(EntityType.DocumentaryUnit, 0),
-      inRepositoryCount = info.get("inRepositories")match {
+      inRepositoryCount = info.get("inRepositories") match {
         case Some(JsNumber(num)) => num.toIntExact
         case _ => 0
       },

--- a/modules/portal/app/utils/Stats.scala
+++ b/modules/portal/app/utils/Stats.scala
@@ -19,16 +19,9 @@ private case class BucketStat(
   `val`: EntityType.Value,
   count: Int
 )
-
 private object BucketStat {
   implicit val reads = Json.reads[BucketStat]
 }
-
-private case class FacetInfo(
-  inRepositories: Int,
-  inCountries: Int,
-  totals: Map[EntityType.Value, Int]
-)
 
 object Stats {
 
@@ -45,57 +38,25 @@ object Stats {
   )
 
   def apply(info: Map[String, Any]): Stats = {
-    val lookupReader: Reads[Seq[BucketStat]] = Reads { json =>
-      (json \ "buckets").validate[Seq[BucketStat]]
-    }
-
-    val parsed = FacetInfo(
-      inRepositories = info.get("inRepositories").flatMap {
-        case JsNumber(num) => Some(num.toIntExact)
-      }.getOrElse(0),
-      inCountries = info.get("inCountries").flatMap {
-        case JsNumber(num) => Some(num.toIntExact)
-      }.getOrElse(0),
-      totals = info.get("totals").flatMap {
-        case js: JsValue => js.validate(lookupReader).asOpt
-          .map(bs =>  bs.map(b => b.`val` -> b.count).toMap)
-      }.getOrElse {
-        println("FAILED")
-        Map.empty
-      }
-    )
+    val totals: Map[defines.EntityType.Value, Int] = info.get("totals").flatMap {
+      case js: JsValue => (js \ "buckets").validate[Seq[BucketStat]].asOpt
+        .map(bs => bs.map(b => b.`val` -> b.count).toMap)
+    }.getOrElse(Map.empty)
 
     Stats(
-      countryCount = parsed.totals.getOrElse(EntityType.Country, 0),
-      repositoryCount = parsed.totals.getOrElse(EntityType.Repository, 0),
-      documentaryUnitCount = parsed.totals.getOrElse(EntityType.DocumentaryUnit, 0),
-      inRepositoryCount = parsed.inRepositories,
-      inCountryCount = parsed.inCountries
+      countryCount = totals.getOrElse(EntityType.Country, 0),
+      repositoryCount = totals.getOrElse(EntityType.Repository, 0),
+      documentaryUnitCount = totals.getOrElse(EntityType.DocumentaryUnit, 0),
+      inRepositoryCount = info.get("inRepositories")match {
+        case Some(JsNumber(num)) => num.toIntExact
+        case _ => 0
+      },
+      inCountryCount = info.get("inCountries") match {
+        case Some(JsNumber(num)) => num.toIntExact
+        case _ => 0
+      }
     )
   }
-
-  /**
-    * Extract the count of a particular facet within the given class.
-    */
-  private def typeCount(facets: Seq[FacetClass[Facet]], key: String, facetName: Any): Int =
-  facets.find(_.key == key).flatMap(_.facets.find(_.value == facetName.toString).map(_.count)).getOrElse(0)
-
-  /**
-    * Extract the total number of facets for a given class.
-    */
-  private def allCount(facets: Seq[FacetClass[Facet]], key: String): Int =
-  facets.find(_.key == key).flatMap(_.total).getOrElse(0)
-
-  /**
-    * Construct a Stats value from a list of facets.
-    */
-  def apply(facets: Seq[FacetClass[Facet]]): Stats = new Stats(
-    countryCount = typeCount(facets, SearchConstants.TYPE, EntityType.Country),
-    repositoryCount = typeCount(facets, SearchConstants.TYPE, EntityType.Repository),
-    inCountryCount = allCount(facets, SearchConstants.COUNTRY_CODE),
-    documentaryUnitCount = typeCount(facets, SearchConstants.TYPE, EntityType.DocumentaryUnit),
-    inRepositoryCount = allCount(facets, SearchConstants.HOLDER_ID)
-  )
 }
 
 

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/QueryResponseExtractor.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/QueryResponseExtractor.scala
@@ -3,14 +3,21 @@ package eu.ehri.project.search.solr
 import utils.search.{AppliedFacet, Facet, FacetClass, SearchHit}
 
 /**
- * Trait that exposes all the relevant information
- * we need to extract from a search query response.
- */
+  * Trait that exposes all the relevant information
+  * we need to extract from a search query response.
+  */
 trait QueryResponseExtractor {
   def phrases: Seq[String]
+
   def items: Seq[SearchHit]
+
   def extractFacetData(appliedFacets: Seq[AppliedFacet], allFacets: Seq[FacetClass[Facet]]): Seq[FacetClass[Facet]]
+
   def count: Int
-  def highlightMap: Map[String,Map[String,Seq[String]]]
-  def spellcheckSuggestion: Option[(String,String)]
+
+  def highlightMap: Map[String, Map[String, Seq[String]]]
+
+  def spellcheckSuggestion: Option[(String, String)]
+
+  def facetInfo: Map[String, Any]
 }

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrJsonResponseHandler.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrJsonResponseHandler.scala
@@ -106,6 +106,10 @@ case class SolrJsonResponseHandler @Inject()(app: play.api.Application) extends 
      */
     def count: Int = raw.count
 
+    lazy val facetInfo: Map[String, Any] = (response \ "facets")
+      .asOpt[Map[String, JsValue]]
+      .getOrElse(Map.empty[String, JsValue])
+
     /**
      * Get highlight map.
      */

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
@@ -122,7 +122,7 @@ case class SolrSearchConfig(
       val parser = handler.getResponseParser(response.body)
       val facetClassList: Seq[FacetClass[Facet]] = parser.extractFacetData(facets, facetClasses)
       val page = Page(params.offset, params.countOrDefault, parser.count, parser.items)
-      SearchResult(page, params, facets, facetClassList, spellcheck = parser.spellcheckSuggestion)
+      SearchResult(page, params, facets, facetClassList, spellcheck = parser.spellcheckSuggestion, parser.facetInfo)
     }
   }
 

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
@@ -122,7 +122,7 @@ case class SolrSearchConfig(
       val parser = handler.getResponseParser(response.body)
       val facetClassList: Seq[FacetClass[Facet]] = parser.extractFacetData(facets, facetClasses)
       val page = Page(params.offset, params.countOrDefault, parser.count, parser.items)
-      SearchResult(page, params, facets, facetClassList, spellcheck = parser.spellcheckSuggestion, parser.facetInfo)
+      SearchResult(page, params, facets, facetClassList, parser.facetInfo, spellcheck = parser.spellcheckSuggestion)
     }
   }
 

--- a/modules/solr/src/test/scala/eu/ehri/project/search/solr/SolrQueryParserSpec.scala
+++ b/modules/solr/src/test/scala/eu/ehri/project/search/solr/SolrQueryParserSpec.scala
@@ -32,7 +32,7 @@ class SolrQueryParserSpec extends PlaySpecification with ResourceUtils {
       )
       val facetData = qp.extractFacetData(List.empty, allFacets)
       facetData.size must equalTo(1)
-      facetData.head.count must equalTo(2)
+      facetData.head.facets.size must equalTo(2)
       facetData.head.facets.head.value must equalTo("eng")
       facetData.head.facets(1).value must equalTo("fre")
       facetData.head.facets.headOption must beSome.which { top =>


### PR DESCRIPTION
This is much faster (1 second vs. 8 in production) and more efficient, though the method of extracting the data is quite fiddly. It also requires the leaky abstraction of the search engine to be made more leaky.