### PR TITLE
Select2 fix

### DIFF
--- a/modules/portal/app/assets/css/admin/_admin.less
+++ b/modules/portal/app/assets/css/admin/_admin.less
@@ -316,3 +316,9 @@ a.inline-action:hover {
   }
 }
 
+// Hack to prevent select2 accessibility thing from
+// showing at the bottom of the screen...
+.select2-hidden-accessible {
+  display: none !important;
+  visibility: hidden !important;
+}


### PR DESCRIPTION
Prevent a visible box showing at the bottom of the screen when select2 is clicked