### PR TITLE
Move backend data cache expiration to config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -128,8 +128,8 @@ recaptcha.key.private = 6LcEhOcSAAAAAOTZqZYDeLdXv0911i-yUuMKEPrr
 # Don't show recaptcha
 recaptcha.skip = true
 
-# How long the session takes to timeout in seconds
-auth.session.timeout = 604800 // 1 week
+# How long the session takes to timeout
+auth.session.timeout = 7 days
 
 # Storage configuration
 storage {
@@ -147,6 +147,9 @@ ehri {
         # backend in serialization.
         # For the moment we always want the user's image url
         includedProperties = ["imageUrl"]
+
+        # How long to cache backend data for...
+        cacheExpiration = 5 minutes
     }
 
     # THIS ENSURES SECURED ROUTES ARE SECURED. MAKE SURE IT'S EITHER

--- a/modules/backend/src/main/scala/services/data/Constants.scala
+++ b/modules/backend/src/main/scala/services/data/Constants.scala
@@ -64,12 +64,6 @@ object Constants {
   val INCLUDE_PROPERTIES_PARAM = "_ip"
 
   /**
-   * Time to cache rest requests for...
-   */
-  import scala.concurrent.duration._
-  val cacheTime: FiniteDuration = (60 * 5).seconds
-
-  /**
     * Pagination
     */
   final val PAGE_PARAM = "page"

--- a/modules/backend/src/main/scala/services/data/DataApiService.scala
+++ b/modules/backend/src/main/scala/services/data/DataApiService.scala
@@ -33,6 +33,8 @@ case class DataApiServiceHandle(eventHandler: EventHandler)(
   val ws: WSClient
 ) extends DataApiHandle with RestService with DataApiContext {
 
+  private val cacheTime: Duration = config.get[Duration]("ehri.backend.cacheExpiration")
+
   override def withEventHandler(eventHandler: EventHandler): DataApiServiceHandle = this.copy(eventHandler = eventHandler)
 
   override def status(): Future[String] = {

--- a/modules/core/app/auth/handler/cookie/CookieAuthHandler.scala
+++ b/modules/core/app/auth/handler/cookie/CookieAuthHandler.scala
@@ -33,7 +33,7 @@ case class CookieAuthHandler @Inject()(
   import scala.concurrent.duration._
 
   override def sessionTimeout: FiniteDuration =
-    config.get[Int]("auth.session.timeout").seconds
+    config.get[FiniteDuration]("auth.session.timeout")
 
   override def restoreAccount(implicit request: RequestHeader): Future[(Option[Account], ResultUpdater)] = {
     (for {


### PR DESCRIPTION
Also use a Duration for session timeout, instead of integer seconds