### PR TITLE
Add more streaming/batch methods to the API

### DIFF
--- a/modules/backend/src/main/scala/services/data/BatchResult.scala
+++ b/modules/backend/src/main/scala/services/data/BatchResult.scala
@@ -1,0 +1,9 @@
+package services.data
+
+import play.api.libs.json.{Format, Json}
+
+case class BatchResult(created: Int, updated: Int, unchanged: Int, errors: Map[String, String])
+
+object BatchResult {
+  implicit val format: Format[BatchResult] = Json.format[BatchResult]
+}

--- a/modules/backend/src/main/scala/services/data/DataApi.scala
+++ b/modules/backend/src/main/scala/services/data/DataApi.scala
@@ -3,7 +3,7 @@ package services.data
 import acl.{GlobalPermissionSet, ItemPermissionSet}
 import akka.stream.scaladsl.Source
 import defines.{ContentTypes, EntityType}
-import play.api.libs.json.JsObject
+import play.api.libs.json.{JsObject, JsValue}
 import play.api.libs.ws.WSResponse
 import play.api.mvc.Headers
 import utils._
@@ -147,9 +147,33 @@ trait DataApiHandle {
     * @param scope   an optional item scope
     * @param logMsg  a log message
     * @param version whether or not to create pre-delete versions of the deleted items
+    * @param commit  whether to commit the changes
     * @return the number of items deleted
     */
   def batchDelete(ids: Seq[String], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean = false): Future[Int]
+
+  /**
+    * Update a batch of items via a stream of partial JSON bundles.
+    *
+    * @param data    partial model data a JSON stream
+    * @param scope   the optional shared item scope
+    * @param version whether or not to create pre-update versions of updated items
+    * @param commit  whether to commit the changes
+    * @return the number of items updated
+    */
+  def batchUpdate(data: Source[JsValue, _], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult]
+
+  /**
+    * Update a batch of items.
+    *
+    * @param data    the model data
+    * @param scope   the optional shared item scope
+    * @param version whether or not to create pre-update versions of updated items
+    * @param commit  whether to commit the changes
+    * @tparam T the generic model data type
+    * @return the number of items updated
+    */
+  def batchUpdate[T: Writable](data: Seq[T], scope: Option[String], logMsg: String, version: Boolean, commit: Boolean): Future[BatchResult]
 
   /**
     * Fetch any type of item by ID.
@@ -291,7 +315,7 @@ trait DataApiHandle {
     * Fetch child items as a stream.
     *
     * @param id the parent item id
-    * @tparam MT the parent generic type
+    * @tparam MT  the parent generic type
     * @tparam CMT the child generic resource type
     * @return a Source of child items
     */

--- a/modules/backend/src/main/scala/services/data/DataApi.scala
+++ b/modules/backend/src/main/scala/services/data/DataApi.scala
@@ -1,6 +1,7 @@
 package services.data
 
 import acl.{GlobalPermissionSet, ItemPermissionSet}
+import akka.stream.scaladsl.Source
 import defines.{ContentTypes, EntityType}
 import play.api.libs.json.JsObject
 import play.api.libs.ws.WSResponse
@@ -269,6 +270,14 @@ trait DataApiHandle {
   def list[MT: Resource](params: PageParams = PageParams.empty): Future[Page[MT]]
 
   /**
+    * Stream items with the implicit resource type.
+    *
+    * @tparam MT the generic type of the items
+    * @return a Source of items
+    */
+  def stream[MT: Resource](): Source[MT, _]
+
+  /**
     * List child items of this parent type.
     *
     * @param id     the parent item id
@@ -277,6 +286,16 @@ trait DataApiHandle {
     * @tparam CMT the child generic resource type
     */
   def children[MT: Resource, CMT: Readable](id: String, params: PageParams = PageParams.empty): Future[Page[CMT]]
+
+  /**
+    * Fetch child items as a stream.
+    *
+    * @param id the parent item id
+    * @tparam MT the parent generic type
+    * @tparam CMT the child generic resource type
+    * @return a Source of child items
+    */
+  def streamChildren[MT: Resource, CMT: Readable](id: String): Source[CMT, _]
 
   /**
     * Count child items of a resource.


### PR DESCRIPTION
This is to help handle bulk update tasks such as geocoding.