### PR TITLE
Remove an old hack for getting forwarded remote address.

### DIFF
--- a/modules/core/app/controllers/base/ControllerHelpers.scala
+++ b/modules/core/app/controllers/base/ControllerHelpers.scala
@@ -1,7 +1,6 @@
 package controllers.base
 
 import play.api.Logger
-import play.api.http.HeaderNames
 import play.api.mvc._
 
 import scala.concurrent.duration.FiniteDuration
@@ -19,15 +18,6 @@ trait ControllerHelpers extends play.api.i18n.I18nSupport {
     * Session key for last page prior to login
     */
   protected val ACCESS_URI: String = "access_uri"
-
-  /**
-    * Get the remote IP of a user, taking into account intermediate
-    * proxying. FIXME: there's got to be a better way to do this.
-    */
-  protected def remoteIp(implicit request: RequestHeader): String =
-    request.headers.get(HeaderNames.X_FORWARDED_FOR)
-      .flatMap(_.split(",").map(_.trim).headOption)
-      .getOrElse(request.remoteAddress)
 
   /**
     * Fetch a value from config or throw an error.
@@ -57,7 +47,7 @@ trait ControllerHelpers extends play.api.i18n.I18nSupport {
     * given action. Whenever this function is called the user's
     */
   protected def checkRateLimit[A](limit: Int, duration: FiniteDuration)(implicit request: Request[A]): Boolean = {
-    val ip = remoteIp(request)
+    val ip = request.remoteAddress
     val key = request.path + ip
     val count = cache.get(key).getOrElse(0)
     logger.debug(s"Check rate limit: Limit $limit, timeout $duration, ip: $ip, key: $key, current: $count")

--- a/modules/core/app/controllers/base/CoreActionBuilders.scala
+++ b/modules/core/app/controllers/base/CoreActionBuilders.scala
@@ -292,7 +292,7 @@ trait CoreActionBuilders extends Controller with ControllerHelpers {
       globalConfig.ipFilter.map { whitelist =>
         // Extract the client from the forwarded header, falling back
         // on the remote address. This is dependent on the proxy situation.
-        if (whitelist.contains(remoteIp(request))) immediate(None)
+        if (whitelist.contains(request.remoteAddress)) immediate(None)
         else downForMaintenance(request).map(r => Some(r))
       }.getOrElse(immediate(None))
     }

--- a/modules/portal/app/controllers/portal/account/Accounts.scala
+++ b/modules/portal/app/controllers/portal/account/Accounts.scala
@@ -143,10 +143,10 @@ case class Accounts @Inject()(
         boundForm.fold(
           errForm => {
             if (errForm.error(HoneyPotForm.BLANK_CHECK).nonEmpty) {
-              logger.warn(s"Honeypot miss on signup from IP $remoteIp")
+              logger.warn(s"Honeypot miss on signup from IP ${request.remoteAddress}")
             }
             if (errForm.error(TimeCheckForm.TIMESTAMP).nonEmpty) {
-              logger.warn(s"Time-to-submit violation on signup from IP $remoteIp")
+              logger.warn(s"Time-to-submit violation on signup from IP ${request.remoteAddress}")
             }
             badForm(errForm)
           },


### PR DESCRIPTION
To be set combined with the `play.http.forwarded` conf values.