### PR TITLE
Change (again) the way child item descriptions are rendered wrt lang

### DIFF
--- a/modules/admin/app/views/admin/documentaryUnit/listItem.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/listItem.scala.html
@@ -1,8 +1,7 @@
 @(item: DocumentaryUnit)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, descriptionId: Option[String] = None)
 
 @common.search.searchItemOutline(item) {
-    @* include an anchor to the selected description *@
-    @defining(descriptionId.map(did => "#desc-" + did).getOrElse("")) { anchor =>
+    @defining(item.data.primaryDescription(descriptionId).flatMap(_.localId).map("#desc-" + _).getOrElse("")) { anchor =>
         <a href="@{controllers.units.routes.DocumentaryUnits.get(item.id) + anchor}">
             <span class="primary-identifier">@item.data.identifier</span> | @item.toStringLang
         </a>

--- a/modules/admin/app/views/admin/search/searchItemListWithAdditionalContent.scala.html
+++ b/modules/admin/app/views/admin/search/searchItemListWithAdditionalContent.scala.html
@@ -2,7 +2,7 @@
 
 <ol class="search-result-list">
     @result.page.map { case(item, hit) =>
-        @defining(models.base.Description.localId(hit.id)) { implicit descriptionId =>
+        @defining(result.params.query.map(_ => hit.id)) { implicit descriptionId =>
             <li class="row">
                 <div class="col-md-10">
                     @views.html.admin.search.searchItem(item)

--- a/modules/admin/app/views/admin/virtualUnit/listItem.scala.html
+++ b/modules/admin/app/views/admin/virtualUnit/listItem.scala.html
@@ -2,7 +2,7 @@
 
 @common.search.searchItemOutline(item) {
     @* include an anchor to the selected description *@
-    @defining(descriptionId.map(did => "#desc-" + did).getOrElse("")) { anchor =>
+    @defining(descriptionId.flatMap(models.base.Description.localId).map(did => "#desc-" + did).getOrElse("")) { anchor =>
         @if(path.nonEmpty) {
             @defining(path.map(_.id).mkString(",")) { pathStr =>
             <a href="@{controllers.virtual.routes.VirtualUnits.getInVc(pathStr, item.id) + anchor}">@item.toStringLang</a>

--- a/modules/admin/app/views/admin/virtualUnit/searchItemList.scala.html
+++ b/modules/admin/app/views/admin/virtualUnit/searchItemList.scala.html
@@ -2,7 +2,7 @@
 
 <ul class="list-unstyled">
     @result.page.map { case(item, hit) =>
-        @defining(models.base.Description.localId(hit.id)) { implicit descriptionId =>
+        @defining(result.params.query.map(_ => hit.id)) { implicit descriptionId =>
             <li>
                 @views.html.virtualUnit.ifVirtual(item)(v => listItem(v, path))(d => listItem(d, path))
             </li>

--- a/modules/portal/app/views/common/search/searchItemList.scala.html
+++ b/modules/portal/app/views/common/search/searchItemList.scala.html
@@ -2,7 +2,7 @@
 
 <ol class="search-result-list">
     @result.page.map { case(item, hit) =>
-        @defining(models.base.Description.localId(hit.id)) { implicit descriptionId =>
+        @defining(result.params.query.map(_ => hit.id)) { implicit descriptionId =>
             @defining(watched.contains(item.id)) { watched =>
             <li class="@itemClass">
                 @item match {

--- a/modules/portal/app/views/documentaryUnit/searchItem.scala.html
+++ b/modules/portal/app/views/documentaryUnit/searchItem.scala.html
@@ -11,23 +11,23 @@
     }
 }
 
-@anchor = @{descriptionId.map(id => s"#desc-$id").getOrElse("")}
-
 @item.data.primaryDescription(descriptionId).map { desc =>
-    @defining(views.Helpers.textDirection(desc)) { dir =>
-        <div class="search-item" id="@item.id" dir="@dir">
-            <div class="search-item-actions">
-            @views.html.common.watchButtonsSmall(item, watched)
+    @defining(desc.localId.map("#desc-" + _).getOrElse("")) { anchor =>
+        @defining(views.Helpers.textDirection(desc)) { dir =>
+            <div class="search-item" id="@item.id" dir="@dir">
+                <div class="search-item-actions">
+                @views.html.common.watchButtonsSmall(item, watched)
+                </div>
+                <h3 class="search-item-heading type-highlight @item.isA.toString" dir="@dir">
+                @views.html.helpers.linkToWithFragment(item, fragment = anchor, content = Html(highlighter.highlight(desc.name)))
+                </h3>
+                <div class="search-item-body" dir="@dir">
+                    @if(item.parent.isDefined) {
+                        <ol class="breadcrumb">@wrapParent(item, item.parent)</ol>
+                    }
+                    @views.html.documentaryUnit.listItemBody(item, showRepository, highlighter = highlighter)
+                </div>
             </div>
-            <h3 class="search-item-heading type-highlight @item.isA.toString" dir="@dir">
-              @views.html.helpers.linkToWithFragment(item, fragment = anchor, content = Html(highlighter.highlight(desc.name)))
-            </h3>
-            <div class="search-item-body" dir="@dir">
-                @if(item.parent.isDefined) {
-                    <ol class="breadcrumb">@wrapParent(item, item.parent)</ol>
-                }
-                @views.html.documentaryUnit.listItemBody(item, showRepository, highlighter = highlighter)
-            </div>
-        </div>
+        }
     }
 }

--- a/modules/portal/app/views/virtualUnit/childItemSearch.scala.html
+++ b/modules/portal/app/views/virtualUnit/childItemSearch.scala.html
@@ -5,7 +5,7 @@
 
         <ul class="list-unstyled search-result-list">
             @result.page.items.map { case(doc, hit) =>
-                @defining(models.base.Description.localId(hit.id)) { implicit descriptionId =>
+                @defining(result.params.query.map(_ => hit.id)) { implicit descriptionId =>
                     @defining(watched.contains(doc.id)) { watched =>
                         <li>@searchItem(doc, path :+ item, hit, watched)</li>
                     }


### PR DESCRIPTION
If there is no active search, the description closest to the current language is shown. If there is a search, we use the hit ID as a hint. Child item lists then anchor-link to the same language description.