### PR TITLE
Change semantics of backup /fetch endpoint so invalid items are null.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val projectScalaVersion = "2.11.8"
 val appName = "docview"
 val appVersion = "1.0.6-SNAPSHOT"
 
-val backendVersion = "0.13.8-SNAPSHOT"
+val backendVersion = "0.13.9"
 val dataConverterVersion = "1.1.10"
 
 val backendDependencies = Seq(

--- a/modules/admin/app/controllers/admin/Data.scala
+++ b/modules/admin/app/controllers/admin/Data.scala
@@ -28,9 +28,9 @@ case class Data @Inject()(
   def getItem(id: String): Action[AnyContent] = OptionalUserAction.async { implicit request =>
     implicit val rd: Readable[AnyModel] = AnyModel.Converter
     userDataApi.fetch(List(id)).map {
-      case Nil => NotFound(views.html.errors.itemNotFound())
-      case mm :: _ => views.admin.Helpers.linkToOpt(mm)
+      case Some(mm) :: _ => views.admin.Helpers.linkToOpt(mm)
         .map(Redirect) getOrElse NotFound(views.html.errors.itemNotFound())
+      case _ => NotFound(views.html.errors.itemNotFound())
     }
   }
 

--- a/modules/backend/src/main/scala/backend/DataApi.scala
+++ b/modules/backend/src/main/scala/backend/DataApi.scala
@@ -146,7 +146,7 @@ trait DataApiHandle {
     * @param ids  a sequence of string IDs
     * @param gids a sequence of graph IDs
     */
-  def fetch[MT: Readable](ids: Seq[String] = Seq.empty, gids: Seq[Long] = Seq.empty): Future[Seq[MT]]
+  def fetch[MT: Readable](ids: Seq[String] = Seq.empty, gids: Seq[Long] = Seq.empty): Future[Seq[Option[MT]]]
 
   /**
     * Set visibility for a given item.

--- a/modules/core/app/backend/rest/resolvers.scala
+++ b/modules/core/app/backend/rest/resolvers.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
  * Resolve search hits to DB items by the GID field
  */
 case class GidSearchResolver @Inject()(dataApi: DataApi)(implicit executionContext: ExecutionContext) extends SearchItemResolver {
-  def resolve[MT: Readable](docs: Seq[SearchHit])(implicit apiUser: ApiUser): Future[Seq[MT]] =
+  def resolve[MT: Readable](docs: Seq[SearchHit])(implicit apiUser: ApiUser): Future[Seq[Option[MT]]] =
     dataApi.withContext(apiUser).fetch(gids = docs.map(_.gid))
 }
 
@@ -19,6 +19,6 @@ case class GidSearchResolver @Inject()(dataApi: DataApi)(implicit executionConte
  * Resolve search hits to DB items by the itemId field
  */
 case class IdSearchResolver @Inject()(dataApi: DataApi)(implicit executionContext: ExecutionContext) extends SearchItemResolver {
-  def resolve[MT: Readable](docs: Seq[SearchHit])(implicit apiUser: ApiUser): Future[Seq[MT]] =
+  def resolve[MT: Readable](docs: Seq[SearchHit])(implicit apiUser: ApiUser): Future[Seq[Option[MT]]] =
     dataApi.withContext(apiUser).fetch(ids = docs.map(_.itemId))
 }

--- a/modules/core/app/controllers/generic/Search.scala
+++ b/modules/core/app/controllers/generic/Search.scala
@@ -129,7 +129,9 @@ trait Search extends CoreActionBuilders {
       if (list.size != res.page.size) {
         logger.warn(s"Items returned by search were not found in database: ${res.page.items.map(_.id)} -> $list")
       }
-      res.copy(page = res.page.copy(items = list.zip(res.page.items)))
+      res.copy(page = res.page.copy(items = list.zip(res.page.items).collect {
+        case (Some(a), h) => (a, h)
+      }))
     }
   }
 

--- a/modules/core/app/utils/search/SearchHit.scala
+++ b/modules/core/app/utils/search/SearchHit.scala
@@ -1,10 +1,12 @@
 package utils.search
 
 import defines.EntityType
+
 import scala.annotation.tailrec
 import scala._
 import SearchConstants._
-import play.twirl.api.{HtmlFormat, Html}
+import play.api.libs.json.JsValue
+import play.twirl.api.{Html, HtmlFormat}
 
 /**
  * Class representing a search engine hit
@@ -14,7 +16,7 @@ case class SearchHit(
   itemId: String,
   `type`: EntityType.Value,
   gid: Long,
-  fields: Map[String,String] = Map.empty,
+  fields: Map[String,JsValue] = Map.empty,
   highlights: Map[String,Seq[String]] = Map.empty,
   phrases: Seq[String] = Seq.empty
 ) extends views.Highlighter {

--- a/modules/core/app/utils/search/SearchItemResolver.scala
+++ b/modules/core/app/utils/search/SearchItemResolver.scala
@@ -11,5 +11,5 @@ import backend.{Readable, ApiUser}
  * or more optimised internal graph IDs for faster resolution.
  */
 trait SearchItemResolver {
-  def resolve[MT: Readable](results: Seq[SearchHit])(implicit apiUser: ApiUser): Future[Seq[MT]]
+  def resolve[MT: Readable](results: Seq[SearchHit])(implicit apiUser: ApiUser): Future[Seq[Option[MT]]]
 }

--- a/modules/core/test/utils/search/SearchHitSpec.scala
+++ b/modules/core/test/utils/search/SearchHitSpec.scala
@@ -2,6 +2,7 @@ package utils.search
 
 import play.api.test.PlaySpecification
 import defines.EntityType
+import play.api.libs.json.JsString
 
 class SearchHitSpec extends PlaySpecification {
 
@@ -11,22 +12,22 @@ class SearchHitSpec extends PlaySpecification {
     `type`= EntityType.DocumentaryUnit,
     gid = 87287L,
     fields = Map(
-      "repositoryName" -> "Archives de la Ville de Luxembourg",
-      "archivistNote_t" -> "Copied from online search engine",
-      "name" -> "Demandes en obtention d' une autorisation de batir",
-      "identifier" -> "LU 11 - IV/3 - 286",
-      "scope" -> "high",
-      "repositoryId" -> "lu-006007",
-      "languageCode" -> "fra",
-      "countryName" -> "Luxembourg",
-      "publicationStatus" -> "Draft",
-      "id" -> "lu-006007-lu-11-iv-3-286-fra",
-      "countryCode" -> "lu",
-      "itemId" -> "lu-006007-lu-11-iv-3-286",
-      "copyright_t" -> "no",
-      "title" -> "Demandes en obtention d' une autorisation de batir",
-      "type" -> "documentaryUnit",
-      "name_fr" -> "Demandes en obtention d' une autorisation de batir"
+      "repositoryName" -> JsString("Archives de la Ville de Luxembourg"),
+      "archivistNote_t" -> JsString("Copied from online search engine"),
+      "name" -> JsString("Demandes en obtention d' une autorisation de batir"),
+      "identifier" -> JsString("LU 11 - IV/3 - 286"),
+      "scope" -> JsString("high"),
+      "repositoryId" -> JsString("lu-006007"),
+      "languageCode" -> JsString("fra"),
+      "countryName" -> JsString("Luxembourg"),
+      "publicationStatus" -> JsString("Draft"),
+      "id" -> JsString("lu-006007-lu-11-iv-3-286-fra"),
+      "countryCode" -> JsString("lu"),
+      "itemId" -> JsString("lu-006007-lu-11-iv-3-286"),
+      "copyright_t" -> JsString("no"),
+      "title" -> JsString("Demandes en obtention d' une autorisation de batir"),
+      "type" -> JsString("documentaryUnit"),
+      "name_fr" -> JsString("Demandes en obtention d' une autorisation de batir")
     ),
     Map(
       "itemId" -> List("<em>lu-006007-lu-11-iv-3-286</em>"),

--- a/modules/guides/app/controllers/portal/guides/Guides.scala
+++ b/modules/guides/app/controllers/portal/guides/Guides.scala
@@ -436,8 +436,10 @@ case class Guides @Inject()(
             sort = SearchSort.Name
           ) else immediate(SearchResult.empty)
           selectedAccessPoints <- userDataApi.fetch[AnyModel](facets)
+            .map(_.collect{ case Some(h) => h})
           availableFacets <- otherFacets(guide, ids)
           tempAccessPoints <- userDataApi.fetch[AnyModel](gids = availableFacets)
+            .map(_.collect{ case Some(h) => h})
         } yield {
           Ok(views.html.guides.facet(
             guide,
@@ -509,7 +511,7 @@ case class Guides @Inject()(
         case Some(t) => searchLinks(id, t)
         case _ => searchLinks(id)
       })
-      docs <- userDataApi.fetch[AnyModel](gids = gids)
+      docs <- userDataApi.fetch[AnyModel](gids = gids).map(_.collect{ case Some(h) => h})
     } yield Ok(Json.toJson(docs.zip(gids).map { case (doc, gid) =>
       Json.toJson(FilterHit(doc.id, "", doc.toStringLang, doc.isA, None, gid))
     }))
@@ -522,7 +524,7 @@ case class Guides @Inject()(
         case Some(t) => searchLinks(id, t, Some(context))
         case _ => searchLinks(id, context = Some(context))
       })
-      docs <- userDataApi.fetch[AnyModel](gids = gids)
+      docs <- userDataApi.fetch[AnyModel](gids = gids).map(_.collect{ case Some(h) => h})
     } yield Ok(Json.toJson(docs.zip(gids).map { case (doc, gid) =>
       Json.toJson(FilterHit(doc.id, "", doc.toStringLang, doc.isA, None, gid))
     }))

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrJsonResponseParser.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrJsonResponseParser.scala
@@ -164,12 +164,7 @@ case class SolrJsonResponseParser @Inject()(config: play.api.Configuration) exte
           fhl <- hl.get(hit.id)
         } yield fhl).getOrElse(Map.empty)
 
-        val fields = jsObj.value.collect {
-          case (field, JsString(str)) => field -> str
-          case (field, JsArray(Seq(JsString(str), _*))) => field -> str
-        }.toMap
-
-        hit.copy(fields = fields, highlights = highlights, phrases = raw.query.toSeq)
+        hit.copy(fields = jsObj.value.toMap, highlights = highlights, phrases = raw.query.toSeq)
       }
     }
 

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrSearchEngine.scala
@@ -4,6 +4,7 @@ import java.net.ConnectException
 import javax.inject.Inject
 
 import backend.rest.BadJson
+import play.api.libs.json.JsString
 import play.api.libs.ws.{WSClient, WSResponse}
 import play.api.{Configuration, Logger}
 import utils.Page
@@ -66,9 +67,13 @@ case class SolrSearchEngine @Inject()(
       val items = data.items.map(i => FilterHit(
         i.itemId,
         i.id,
-        i.fields.getOrElse(SearchConstants.NAME_EXACT, i.itemId),
+        i.fields
+          .collect { case (SearchConstants.NAME_EXACT, JsString(id)) => id}
+          .headOption.getOrElse(i.itemId),
         i.`type`,
-        i.fields.get(SearchConstants.HOLDER_NAME),
+        i.fields
+          .collect { case (SearchConstants.HOLDER_NAME, JsString(id)) => id}
+          .headOption,
         i.gid
       ))
       val page = Page(query.paging.offset, query.paging.limit, data.count, items)

--- a/modules/solr/src/test/scala/eu/ehri/project/search/solr/SolrQueryParserSpec.scala
+++ b/modules/solr/src/test/scala/eu/ehri/project/search/solr/SolrQueryParserSpec.scala
@@ -5,6 +5,7 @@ import play.api.test.PlaySpecification
 import utils.search.FieldFacetClass
 import models.base.Description
 import play.api.Configuration
+import play.api.libs.json.Json
 
 
 class SolrQueryParserSpec extends PlaySpecification with ResourceUtils {
@@ -76,7 +77,7 @@ class SolrQueryParserSpec extends PlaySpecification with ResourceUtils {
       place.get must equalTo(Seq("Active in the Netherlands, <em>Amsterdam</em>."))
 
       qp.items.head.fields.get("holderName") must beSome.which { v =>
-        v must equalTo("EHRI Corporate Bodies")
+        v must equalTo(Json.arr("EHRI Corporate Bodies"))
       }
 
       val doc1 = qp.items.head

--- a/test/backend/RestApiSpec.scala
+++ b/test/backend/RestApiSpec.scala
@@ -53,9 +53,18 @@ class RestApiSpec extends IntegrationTestRunner {
   }
 
   "RestBackend" should {
-    "allow fetching objects" in new ITestApp {
+    "allow fetching single objects" in new ITestApp {
       val test: TestResource = await(testBackend.get[TestResource]("c1"))
       test.id must equalTo("c1")
+    }
+
+    "allow fetching multiple objects" in new ITestApp {
+      val test: Seq[Option[TestResource]] = await(testBackend.fetch[TestResource](Seq("c1", "bad)")))
+      test.size must_== 2
+      test.head must beSome.which { i =>
+        i.id must_== "c1"
+      }
+      test(1) must beNone
     }
   }
 

--- a/test/utils/search/MockSearchEngine.scala
+++ b/test/utils/search/MockSearchEngine.scala
@@ -3,13 +3,15 @@ package utils.search
 import javax.inject.Inject
 
 import defines.EntityType
-import utils.{PageParams, Page}
+import utils.{Page, PageParams}
 
 import scala.concurrent.ExecutionContext.Implicits._
 import models._
+
 import scala.concurrent.Future
-import backend.{DataApiHandle, DataApi, ApiUser}
-import models.base.{DescribedMeta, Described, Description, AnyModel}
+import backend.{ApiUser, DataApi, DataApiHandle}
+import models.base.{AnyModel, Described, DescribedMeta, Description}
+import play.api.libs.json.JsString
 
 
 /**
@@ -39,7 +41,7 @@ case class MockSearchEngine @Inject()(
   private def modelToSearchHit(m: AnyModel): SearchHit = m match {
     case d: DescribedMeta[Description,Described[Description]] => descModelToHit(d)
     case _ => SearchHit(m.id, m.id, m.isA, -1L, Map(
-      SearchConstants.NAME_EXACT -> m.toStringLang
+      SearchConstants.NAME_EXACT -> JsString(m.toStringLang)
     ))
   }
 
@@ -49,7 +51,7 @@ case class MockSearchEngine @Inject()(
     `type` = m.isA,
     gid = m.meta.value.get("gid").flatMap(_.asOpt[Long]).getOrElse(-1L),
     fields = Map(
-      SearchConstants.NAME_EXACT -> m.toStringLang
+      SearchConstants.NAME_EXACT -> JsString(m.toStringLang)
     )
   )
 


### PR DESCRIPTION
This means we always get back a list the same length as that put in.

Also make Solr hit fields JsValues instead of flattening them to strings.