### PR TITLE
Add rel='nofollow' to search ordering and facet links

### DIFF
--- a/modules/portal/app/views/common/listSorting.scala.html
+++ b/modules/portal/app/views/common/listSorting.scala.html
@@ -7,13 +7,11 @@
     @options.map { case (sortKey, i18nKey) =>
         @defining((Messages(i18nKey), Messages(i18nKey + ".title"))) { case (name, title) =>
             @if(current.contains(sortKey)) {
-                <a class="current-search-sort btn btn-xs btn-default btn-active" title="@title"
-                href="@utils.http.joinPath(req.path, req.queryString.filterKeys(_ != SearchParams.SORT))">
+                <a rel="nofollow" class="current-search-sort btn btn-xs btn-default btn-active" title="@title" href="@utils.http.joinPath(req.path, req.queryString.filterKeys(_ != SearchParams.SORT))">
                 @name
                 </a>
             } else {
-                <a class="btn btn-xs btn-default" style="" title="@title"
-                href="@utils.http.joinPath(req.path, req.queryString.updated(SearchParams.SORT, Seq(sortKey.toString)))">
+                <a rel="nofollow" class="btn btn-xs btn-default" title="@title" href="@utils.http.joinPath(req.path, req.queryString.updated(SearchParams.SORT, Seq(sortKey.toString)))">
                 @name
                 </a>
             }

--- a/modules/portal/app/views/common/search/facetList.scala.html
+++ b/modules/portal/app/views/common/search/facetList.scala.html
@@ -12,14 +12,14 @@
 @facetItem(fc: FacetClass[Facet], f: Facet) = {
     @if(f.applied) {
         <li class="remove-filter">
-            <a href="@pathWithoutFacet(fc, f.value, call.url, req.queryString.filterKeys(_!="page"))">
+            <a rel="nofollow" href="@pathWithoutFacet(fc, f.value, call.url, req.queryString.filterKeys(_!="page"))">
                 <span class="facet-name">@fc.pretty(f)</span>
                 <span class="facet-count">(@f.count)</span>
             </a>
         </li>
     } else {
         <li class="apply-filter">
-            <a href="@pathWithFacet(fc, f.value, call.url, req.queryString.filterKeys(_!="page"))">
+            <a rel="nofollow" href="@pathWithFacet(fc, f.value, call.url, req.queryString.filterKeys(_!="page"))">
                 <span class="facet-name">@fc.pretty(f)</span>
                 <span class="facet-count">(@f.count)</span>
             </a>
@@ -58,12 +58,12 @@
             @fc.facets.map { f =>
                 @if(f.applied) {
                     <input type="hidden" name="@fc.param" value="@f.value" />
-                    <a class="remove-filter" href="@pathWithoutFacet(fc, f.value, call.url, req.queryString.filterKeys(_!="page"))">
+                    <a rel="nofollow" class="remove-filter" href="@pathWithoutFacet(fc, f.value, call.url, req.queryString.filterKeys(_!="page"))">
                         <span class="facet-name">@fc.pretty(f)</span>
                         <span class="facet-count">(@f.count)</span>
                     </a>
                 } else {
-                    <a class="apply-filter" href="@pathWithFacet(fc, f.value, call.url, req.queryString.filterKeys(_!="page"))">
+                    <a rel="nofollow" class="apply-filter" href="@pathWithFacet(fc, f.value, call.url, req.queryString.filterKeys(_!="page"))">
                         <span class="facet-name">@fc.pretty(f)</span>
                         <span class="facet-count">(@f.count)</span>
                     </a>
@@ -86,7 +86,7 @@
                             <div id="facet-extra-@fc.key" class="collapse collapsed">
                                 @rest.map(f => facetItem(fc, f))
                             </div>
-                            <a class="more-less-options" href="#facet-extra-@fc.key">More...</a>
+                            <a rel="nofollow" class="more-less-options" href="#facet-extra-@fc.key">More...</a>
                         }
                     }
                 </ol>
@@ -114,7 +114,7 @@
         <h4 class="facet-label">
             @Messages(fc.name)
             @if(fc.facets.isEmpty) {
-                <a href="#" class="date-submit pull-right">
+                <a rel="nofollow" href="#" class="date-submit pull-right">
                     <span class="glyphicon glyphicon-ok-circle"></span>
                 </a>
             }
@@ -153,7 +153,7 @@
                 <h3>@Messages("search.facets.heading")</h3>
             </div>
             <ul class="facet-classes">
-            @activeClasses.map { fc =>
+            @activeClasses.filter(_ != FacetDisplay.Hidden).map { fc =>
                 @fc.display match {
                     case FacetDisplay.DropDown => {
                         @facetDropDown(fc)

--- a/modules/portal/app/views/common/search/searchSort.scala.html
+++ b/modules/portal/app/views/common/search/searchSort.scala.html
@@ -1,6 +1,6 @@
 @(params: services.search.SearchParams, values: Seq[services.search.SearchSort.Value] = Seq.empty)(implicit req: RequestHeader, messages: Messages)
 
-@import services.search.{SearchParams, SearchSort}
+@import services.search.SearchSort
 
 @defaultValues = @{if(values.nonEmpty) values else Seq(SearchSort.Score, SearchSort.Id, SearchSort.Name, SearchSort.DateNewest, SearchSort.Detail)}
 


### PR DESCRIPTION
This is basically so search engines don't index hundreds of permutations of them pointlessly.