### PR TITLE
Update Play and fix a fragile test.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.6")
 

--- a/test/helpers/TestConfiguration.scala
+++ b/test/helpers/TestConfiguration.scala
@@ -49,6 +49,7 @@ trait TestConfiguration {
   protected val storedFileBuffer: ListBuffer[URI] = collection.mutable.ListBuffer.empty[java.net.URI]
   protected val searchParamBuffer: ListBuffer[ParamLog] = collection.mutable.ListBuffer.empty[ParamLog]
   protected val indexEventBuffer: ListBuffer[String] = collection.mutable.ListBuffer.empty[String]
+  protected val movedPages: collection.mutable.ListBuffer[(String, String)] = collection.mutable.ListBuffer.empty[(String, String)]
 
   private def mockMailer: MailerClient = MockBufferedMailer(mailBuffer)
   private def mockIndexer: SearchIndexMediator = MockSearchIndexMediator(indexEventBuffer)
@@ -59,7 +60,7 @@ trait TestConfiguration {
   // in the mocks package.
   protected def mockAccounts: AccountManager = MockAccountManager()
   private def mockOAuth2Flow: OAuth2Flow = MockOAuth2Flow()
-  private def mockRelocator: MovedPageLookup = MockMovedPageLookup()
+  private def mockRelocator: MovedPageLookup = MockMovedPageLookup(movedPages)
   private def mockFileStorage: FileStorage = MockFileStorage(storedFileBuffer)
   private def mockHtmlPages: HtmlPages = MockHtmlPages()
 

--- a/test/integration/admin/BrowserSpec.scala
+++ b/test/integration/admin/BrowserSpec.scala
@@ -8,8 +8,9 @@ import utils.{MockMovedPageLookup, MovedPageLookup}
 
 class BrowserSpec extends PlaySpecification {
 
+  private val buffer = collection.mutable.ArrayBuffer.empty[(String, String)]
   private val appBuilder = new play.api.inject.guice.GuiceApplicationBuilder()
-    .overrides(bind[MovedPageLookup].toInstance(MockMovedPageLookup()))
+    .overrides(bind[MovedPageLookup].toInstance(MockMovedPageLookup(buffer)))
 
   "Application" should {
 
@@ -19,7 +20,7 @@ class BrowserSpec extends PlaySpecification {
     }
 
     "return 301 for moved pages" in new WithBrowser(app = appBuilder.build()) {
-      mockdata.movedPages += "/foo" -> "/bar"
+      buffer += "/foo" -> "/bar"
       browser.goTo("/foo")
       browser.$("#error-title").getTexts.get(0) must equalTo(Messages("errors.pageNotFound"))
     }

--- a/test/integration/admin/UtilsSpec.scala
+++ b/test/integration/admin/UtilsSpec.scala
@@ -77,6 +77,9 @@ class UtilsSpec extends IntegrationTestRunner with FakeMultipartUpload {
         from must_== "/admin/units/c4"
         to must_== "/admin/units/nl-r1-new_c4"
       }
+      // Clear the mutable buffer to prevent redirects
+      // interfering in other tests
+      movedPages.clear()
     }
 
     "handle find/replace correctly" in new ITestApp {

--- a/test/integration/portal/PortalSpec.scala
+++ b/test/integration/portal/PortalSpec.scala
@@ -40,7 +40,7 @@ class PortalSpec extends IntegrationTestRunner {
       val before = FakeRequest(oldRoute).call()
       status(before) must equalTo(NOT_FOUND)
 
-      mockdata.movedPages += oldRoute.url -> newRoute.url
+      movedPages += oldRoute.url -> newRoute.url
       val rename = FakeRequest(oldRoute).call()
       status(rename) must equalTo(MOVED_PERMANENTLY)
       redirectLocation(rename) must equalTo(Some(newRoute.url))

--- a/test/mockdata/package.scala
+++ b/test/mockdata/package.scala
@@ -42,7 +42,4 @@ package object mockdata {
 
   val openIdAssociationFixtures: collection.mutable.ListBuffer[OpenIDAssociation] =
     collection.mutable.ListBuffer.empty[OpenIDAssociation]
-
-  val movedPages: collection.mutable.ListBuffer[(String, String)] =
-    collection.mutable.ListBuffer.empty[(String, String)]
 }

--- a/test/utils/MockMovedPageLookup.scala
+++ b/test/utils/MockMovedPageLookup.scala
@@ -1,15 +1,16 @@
 package utils
 
+import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.Future.{successful => immediate}
 
-case class MockMovedPageLookup() extends MovedPageLookup {
+case class MockMovedPageLookup(movedPages: mutable.Buffer[(String, String)]) extends MovedPageLookup {
   override def hasMovedTo(path: String): Future[Option[String]] =
-    immediate(mockdata.movedPages.find(_._1 == path).map(_._2))
+    immediate(movedPages.find(_._1 == path).map(_._2))
 
   override def addMoved(moved: Seq[(String, String)]): Future[Int] =
     immediate {
-      mockdata.movedPages.appendAll(moved)
+      movedPages.appendAll(moved)
       moved.size
     }
 }


### PR DESCRIPTION
Because the mock redirect DB is mutable, tests can interfere with each other if run in a certain order. To workaround this for the time being we just clear the buffer after adding to it.