### PR TITLE
Some refactoring of controllers and view data.

### DIFF
--- a/modules/admin/app/controllers/annotation/Annotations.scala
+++ b/modules/admin/app/controllers/annotation/Annotations.scala
@@ -37,7 +37,7 @@ case class Annotations @Inject()(
   def visibility(id: String): Action[AnyContent] = EditVisibilityAction(id).apply { implicit request =>
     Ok(views.html.admin.permissions.visibility(request.item,
       forms.VisibilityForm.form.fill(request.item.accessors.map(_.id)),
-      request.users, request.groups, annotationRoutes.visibilityPost(id)))
+      request.usersAndGroups, annotationRoutes.visibilityPost(id)))
   }
 
   def visibilityPost(id: String): Action[AnyContent] = UpdateVisibilityAction(id).apply { implicit request =>

--- a/modules/admin/app/controllers/authorities/HistoricalAgents.scala
+++ b/modules/admin/app/controllers/authorities/HistoricalAgents.scala
@@ -11,8 +11,8 @@ import models._
 import play.api.i18n.Messages
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import services.data.DataHelpers
-import utils.{PageParams, RangeParams}
 import services.search._
+import utils.{PageParams, RangeParams}
 
 
 @Singleton
@@ -98,7 +98,7 @@ case class HistoricalAgents @Inject()(
   def visibility(id: String): Action[AnyContent] = EditVisibilityAction(id).apply { implicit request =>
     Ok(views.html.admin.permissions.visibility(request.item,
       VisibilityForm.form.fill(request.item.accessors.map(_.id)),
-      request.users, request.groups, histRoutes.visibilityPost(id)))
+      request.usersAndGroups, histRoutes.visibilityPost(id)))
   }
 
   def visibilityPost(id: String): Action[AnyContent] = UpdateVisibilityAction(id).apply { implicit request =>
@@ -113,7 +113,7 @@ case class HistoricalAgents @Inject()(
     }
 
   def addItemPermissions(id: String): Action[AnyContent] = EditItemPermissionsAction(id).apply { implicit request =>
-    Ok(views.html.admin.permissions.permissionItem(request.item, request.users, request.groups,
+    Ok(views.html.admin.permissions.permissionItem(request.item, request.usersAndGroups,
       histRoutes.setItemPermissions))
   }
 

--- a/modules/admin/app/controllers/links/Links.scala
+++ b/modules/admin/app/controllers/links/Links.scala
@@ -94,7 +94,7 @@ case class Links @Inject()(
   def visibility(id: String): Action[AnyContent] = EditVisibilityAction(id).apply { implicit request =>
     Ok(views.html.admin.permissions.visibility(request.item,
         VisibilityForm.form.fill(request.item.accessors.map(_.id)),
-        request.users, request.groups,  linkRoutes.visibilityPost(id)))
+        request.usersAndGroups,  linkRoutes.visibilityPost(id)))
   }
 
   def visibilityPost(id: String): Action[AnyContent] = UpdateVisibilityAction(id).apply { implicit request =>

--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -154,18 +154,17 @@ case class DocumentaryUnits @Inject()(
   def createDoc(id: String): Action[AnyContent] = NewChildAction(id).apply { implicit request =>
     Ok(views.html.admin.documentaryUnit.create(
       request.item, childForm, formDefaults, VisibilityForm.form.fill(request.item.accessors.map(_.id)),
-      request.users, request.groups, docRoutes.createDocPost(id)))
+      request.usersAndGroups, docRoutes.createDocPost(id)))
   }
 
-  def createDocPost(id: String): Action[AnyContent] = CreateChildAction(id, childForm).async { implicit request =>
+  def createDocPost(id: String): Action[AnyContent] = CreateChildAction(id, childForm).apply { implicit request =>
     request.formOrItem match {
-      case Left((errorForm, accForm)) => dataHelpers.getUserAndGroupList.map { case (users, groups) =>
+      case Left((errorForm, accForm, usersAndGroups)) =>
         BadRequest(views.html.admin.documentaryUnit.create(request.item,
-          errorForm, formDefaults, accForm, users, groups,
+          errorForm, formDefaults, accForm, usersAndGroups,
           docRoutes.createDocPost(id)))
-      }
-      case Right(doc) => immediate(Redirect(docRoutes.get(doc.id))
-        .flashing("success" -> "item.create.confirmation"))
+      case Right(doc) => Redirect(docRoutes.get(doc.id))
+        .flashing("success" -> "item.create.confirmation")
     }
   }
 
@@ -229,7 +228,7 @@ case class DocumentaryUnits @Inject()(
   def visibility(id: String): Action[AnyContent] = EditVisibilityAction(id).apply { implicit request =>
     Ok(views.html.admin.permissions.visibility(request.item,
       VisibilityForm.form.fill(request.item.accessors.map(_.id)),
-      request.users, request.groups, docRoutes.visibilityPost(id)))
+      request.usersAndGroups, docRoutes.visibilityPost(id)))
   }
 
   def visibilityPost(id: String): Action[AnyContent] = UpdateVisibilityAction(id).apply { implicit request =>
@@ -246,12 +245,12 @@ case class DocumentaryUnits @Inject()(
     }
 
   def addItemPermissions(id: String): Action[AnyContent] = EditItemPermissionsAction(id).apply { implicit request =>
-    Ok(views.html.admin.permissions.permissionItem(request.item, request.users, request.groups,
+    Ok(views.html.admin.permissions.permissionItem(request.item, request.usersAndGroups,
       docRoutes.setItemPermissions))
   }
 
   def addScopedPermissions(id: String): Action[AnyContent] = EditItemPermissionsAction(id).apply { implicit request =>
-    Ok(views.html.admin.permissions.permissionScope(request.item, request.users, request.groups,
+    Ok(views.html.admin.permissions.permissionScope(request.item, request.usersAndGroups,
       docRoutes.setScopedPermissions))
   }
 

--- a/modules/admin/app/controllers/users/UserProfiles.scala
+++ b/modules/admin/app/controllers/users/UserProfiles.scala
@@ -361,7 +361,7 @@ case class UserProfiles @Inject()(
     }
 
   def addItemPermissions(id: String): Action[AnyContent] = EditItemPermissionsAction(id).apply { implicit request =>
-    Ok(views.html.admin.permissions.permissionItem(request.item, request.users, request.groups,
+    Ok(views.html.admin.permissions.permissionItem(request.item, request.usersAndGroups,
         userRoutes.setItemPermissions))
   }
 

--- a/modules/admin/app/views/admin/authoritativeSet/create.scala.html
+++ b/modules/admin/app/views/admin/authoritativeSet/create.scala.html
@@ -1,10 +1,10 @@
-@(f: Form[models.AuthoritativeSetF], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(f: Form[models.AuthoritativeSetF], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @views.html.admin.layout.rightSidebar(Messages("authoritativeSet.create")) {
 	@helper.form(action = action, 'class -> "entity-form form-horizontal") {
         @formHelpers.csrfToken()
         @form(None, f)
-        @views.html.admin.permissions.visibilityForm(vf, users, groups)
+        @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("authoritativeSet.create.submit"))
 	}

--- a/modules/admin/app/views/admin/concept/create.scala.html
+++ b/modules/admin/app/views/admin/concept/create.scala.html
@@ -1,4 +1,4 @@
-@(item: models.base.AnyModel, f: play.api.data.Form[models.ConceptF], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(item: models.base.AnyModel, f: play.api.data.Form[models.ConceptF], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
  
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
@@ -25,7 +25,7 @@
         @formHelpers.csrfToken()
         @form(None, f)
 
-        @views.html.admin.permissions.visibilityForm(vf, users, groups)
+        @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("cvocConcept.create.submit"), cancel = views.admin.Helpers.linkToOpt(item))
 	}

--- a/modules/admin/app/views/admin/country/create.scala.html
+++ b/modules/admin/app/views/admin/country/create.scala.html
@@ -1,10 +1,10 @@
-@(f: Form[models.CountryF], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(f: Form[models.CountryF], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @views.html.admin.layout.rightSidebar(Messages("country.create")) {
 	@helper.form(action = action, 'class -> "entity-form form-horizontal") {
         @formHelpers.csrfToken()
         @form(None, f)
-        @views.html.admin.permissions.visibilityForm(vf, users, groups)
+        @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("country.create.submit"))
 	}

--- a/modules/admin/app/views/admin/documentaryUnit/create.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/create.scala.html
@@ -1,4 +1,4 @@
-@(item: models.base.AnyModel, f: Form[DocumentaryUnitF], defaults: Option[play.api.Configuration], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(item: models.base.AnyModel, f: Form[DocumentaryUnitF], defaults: Option[play.api.Configuration], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
@@ -24,7 +24,7 @@
         @formHelpers.csrfToken()
 		@views.html.admin.documentaryUnit.form(f, defaults)
 
-        @views.html.admin.permissions.visibilityForm(vf, users, groups)
+        @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
 		@formHelpers.submitButtonWithLogMessageInput(Messages("documentaryUnit.create.submit"), cancel = views.admin.Helpers.linkToOpt(item))
 	}
 } {

--- a/modules/admin/app/views/admin/group/create.scala.html
+++ b/modules/admin/app/views/admin/group/create.scala.html
@@ -1,10 +1,10 @@
-@(f: Form[models.GroupF], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(f: Form[models.GroupF], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @views.html.admin.layout.rightSidebar(Messages("group.create")) {
 	@helper.form(action = action, 'class -> "entity-form form-horizontal") {
         @formHelpers.csrfToken()
         @form(None, f)
-        @memberForm(users, groups)
+        @views.html.admin.group.memberForm(usersAndGroups)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("group.create.submit"))
 	}

--- a/modules/admin/app/views/admin/group/memberForm.scala.html
+++ b/modules/admin/app/views/admin/group/memberForm.scala.html
@@ -1,4 +1,4 @@
-@(users: Seq[(String,String)], groups: Seq[(String,String)])(implicit messages: Messages, md: views.MarkdownRenderer)
+@(usersAndGroups: UsersAndGroups)(implicit messages: Messages, md: views.MarkdownRenderer)
 
 @import services.data.Constants.MEMBER
 
@@ -7,12 +7,12 @@
     <div class="control-elements">
         <select class="form-control select2" name="@{MEMBER}[]" multiple id="id_group_members">
             <optgroup label="@Messages("contentTypes.UserProfile")">
-            @users.map { case (id,name) =>
+            @usersAndGroups.users.map { case (id,name) =>
             <option value="@id">@name (@id)</option>
             }
             </optgroup>
             <optgroup label="@Messages("contentTypes.Group")">
-            @groups.map { case (id,name) =>
+            @usersAndGroups.groups.map { case (id,name) =>
             <option value="@id">@name</option>
             }
             </optgroup>

--- a/modules/admin/app/views/admin/historicalAgent/create.scala.html
+++ b/modules/admin/app/views/admin/historicalAgent/create.scala.html
@@ -1,4 +1,4 @@
-@(item: AuthoritativeSet, f: Form[HistoricalAgentF], defaults: Option[play.api.Configuration], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(item: AuthoritativeSet, f: Form[HistoricalAgentF], defaults: Option[play.api.Configuration], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
@@ -14,7 +14,7 @@
                 @formHelpers.enumChoiceInput(f(PUBLICATION_STATUS), PublicationStatus, Messages(PUBLICATION_STATUS))
             }
 
-            @views.html.admin.permissions.visibilityForm(vf, users, groups)
+            @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
         }
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("historicalAgent.create.submit"), cancel = views.admin.Helpers.linkToOpt(item))

--- a/modules/admin/app/views/admin/permissions/permissionItem.scala.html
+++ b/modules/admin/app/views/admin/permissions/permissionItem.scala.html
@@ -1,4 +1,4 @@
-@(item: models.base.Accessible, users: Seq[(String,String)], groups: Seq[(String,String)], action: (String, defines.EntityType.Value,String) => Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, prefs: utils.SessionPrefs, flash: Flash)
+@(item: models.base.Accessible, usersAndGroups: UsersAndGroups, action: (String, defines.EntityType.Value,String) => Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, prefs: utils.SessionPrefs, flash: Flash)
 
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
@@ -8,10 +8,10 @@
         @Messages("permissions.itemLevel.manage.info")
     </div>
 
-    @if(groups.nonEmpty) {
+    @if(usersAndGroups.groups.nonEmpty) {
         <strong>@Messages("contentTypes.Group"): </strong>&nbsp;
         <ul>
-        @groups.map { case (id, name) =>
+        @usersAndGroups.groups.map { case (id, name) =>
         <li>
             <a href="@action(item.id, defines.EntityType.Group, id)">@name</a>
         </li>
@@ -20,10 +20,10 @@
         <hr />
     }
 
-    @if(users.nonEmpty) {
+    @if(usersAndGroups.users.nonEmpty) {
         <strong>@Messages("contentTypes.UserProfile"): </strong>&nbsp;
         <ul>
-        @users.map { case (id, name) =>
+        @usersAndGroups.users.map { case (id, name) =>
         <li>
             <a href="@action(item.id, defines.EntityType.UserProfile, id)">@name</a>
         </li>

--- a/modules/admin/app/views/admin/permissions/permissionScope.scala.html
+++ b/modules/admin/app/views/admin/permissions/permissionScope.scala.html
@@ -1,4 +1,4 @@
-@(item: models.base.Accessible, users: Seq[(String,String)], groups: Seq[(String,String)], action: (String, defines.EntityType.Value,String) => Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, prefs: utils.SessionPrefs, flash: Flash)
+@(item: models.base.Accessible, usersAndGroups: UsersAndGroups, action: (String, defines.EntityType.Value,String) => Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, prefs: utils.SessionPrefs, flash: Flash)
 
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
@@ -8,10 +8,10 @@
         @Messages("permissions.scopeLevel.manage.info")
     </div>
 
-    @if(groups.nonEmpty) {
+    @if(usersAndGroups.groups.nonEmpty) {
         <strong>@Messages("contentTypes.Group"): </strong>&nbsp;
         <ul>
-        @groups.map { case (id, name) =>
+        @usersAndGroups.groups.map { case (id, name) =>
         <li>
             <a href="@action(item.id, defines.EntityType.Group, id)">@name</a>
         </li>
@@ -20,10 +20,10 @@
         <hr />
     }
 
-    @if(users.nonEmpty) {
+    @if(usersAndGroups.users.nonEmpty) {
         <strong>@Messages("contentTypes.UserProfile"): </strong>&nbsp;
         <ul>
-        @users.map { case (id, name) =>
+        @usersAndGroups.users.map { case (id, name) =>
         <li>
             <a href="@action(item.id, defines.EntityType.UserProfile, id)">@name</a>
         </li>

--- a/modules/admin/app/views/admin/permissions/visibility.scala.html
+++ b/modules/admin/app/views/admin/permissions/visibility.scala.html
@@ -1,4 +1,4 @@
-@(item: models.base.Accessible, f: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(item: models.base.Accessible, f: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @views.html.admin.layout.rightSidebar(Messages("visibility.update"), breadcrumbs = views.html.admin.common.breadcrumbs(List(item))) {
     @if(item.accessors.isEmpty) {
@@ -21,7 +21,7 @@
 
     @helper.form(action = action, 'class -> "entity-form form-horizontal") {
         @formHelpers.csrfToken()
-        @visibilityForm(f, users, groups)
+        @views.html.admin.permissions.visibilityForm(f, usersAndGroups)
         @formHelpers.submitButtonWithLogMessageInput(Messages("visibility.update.submit"), cancel = views.admin.Helpers.linkToOpt(item))
     }
 } {

--- a/modules/admin/app/views/admin/permissions/visibilityForm.scala.html
+++ b/modules/admin/app/views/admin/permissions/visibilityForm.scala.html
@@ -1,4 +1,4 @@
-@(f: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)])(implicit req: RequestHeader, messages: Messages)
+@(f: Form[Seq[String]], usersAndGroups: UsersAndGroups)(implicit req: RequestHeader, messages: Messages)
 
 @import services.data.Constants.ACCESSOR_PARAM
 
@@ -9,7 +9,7 @@
         <div class="control-elements">
             <select class="form-control select2" data-placeholder="@Messages("visibility.chooseGroups")" multiple
             name="@(ACCESSOR_PARAM)[]">
-            @groups.map{ case(id, name) =>
+            @usersAndGroups.groups.map{ case(id, name) =>
                 <option value="@id" @(if(f.value.exists(_.contains(id))) "selected")>@name</option>
             }
             </select>
@@ -20,7 +20,7 @@
         <div class="control-elements">
             <select class="form-control select2" data-placeholder="@Messages("visibility.chooseUsers")" multiple
             name="@(ACCESSOR_PARAM)[]">
-            @users.map { case(id, name) =>
+            @usersAndGroups.users.map { case(id, name) =>
                 <option value="@id" @(if(f.value.exists(_.contains(id))) "selected")>@name</option>
             }
             </select>

--- a/modules/admin/app/views/admin/repository/create.scala.html
+++ b/modules/admin/app/views/admin/repository/create.scala.html
@@ -1,4 +1,4 @@
-@(item: Country, f: Form[RepositoryF], defaults: Option[play.api.Configuration], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(item: Country, f: Form[RepositoryF], defaults: Option[play.api.Configuration], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
@@ -6,7 +6,7 @@
 	@helper.form(action = action, 'class -> "entity-form form-horizontal") {
         @formHelpers.csrfToken()
         @form(f, defaults)
-        @views.html.admin.permissions.visibilityForm(vf, users, groups)
+        @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
         @formHelpers.submitButtonWithLogMessageInput(Messages("repository.create.submit"), cancel = views.admin.Helpers.linkToOpt(item))
 	}
 } {

--- a/modules/admin/app/views/admin/virtualUnit/create.scala.html
+++ b/modules/admin/app/views/admin/virtualUnit/create.scala.html
@@ -1,4 +1,4 @@
-@(item: Option[AnyModel], f: Form[VirtualUnitF], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(item: Option[models.base.AnyModel], f: Form[VirtualUnitF], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
@@ -16,7 +16,7 @@
         @formHelpers.csrfToken()
 		@form(f)
 
-        @views.html.admin.permissions.visibilityForm(vf, users, groups)
+        @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
         @formHelpers.submitButtonWithLogMessageInput(Messages("virtualUnit.create.submit"), cancel = item.map(i => views.admin.Helpers.linkTo(i)))
     }
 } {

--- a/modules/admin/app/views/admin/vocabulary/create.scala.html
+++ b/modules/admin/app/views/admin/vocabulary/create.scala.html
@@ -1,10 +1,10 @@
-@(f: Form[models.VocabularyF], vf: Form[Seq[String]], users: Seq[(String,String)], groups: Seq[(String,String)], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
+@(f: Form[models.VocabularyF], vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
 @views.html.admin.layout.rightSidebar(Messages("cvocVocabulary.create")) {
 	@helper.form(action = action, 'class -> "entity-form form-horizontal") {
         @formHelpers.csrfToken()
         @form(None, f)
-        @views.html.admin.permissions.visibilityForm(vf, users, groups)
+        @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("cvocVocabulary.create.submit"))
 	}

--- a/modules/backend/src/main/scala/models/UsersAndGroups.scala
+++ b/modules/backend/src/main/scala/models/UsersAndGroups.scala
@@ -1,0 +1,13 @@
+package models
+
+/**
+  * Data about the available users and groups in the
+  * system.
+  *
+  * @param users  a list of user IDs to names
+  * @param groups a list of group IDs to names
+  */
+case class UsersAndGroups(
+  users: Seq[(String, String)],
+  groups: Seq[(String, String)]
+)

--- a/modules/backend/src/main/scala/services/data/DataHelpers.scala
+++ b/modules/backend/src/main/scala/services/data/DataHelpers.scala
@@ -3,6 +3,7 @@ package services.data
 import javax.inject.{Inject, Singleton}
 
 import defines.EntityType
+import models.UsersAndGroups
 import play.api.libs.json.JsValue
 import services.cypher.Cypher
 
@@ -28,9 +29,9 @@ case class DataHelpers @Inject()(cypher: Cypher)(implicit executionContext: Exec
     .cypher(s"MATCH (n:${EntityType.UserProfile}) WHERE n.active AND n.staff RETURN n.__id, n.name")
     .map(parseIds)
 
-  def getUserAndGroupList: Future[(Seq[(String, String)], Seq[(String, String)])] = {
+  def getUserAndGroupList: Future[UsersAndGroups] = {
     val usersF = getUserList
     val groupsF = getGroupList
-    for (users <- usersF; groups <- groupsF) yield (users, groups)
+    for (users <- usersF; groups <- groupsF) yield UsersAndGroups(users, groups)
   }
 }

--- a/modules/core/app/controllers/generic/Create.scala
+++ b/modules/core/app/controllers/generic/Create.scala
@@ -1,19 +1,18 @@
 package controllers.generic
 
-import services.data.{ContentType, DataHelpers, ValidationError, Writable}
+import services.data._
 import defines.PermissionType
 import forms.VisibilityForm
-import models.UserProfile
+import models.{UserProfile, UsersAndGroups}
 import models.base.{MetaModel, Model, Persistable}
 import play.api.data._
 import play.api.mvc._
 
 import scala.concurrent.Future
-import scala.concurrent.Future.{successful => immediate}
 
 /**
- * Controller trait for creating AccessibleEntities.
- */
+  * Controller trait for creating [[models.base.Accessible]] ites..
+  */
 trait Create[F <: Model with Persistable, MT <: MetaModel[F]] extends Write {
 
   this: Read[MT] =>
@@ -21,24 +20,23 @@ trait Create[F <: Model with Persistable, MT <: MetaModel[F]] extends Write {
   protected def dataHelpers: DataHelpers
 
   /**
-   * A request containing id->name tuples for available users
-   * and groups.
-   * @param users a seq of id -> name tuples for users on the system
-   * @param groups a seq of id -> name tuples for users on the system
-   * @param user a profile
-   * @param request the underlying request
-   * @tparam A the type of the underlying request
-   */
+    * A request containing id->name tuples for available users
+    * and groups.
+    *
+    * @param usersAndGroups data about user and groups
+    * @param user           a profile
+    * @param request        the underlying request
+    * @tparam A the type of the underlying request
+    */
   case class UserGroupsRequest[A](
-    users: Seq[(String,String)],
-    groups: Seq[(String,String)],
+    usersAndGroups: UsersAndGroups,
     user: UserProfile,
     request: Request[A]
   ) extends WrappedRequest[A](request)
     with WithUser
 
   case class CreateRequest[A](
-    formOrItem: Either[(Form[F],Form[Seq[String]]),MT],
+    formOrItem: Either[(Form[F], Form[Seq[String]], UsersAndGroups), MT],
     user: UserProfile,
     request: Request[A]
   ) extends WrappedRequest[A](request)
@@ -47,31 +45,35 @@ trait Create[F <: Model with Persistable, MT <: MetaModel[F]] extends Write {
   protected def NewItemAction(implicit ct: ContentType[MT]): ActionBuilder[UserGroupsRequest, AnyContent] =
     WithContentPermissionAction(PermissionType.Create, ct.contentType) andThen new CoreActionTransformer[WithUserRequest, UserGroupsRequest] {
       override protected def transform[A](request: WithUserRequest[A]): Future[UserGroupsRequest[A]] = {
-        dataHelpers.getUserAndGroupList.map { case (users, groups) =>
-          UserGroupsRequest(users, groups, request.user, request)
+        dataHelpers.getUserAndGroupList.map { usersAndGroups =>
+          UserGroupsRequest(usersAndGroups, request.user, request)
         }
       }
     }
 
-  protected def CreateItemAction(form: Form[F], pf: Request[_] => Map[String,Seq[String]] = _ => Map.empty)(
+  protected def CreateItemAction(form: Form[F], pf: Request[_] => Map[String, Seq[String]] = _ => Map.empty)(
     implicit fmt: Writable[F], ct: ContentType[MT]): ActionBuilder[CreateRequest, AnyContent] =
     WithContentPermissionAction(PermissionType.Create, ct.contentType) andThen new CoreActionTransformer[WithUserRequest, CreateRequest] {
       def transform[A](request: WithUserRequest[A]): Future[CreateRequest[A]] = {
-        implicit val req = request
+        implicit val req: WithUserRequest[A] = request
         val visForm = VisibilityForm.form.bindFromRequest
         form.bindFromRequest.fold(
-          errorForm => immediate(CreateRequest(Left((errorForm, visForm)), request.user, request.request)),
+          errorForm => dataHelpers.getUserAndGroupList.map { usersAndGroups =>
+            CreateRequest(Left((errorForm, visForm, usersAndGroups)), request.user, request.request)
+          },
           doc => {
             val accessors = visForm.value.getOrElse(Nil)
             userDataApi.create(doc, accessors, params = pf(request), logMsg = getLogMessage).map { item =>
               CreateRequest(Right(item), request.user, request)
-            } recover {
+            } recoverWith {
               // If we have an error, check if it's a validation error.
               // If so, we need to merge those errors back into the form
               // and redisplay it...
               case ValidationError(errorSet) =>
                 val filledForm = doc.getFormErrors(errorSet, form.fill(doc))
-                CreateRequest(Left((filledForm, visForm)), request.user, request)
+                dataHelpers.getUserAndGroupList.map { usersAndGroups =>
+                  CreateRequest(Left((filledForm, visForm, usersAndGroups)), request.user, request)
+                }
             }
           }
         )

--- a/modules/core/app/controllers/generic/Delete.scala
+++ b/modules/core/app/controllers/generic/Delete.scala
@@ -7,19 +7,19 @@ import services.data.ContentType
 import scala.concurrent.Future
 
 /**
-  * Controller trait for deleting AccessibleEntities.
+  * Controller trait for deleting [[models.base.Accessible]] items.
   */
 trait Delete[MT] extends Write {
 
   self: Read[MT] =>
 
-  protected def CheckDeleteAction(id: String)(implicit ct: ContentType[MT]) =
+  protected def CheckDeleteAction(id: String)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Delete)
 
   private[generic] def DeleteTransformer(id: String)(implicit ct: ContentType[MT]) =
     new CoreActionTransformer[ItemPermissionRequest, OptionalUserRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[OptionalUserRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.delete(id, logMsg = getLogMessage).map { _ =>
           OptionalUserRequest(request.userOpt, request)
         }

--- a/modules/core/app/controllers/generic/Descriptions.scala
+++ b/modules/core/app/controllers/generic/Descriptions.scala
@@ -39,7 +39,7 @@ trait Descriptions[D <: Description with Persistable, T <: Model with Described[
     implicit fmt: Writable[D], ct: ContentType[MT]): ActionBuilder[ManageDescriptionRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Update) andThen new CoreActionTransformer[ItemPermissionRequest, ManageDescriptionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ManageDescriptionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         form.bindFromRequest.fold(
           ef => immediate(ManageDescriptionRequest(request.item, Left(ef), request.userOpt, request)),
           desc => userDataApi.createDescription(id, desc, logMsg = getLogMessage).map { updated =>
@@ -57,7 +57,7 @@ trait Descriptions[D <: Description with Persistable, T <: Model with Described[
     implicit fmt: Writable[D], ct: ContentType[MT]): ActionBuilder[ManageDescriptionRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Update) andThen new CoreActionTransformer[ItemPermissionRequest, ManageDescriptionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ManageDescriptionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         form.bindFromRequest.fold(
           ef => immediate(ManageDescriptionRequest(request.item, Left(ef), request.userOpt, request)),
           desc => userDataApi.updateDescription(id, did, desc, logMsg = getLogMessage).map { updated =>
@@ -85,7 +85,7 @@ trait Descriptions[D <: Description with Persistable, T <: Model with Described[
   protected def DeleteDescriptionAction(id: String, did: String)(implicit ct: ContentType[MT]): ActionBuilder[OptionalUserRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Update) andThen new CoreActionTransformer[ItemPermissionRequest, OptionalUserRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[OptionalUserRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.deleteDescription(id, did, logMsg = getLogMessage).map { _ =>
           OptionalUserRequest(request.userOpt, request)
         }

--- a/modules/core/app/controllers/generic/ItemPermissions.scala
+++ b/modules/core/app/controllers/generic/ItemPermissions.scala
@@ -38,7 +38,7 @@ trait ItemPermissions[MT] extends Visibility[MT] {
   protected def PermissionGrantAction(id: String, paging: PageParams)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionGrantRequest, AnyContent] =
     WithGrantPermission(id) andThen new CoreActionTransformer[ItemPermissionRequest, ItemPermissionGrantRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ItemPermissionGrantRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.itemPermissionGrants[PermissionGrant](id, paging).map { permGrants =>
           ItemPermissionGrantRequest(request.item, permGrants, request.userOpt, request)
         }
@@ -52,7 +52,7 @@ trait ItemPermissions[MT] extends Visibility[MT] {
     implicit ct: ContentType[MT]): ActionBuilder[SetItemPermissionRequest, AnyContent] =
     WithGrantPermission(id) andThen new CoreActionTransformer[ItemPermissionRequest, SetItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[SetItemPermissionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         val accessorF = userDataApi.get[Accessor](Accessor.resourceFor(userType), userId)
         val permsF = userDataApi.itemPermissions(userId, ct.contentType, id)
         for {
@@ -72,7 +72,7 @@ trait ItemPermissions[MT] extends Visibility[MT] {
     implicit ct: ContentType[MT]): ActionBuilder[SetItemPermissionRequest, AnyContent] =
     WithGrantPermission(id) andThen new CoreActionTransformer[ItemPermissionRequest, SetItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[SetItemPermissionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         val data = getData(request).getOrElse(Map.empty)
         val perms: Seq[String] = data.getOrElse(ct.contentType.toString, Seq.empty)
         for {

--- a/modules/core/app/controllers/generic/Membership.scala
+++ b/modules/core/app/controllers/generic/Membership.scala
@@ -54,7 +54,7 @@ trait Membership[MT <: Accessor] extends Read[MT] {
   protected def CheckManageGroupAction(id: String, groupId: String)(implicit ct: ContentType[MT]): ActionBuilder[ManageGroupRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Grant) andThen new CoreActionTransformer[ItemPermissionRequest, ManageGroupRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ManageGroupRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.get[Group](groupId).map { group =>
           ManageGroupRequest(request.item, group, request.userOpt, request)
         }
@@ -64,7 +64,7 @@ trait Membership[MT <: Accessor] extends Read[MT] {
   protected def AddToGroupAction(id: String, groupId: String)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionRequest, AnyContent] =
     MustBelongTo(groupId) andThen WithItemPermissionAction(id, PermissionType.Grant) andThen new CoreActionTransformer[ItemPermissionRequest, ItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ItemPermissionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.addGroup[Group, MT](groupId, id).map(_ => request)
       }
     }
@@ -72,7 +72,7 @@ trait Membership[MT <: Accessor] extends Read[MT] {
   protected def RemoveFromGroupAction(id: String, groupId: String)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionRequest, AnyContent] =
     MustBelongTo(groupId) andThen WithItemPermissionAction(id, PermissionType.Grant) andThen new CoreActionTransformer[ItemPermissionRequest, ItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ItemPermissionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.removeGroup[Group, MT](groupId, id).map(_ => request)
       }
     }

--- a/modules/core/app/controllers/generic/PermissionHolder.scala
+++ b/modules/core/app/controllers/generic/PermissionHolder.scala
@@ -43,7 +43,7 @@ trait PermissionHolder[MT <: Accessor] extends Read[MT] {
   protected def GrantListAction(id: String, paging: PageParams)(implicit ct: ContentType[MT]): ActionBuilder[HolderPermissionGrantRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Grant) andThen new CoreActionTransformer[ItemPermissionRequest, HolderPermissionGrantRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[HolderPermissionGrantRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.permissionGrants[PermissionGrant](id, paging).map { perms =>
           HolderPermissionGrantRequest(request.item, perms, request.userOpt, request)
         }
@@ -59,7 +59,7 @@ trait PermissionHolder[MT <: Accessor] extends Read[MT] {
   protected def CheckGlobalPermissionsAction(id: String)(implicit ct: ContentType[MT]): ActionBuilder[GlobalPermissionSetRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Grant) andThen new CoreActionTransformer[ItemPermissionRequest, GlobalPermissionSetRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[GlobalPermissionSetRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.globalPermissions(id).map { perms =>
           GlobalPermissionSetRequest(request.item, perms, request.userOpt, request)
         }
@@ -69,7 +69,7 @@ trait PermissionHolder[MT <: Accessor] extends Read[MT] {
   protected def SetGlobalPermissionsAction(id: String)(implicit ct: ContentType[MT]): ActionBuilder[GlobalPermissionSetRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Grant) andThen new CoreActionTransformer[ItemPermissionRequest, GlobalPermissionSetRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[GlobalPermissionSetRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         val data = getData(request).getOrElse(Map.empty)
         val perms: Map[String, Seq[String]] = ContentTypes.values.toSeq.map { ct =>
           ct.toString -> data.getOrElse(ct.toString, Seq.empty)
@@ -83,7 +83,7 @@ trait PermissionHolder[MT <: Accessor] extends Read[MT] {
   protected def CheckRevokePermissionAction(id: String, permId: String)(implicit ct: ContentType[MT]): ActionBuilder[PermissionGrantRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Grant) andThen new CoreActionTransformer[ItemPermissionRequest, PermissionGrantRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[PermissionGrantRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.get[PermissionGrant](permId).map { perm =>
           PermissionGrantRequest(request.item, perm, request.userOpt, request)
         }
@@ -93,7 +93,7 @@ trait PermissionHolder[MT <: Accessor] extends Read[MT] {
   protected def RevokePermissionAction(id: String, permId: String)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionRequest, AnyContent] =
     WithItemPermissionAction(id, PermissionType.Grant) andThen new CoreActionTransformer[ItemPermissionRequest, ItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ItemPermissionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         userDataApi.delete[PermissionGrant](permId).map(_ => request)
       }
     }

--- a/modules/core/app/controllers/generic/Promotion.scala
+++ b/modules/core/app/controllers/generic/Promotion.scala
@@ -1,6 +1,7 @@
 package controllers.generic
 
 import defines.PermissionType
+import models.UserProfile
 import play.api.mvc._
 import services.data.ContentType
 
@@ -19,7 +20,7 @@ trait Promotion[MT] {
   protected def PromoteItemAction(id: String)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionRequest, AnyContent] =
     EditPromotionAction(id) andThen new CoreActionTransformer[ItemPermissionRequest, ItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ItemPermissionRequest[A]] = {
-        implicit val userOpt = request.userOpt
+        implicit val user: Option[UserProfile] = request.userOpt
         userDataApi.promote(id).map { updated =>
           ItemPermissionRequest(updated, request.userOpt, request)
         }
@@ -29,7 +30,7 @@ trait Promotion[MT] {
   protected def RemovePromotionAction(id: String)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionRequest, AnyContent] =
     EditPromotionAction(id) andThen new CoreActionTransformer[ItemPermissionRequest, ItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ItemPermissionRequest[A]] = {
-        implicit val userOpt = request.userOpt
+        implicit val user: Option[UserProfile] = request.userOpt
         userDataApi.removePromotion(id).map { updated =>
           ItemPermissionRequest(updated, request.userOpt, request)
         }
@@ -39,7 +40,7 @@ trait Promotion[MT] {
   protected def DemoteItemAction(id: String)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionRequest, AnyContent] =
     EditPromotionAction(id) andThen new CoreActionTransformer[ItemPermissionRequest, ItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ItemPermissionRequest[A]] = {
-        implicit val userOpt = request.userOpt
+        implicit val user: Option[UserProfile] = request.userOpt
         userDataApi.demote(id).map { updated =>
           ItemPermissionRequest(updated, request.userOpt, request)
         }
@@ -49,7 +50,7 @@ trait Promotion[MT] {
   protected def RemoveDemotionAction(id: String)(implicit ct: ContentType[MT]): ActionBuilder[ItemPermissionRequest, AnyContent] =
     EditPromotionAction(id) andThen new CoreActionTransformer[ItemPermissionRequest, ItemPermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ItemPermissionRequest[A]] = {
-        implicit val userOpt = request.userOpt
+        implicit val user: Option[UserProfile] = request.userOpt
         userDataApi.removeDemotion(id).map { updated =>
           ItemPermissionRequest(updated, request.userOpt, request)
         }

--- a/modules/core/app/controllers/generic/ScopePermissions.scala
+++ b/modules/core/app/controllers/generic/ScopePermissions.scala
@@ -38,7 +38,7 @@ trait ScopePermissions[MT] extends ItemPermissions[MT] {
   protected def ScopePermissionGrantAction(id: String, itemPaging: PageParams, scopePaging: PageParams)(implicit ct: ContentType[MT]): ActionBuilder[ScopePermissionGrantRequest, AnyContent] =
     WithGrantPermission(id) andThen new CoreActionTransformer[ItemPermissionRequest, ScopePermissionGrantRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[ScopePermissionGrantRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         for {
           permGrants <- userDataApi.itemPermissionGrants[PermissionGrant](id, itemPaging)
           scopeGrants <- userDataApi.scopePermissionGrants[PermissionGrant](id, scopePaging)
@@ -50,7 +50,7 @@ trait ScopePermissions[MT] extends ItemPermissions[MT] {
     implicit ct: ContentType[MT]): ActionBuilder[SetScopePermissionRequest, AnyContent] =
     WithGrantPermission(id) andThen new CoreActionTransformer[ItemPermissionRequest, SetScopePermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[SetScopePermissionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         val accessorF = userDataApi.get[Accessor](Accessor.resourceFor(userType), userId)
         val permsF = userDataApi.scopePermissions(userId, id)
         for {
@@ -65,7 +65,7 @@ trait ScopePermissions[MT] extends ItemPermissions[MT] {
     implicit ct: ContentType[MT]): ActionBuilder[SetScopePermissionRequest, AnyContent] =
     WithGrantPermission(id) andThen new CoreActionTransformer[ItemPermissionRequest, SetScopePermissionRequest] {
       override protected def transform[A](request: ItemPermissionRequest[A]): Future[SetScopePermissionRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         val data = getData(request).getOrElse(Map.empty)
         val perms: Map[String, Seq[String]] = targetContentTypes.map { ct =>
           ct.toString -> data.getOrElse(ct.toString, Seq.empty)

--- a/modules/core/app/controllers/generic/SearchType.scala
+++ b/modules/core/app/controllers/generic/SearchType.scala
@@ -30,7 +30,7 @@ trait SearchType[MT] extends Read[MT] with Search {
     facetBuilder: FacetBuilder = emptyFacets)(implicit ct: ContentType[MT]): ActionBuilder[SearchTypeRequest, AnyContent] =
     OptionalUserAction andThen new CoreActionTransformer[OptionalUserRequest, SearchTypeRequest] {
       override protected def transform[A](request: OptionalUserRequest[A]): Future[SearchTypeRequest[A]] = {
-        implicit val r = request
+        implicit val req: OptionalUserRequest[A] = request
         findType[MT](params, paging, filters, extra, sort, facetBuilder = facetBuilder).map { result =>
           SearchTypeRequest(result, request.userOpt, request)
         }

--- a/modules/core/app/controllers/generic/Update.scala
+++ b/modules/core/app/controllers/generic/Update.scala
@@ -32,7 +32,7 @@ trait Update[F <: Model with Persistable, MT <: MetaModel[F]] extends Write {
     implicit ct: ContentType[MT], wd: Writable[F]): ActionBuilder[UpdateRequest, AnyContent] =
     EditAction(id) andThen new CoreActionTransformer[ItemPermissionRequest, UpdateRequest] {
       def transform[A](request: ItemPermissionRequest[A]): Future[UpdateRequest[A]] = {
-        implicit val req = request
+        implicit val req: ItemPermissionRequest[A] = request
         form.bindFromRequest.fold(
           errorForm => immediate(UpdateRequest(request.item, Left(errorForm), request.userOpt, request.request)),
           mod => {


### PR DESCRIPTION
 - make a specific data structure for the lists of user and group id/name pairs since this is used a lot
 - when re-rendering creation forms, look up the user/group info in the action builder since this simplifies controllers