### PR TITLE
Refactor markdown renderers

### DIFF
--- a/app/AppModule.scala
+++ b/app/AppModule.scala
@@ -3,7 +3,6 @@ import javax.inject.{Inject, Provider}
 import auth.handler.AuthIdContainer
 import auth.handler.cookie.CookieIdContainer
 import auth.oauth2.{OAuth2Flow, WebOAuth2Flow}
-import services.cypher.{Cypher, CypherQueryService, CypherService, SqlCypherQueryService}
 import com.google.inject.AbstractModule
 import eu.ehri.project.indexing.index.Index
 import eu.ehri.project.indexing.index.impl.SolrIndex
@@ -11,6 +10,7 @@ import eu.ehri.project.search.solr._
 import global.{AppGlobalConfig, GlobalConfig, GlobalEventHandler}
 import models.{GuideService, SqlGuideService}
 import services.accounts.{AccountManager, SqlAccountManager}
+import services.cypher.{Cypher, CypherQueryService, CypherService, SqlCypherQueryService}
 import services.data.{GidSearchResolver, _}
 import services.feedback.{FeedbackService, SqlFeedbackService}
 import services.htmlpages.{GoogleDocsHtmlPages, HtmlPages}
@@ -18,7 +18,8 @@ import services.ingest.{IngestApi, IngestApiService}
 import services.redirects.{MovedPageLookup, SqlMovedPageLookup}
 import services.search.{SearchEngine, SearchIndexMediator, SearchItemResolver, SearchToolsIndexMediator}
 import services.storage.{FileStorage, S3FileStorage}
-import views.{FlexmarkMarkdownRendererProvider, MarkdownRenderer}
+import utils.markdown.{CommonmarkMarkdownRenderer, RawMarkdownRenderer, SanitisingMarkdownRenderer}
+import views.MarkdownRenderer
 
 private class SolrIndexProvider @Inject()(config: play.api.Configuration) extends Provider[Index] {
   override def get(): Index = new SolrIndex(utils.serviceBaseUrl("solr", config))
@@ -45,7 +46,8 @@ class AppModule extends AbstractModule {
     bind(classOf[FileStorage]).to(classOf[S3FileStorage])
     bind(classOf[HtmlPages]).to(classOf[GoogleDocsHtmlPages])
     bind(classOf[GuideService]).to(classOf[SqlGuideService])
-    bind(classOf[MarkdownRenderer]).toProvider(classOf[FlexmarkMarkdownRendererProvider])
+    bind(classOf[RawMarkdownRenderer]).to(classOf[CommonmarkMarkdownRenderer])
+    bind(classOf[MarkdownRenderer]).to(classOf[SanitisingMarkdownRenderer])
     bind(classOf[Cypher]).to(classOf[CypherService])
     bind(classOf[IngestApi]).to(classOf[IngestApiService])
   }

--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,9 @@ val coreDependencies = backendDependencies ++ Seq(
   // Markdown rendering
   "com.vladsch.flexmark" % "flexmark-all" % "0.28.10",
 
+  "com.atlassian.commonmark" % "commonmark" % "0.10.0",
+  "com.atlassian.commonmark" % "commonmark-ext-autolink" % "0.10.0",
+
   // HTML sanitising...
   "org.jsoup" % "jsoup" % "1.8.3",
 

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ val coreDependencies = backendDependencies ++ Seq(
   "org.postgresql" % "postgresql" % "42.1.1",
 
   // Markdown rendering
-  "com.vladsch.flexmark" % "flexmark-all" % "0.19.3",
+  "com.vladsch.flexmark" % "flexmark-all" % "0.28.10",
 
   // HTML sanitising...
   "org.jsoup" % "jsoup" % "1.8.3",

--- a/modules/portal/app/utils/markdown/CommonmarkMarkdownRenderer.scala
+++ b/modules/portal/app/utils/markdown/CommonmarkMarkdownRenderer.scala
@@ -1,0 +1,36 @@
+package utils.markdown
+
+import java.util
+
+import org.commonmark.Extension
+import org.commonmark.ext.autolink.AutolinkExtension
+import org.commonmark.node.{Link, Node}
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.{AttributeProvider, AttributeProviderContext, AttributeProviderFactory, HtmlRenderer}
+
+case class CommonmarkMarkdownRenderer() extends RawMarkdownRenderer {
+
+  private class LinkAttributeProvider extends AttributeProvider {
+    override def setAttributes(node: Node, tagName: String, attributes: java.util.Map[String,String]): Unit = {
+      node match {
+        case a: Link =>
+          attributes.put("class", "external")
+          attributes.put("target", "_blank")
+          attributes.put("rel", "nofollow")
+        case _ =>
+      }
+    }
+  }
+
+  private val extensions: util.List[Extension] = util.Arrays.asList(AutolinkExtension.create())
+  private val parser = Parser.builder().extensions(extensions).build()
+  private val renderer = HtmlRenderer.builder()
+    .extensions(extensions)
+    .attributeProviderFactory(new AttributeProviderFactory {
+      override def create(context: AttributeProviderContext): AttributeProvider =
+        new LinkAttributeProvider
+    })
+    .build()
+
+  override def render(markdown: String): String = renderer.render(parser.parse(markdown))
+}

--- a/modules/portal/app/utils/markdown/FlexmarkMarkdownRenderer.scala
+++ b/modules/portal/app/utils/markdown/FlexmarkMarkdownRenderer.scala
@@ -1,6 +1,4 @@
-package views
-
-import javax.inject.{Inject, Provider, Singleton}
+package utils.markdown
 
 import com.vladsch.flexmark.ast.{LinkNode, Node}
 import com.vladsch.flexmark.html.HtmlRenderer.{Builder, HtmlRendererExtension}
@@ -10,12 +8,9 @@ import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.profiles.pegdown.{Extensions, PegdownOptionsAdapter}
 import com.vladsch.flexmark.util.html.Attributes
 import com.vladsch.flexmark.util.options.{DataHolder, MutableDataHolder}
-import org.jsoup.Jsoup
-import org.jsoup.safety.Whitelist
-import play.api.Logger
 
 
-case class FlexmarkMarkdownRenderer() extends MarkdownRenderer {
+case class FlexmarkMarkdownRenderer() extends RawMarkdownRenderer {
   
   private class LinkAttributeProvider extends AttributeProvider {
     override def setAttributes(node: Node, part: AttributablePart, attributes: Attributes): Unit = {
@@ -47,30 +42,5 @@ case class FlexmarkMarkdownRenderer() extends MarkdownRenderer {
   private val parser = Parser.builder(options).build()
   private val renderer = HtmlRenderer.builder(options).build()
 
-  private val whiteListStandard: Whitelist = Whitelist.basic()
-    .addAttributes("a", "target", "_blank")
-    .addAttributes("a", "class", "external")
-    .addAttributes("a", "rel", "nofollow")
-
-  private val whiteListStrict: Whitelist = Whitelist.simpleText()
-    .addTags("p", "a")
-    .addAttributes("a", "target", "_blank")
-    .addAttributes("a", "class", "external")
-    .addAttributes("a", "rel", "nofollow")
-
-  private def render(markdown: String): String = renderer.render(parser.parse(markdown))
-
-  override def renderMarkdown(markdown: String): String =
-    Jsoup.clean(render(markdown), whiteListStandard)
-
-  override def renderUntrustedMarkdown(markdown: String): String =
-    Jsoup.clean(render(markdown), whiteListStrict)
-
-  override def renderTrustedMarkdown(markdown: String): String =
-    render(markdown)
-}
-
-@Singleton
-case class FlexmarkMarkdownRendererProvider @Inject()() extends Provider[MarkdownRenderer] {
-  override lazy val get: MarkdownRenderer = new FlexmarkMarkdownRenderer
+  override def render(markdown: String): String = renderer.render(parser.parse(markdown))
 }

--- a/modules/portal/app/utils/markdown/RawMarkdownRenderer.scala
+++ b/modules/portal/app/utils/markdown/RawMarkdownRenderer.scala
@@ -1,0 +1,8 @@
+package utils.markdown
+
+/**
+  * Markdown renderer which does no sanitisation of HTML output.
+  */
+trait RawMarkdownRenderer {
+  def render(markdown: String): String
+}

--- a/modules/portal/app/utils/markdown/SanitisingMarkdownRenderer.scala
+++ b/modules/portal/app/utils/markdown/SanitisingMarkdownRenderer.scala
@@ -1,0 +1,33 @@
+package utils.markdown
+
+import javax.inject.Inject
+
+import org.jsoup.Jsoup
+import org.jsoup.safety.Whitelist
+import views.MarkdownRenderer
+
+
+case class SanitisingMarkdownRenderer @Inject() (rawMarkdownRenderer: RawMarkdownRenderer) extends MarkdownRenderer {
+
+  private val whiteListStandard: Whitelist = Whitelist.basic()
+    .addAttributes("a", "target", "_blank")
+    .addAttributes("a", "class", "external")
+    .addAttributes("a", "rel", "nofollow")
+
+  private val whiteListStrict: Whitelist = Whitelist.simpleText()
+    .addTags("p", "a")
+    .addAttributes("a", "target", "_blank")
+    .addAttributes("a", "class", "external")
+    .addAttributes("a", "rel", "nofollow")
+
+  private def render(markdown: String): String = rawMarkdownRenderer.render(markdown)
+
+  override def renderMarkdown(markdown: String): String =
+    Jsoup.clean(render(markdown), whiteListStandard)
+
+  override def renderUntrustedMarkdown(markdown: String): String =
+    Jsoup.clean(render(markdown), whiteListStrict)
+
+  override def renderTrustedMarkdown(markdown: String): String =
+    render(markdown)
+}

--- a/modules/portal/test/utils/markdown/CommonmarkMarkdownRendererSpec.scala
+++ b/modules/portal/test/utils/markdown/CommonmarkMarkdownRendererSpec.scala
@@ -1,0 +1,28 @@
+package utils.markdown
+
+import play.api.test.PlaySpecification
+
+class CommonmarkMarkdownRendererSpec extends PlaySpecification {
+  val mdprocessor = new CommonmarkMarkdownRenderer
+
+  "commonmark markdown renderer" should {
+    "parse markdown correctly" in {
+      val md =
+        """
+          |This is some text with a **bold** bit.
+        """.stripMargin
+      mdprocessor.render(md) must contain("<strong>")
+    }
+    "render auto links with _blank target" in {
+      mdprocessor.render(" an http://www.autolink.com link") must contain("_blank")
+    }
+    "render auto links with rel=nofollow" in {
+      mdprocessor.render(" an http://www.autolink.com link") must contain("rel=\"nofollow\"")
+    }
+    "render explicit links with _blank target" in {
+      val s: String = mdprocessor.render(" an [blah](http://www.autolink.com) link")
+      s must contain("_blank")
+      s must contain("blah")
+    }
+  }
+}

--- a/modules/portal/test/utils/markdown/FlexmarkMarkdownRendererSpec.scala
+++ b/modules/portal/test/utils/markdown/FlexmarkMarkdownRendererSpec.scala
@@ -1,0 +1,28 @@
+package utils.markdown
+
+import play.api.test.PlaySpecification
+
+class FlexmarkMarkdownRendererSpec extends PlaySpecification {
+  val mdprocessor = new FlexmarkMarkdownRenderer
+
+  "flexmark markdown renderer" should {
+    "parse markdown correctly" in {
+      val md =
+        """
+          |This is some text with a **bold** bit.
+        """.stripMargin
+      mdprocessor.render(md) must contain("<strong>")
+    }
+    "render auto links with _blank target" in {
+      mdprocessor.render(" an http://www.autolink.com link") must contain("_blank")
+    }
+    "render auto links with rel=nofollow" in {
+      mdprocessor.render(" an http://www.autolink.com link") must contain("rel=\"nofollow\"")
+    }
+    "render explicit links with _blank target" in {
+      val s: String = mdprocessor.render(" an [blah](http://www.autolink.com) link")
+      s must contain("_blank")
+      s must contain("blah")
+    }
+  }
+}

--- a/modules/portal/test/utils/markdown/SanitisingMarkdownRendererSpec.scala
+++ b/modules/portal/test/utils/markdown/SanitisingMarkdownRendererSpec.scala
@@ -1,11 +1,11 @@
-package views
+package utils.markdown
 
 import play.api.test.PlaySpecification
 
-class FlexmarkMarkdownProcessorSpec extends PlaySpecification {
-  val mdprocessor = new FlexmarkMarkdownRenderer
+class SanitisingMarkdownRendererSpec extends PlaySpecification {
+  val mdprocessor = SanitisingMarkdownRenderer(CommonmarkMarkdownRenderer())
 
-  "pegdown markdown processor" should {
+  "sanitising markdown renderer" should {
     "parse markdown correctly" in {
       val md =
         """


### PR DESCRIPTION
 - Split renderer between a 'raw' renderer, and one which does
   sanitisation, which makes it easier to substitute different
   implementations
 - Add a commonmark-java raw renderer implementation, now the
   default

Flexmark is still in place.