### PR TITLE
Fix the way some items do language-specific stringification.

### DIFF
--- a/modules/core/app/models/Annotation.scala
+++ b/modules/core/app/models/Annotation.scala
@@ -8,6 +8,7 @@ import play.api.libs.functional.syntax._
 import eu.ehri.project.definitions.Ontology
 import play.api.data.Form
 import play.api.data.Forms._
+import play.api.i18n.Messages
 import play.api.libs.json.JsObject
 import services.data.{ContentType, Writable}
 import utils.EnumUtils
@@ -157,4 +158,8 @@ case class Annotation(
   def formatted: String = {
     s"${data.comment.map(c => s"$c\n\n").getOrElse("")}${data.body}"
   }
+
+  override def toStringLang(implicit messages: Messages): String =
+    Messages("annotation.label", user.map(_.toStringLang).getOrElse("unknown"),
+      latestEvent.map(_.data.datetime).getOrElse("?"))
 }

--- a/modules/core/app/models/base/Model.scala
+++ b/modules/core/app/models/base/Model.scala
@@ -30,13 +30,9 @@ trait Model extends WithId {
   }
 
   /**
-   * Language-dependent version of the name
-   */
-  def toStringLang(implicit messages: Messages): String = this match {
-    case d: DescribedModel =>
-      d.data.primaryDescription(messages).orElse(d.descriptions.headOption).fold(id)(_.name)
-    case t => t.toString
-  }
+    * Language-dependent version of the name. This is a fallback value.
+    */
+  def toStringLang(implicit messages: Messages): String = s"$isA: $id"
 
   /**
    * Abbreviated version of the canonical name
@@ -116,6 +112,9 @@ trait DescribedModel extends Model {
   type T <: Described
 
   def descriptions: Seq[T#D] = data.descriptions
+
+  override def toStringLang(implicit messages: Messages): String =
+    data.primaryDescription(messages).orElse(descriptions.headOption).fold(id)(_.name)
 
   private lazy val allAccessPoints = descriptions.flatMap(_.accessPoints)
 

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -576,6 +576,7 @@ social.unblock.submit=Unblock User
 # Annotations
 #
 annotation=Notes
+annotation.label=Note by ''{0}'' at {1}
 annotation.description=Notes on this description
 annotation.search=Search Notes
 annotation.search.noneFound=No notes found matching ''{0}''.


### PR DESCRIPTION
Previous changes exposed the raw model `toString`, which we don't ever want to use.