### PR TITLE
Since non-admin ingest doesn't work (:sadface:) lock down views

### DIFF
--- a/modules/admin/app/controllers/admin/Ingest.scala
+++ b/modules/admin/app/controllers/admin/Ingest.scala
@@ -6,7 +6,7 @@ import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.stream.Materializer
 import controllers.AppComponents
 import controllers.base.AdminController
-import defines.EntityType
+import defines.ContentTypes
 import javax.inject.{Inject, Singleton}
 import models.base.Model
 import play.api.Logger
@@ -53,57 +53,58 @@ case class Ingest @Inject()(
     }
   }
 
-  def ingestPost(scopeType: EntityType.Value, scopeId: String, dataType: IngestApi.IngestDataType.Value, fonds: Option[String]): Action[MultipartFormData[TemporaryFile]] = AdminAction(parse.multipartFormData(Int.MaxValue)).async { implicit request =>
+  def ingestPost(scopeType: ContentTypes.Value, scopeId: String, dataType: IngestApi.IngestDataType.Value, fonds: Option[String]): Action[MultipartFormData[TemporaryFile]] =
+    AdminAction(parse.multipartFormData(Int.MaxValue)).async { implicit request =>
 
-    def showErrorForm(form: Form[IngestParams]): Future[Result] = {
-      val scopeItemF: Future[Model] = userDataApi.getAny[Model](scopeId)
-      val fondsItemF: Future[Option[Model]] = fonds
-        .map(id => userDataApi.getAny[Model](id)
-          .map(item => Some(item))).getOrElse(Future.successful(None))
+      def showErrorForm(form: Form[IngestParams]): Future[Result] = {
+        val scopeItemF: Future[Model] = userDataApi.getAny[Model](scopeId)
+        val fondsItemF: Future[Option[Model]] = fonds
+          .map(id => userDataApi.getAny[Model](id)
+            .map(item => Some(item))).getOrElse(Future.successful(None))
 
-      for (scopeItem <- scopeItemF; fondsItem <- fondsItemF)
-        yield BadRequest(views.html.admin.tools.ingest(scopeItem, fondsItem, form, dataType,
-          controllers.admin.routes.Ingest.ingestPost(scopeType, scopeId, dataType, fonds)))
-    }
+        for (scopeItem <- scopeItemF; fondsItem <- fondsItemF)
+          yield BadRequest(views.html.admin.tools.ingest(scopeItem, fondsItem, form, dataType,
+            controllers.admin.routes.Ingest.ingestPost(scopeType, scopeId, dataType, fonds)))
+      }
 
-    val boundForm = IngestParams.ingestForm.bindFromRequest()
-    request.body.file(IngestParams.DATA_FILE).map { data =>
-      boundForm.fold(
-        errForm => showErrorForm(errForm),
-        ingestTask => {
+      val boundForm = IngestParams.ingestForm.bindFromRequest()
+      request.body.file(IngestParams.DATA_FILE).map { data =>
+        boundForm.fold(
+          errForm => showErrorForm(errForm),
+          ingestTask => {
 
-          // Tag this task with a unique ID...
-          val jobId = UUID.randomUUID().toString
+            // Tag this task with a unique ID...
+            val jobId = UUID.randomUUID().toString
 
-          // We only want XML types here, everything else is just binary
-          val contentType = data.contentType.filter(_.endsWith("xml"))
-            .getOrElse(play.api.http.ContentTypes.BINARY)
+            // We only want XML types here, everything else is just binary
+            val contentType = data.contentType.filter(_.endsWith("xml"))
+              .getOrElse(play.api.http.ContentTypes.BINARY)
 
-          // Save the properties file, if given, to a temp file on the server.
-          // NB: Overcomplicated due to https://github.com/playframework/playframework/issues/6203
-          val props: Option[TemporaryFile] = request.body
-              .file(IngestParams.PROPERTIES_FILE)
-              .filter(_.filename.nonEmpty)
-              .map(_.ref)
+            // Save the properties file, if given, to a temp file on the server.
+            // NB: Overcomplicated due to https://github.com/playframework/playframework/issues/6203
+            val props: Option[TemporaryFile] = request.body
+                .file(IngestParams.PROPERTIES_FILE)
+                .filter(_.filename.nonEmpty)
+                .map(_.ref)
 
-          val task = ingestTask.copy(properties = props, file = Some(data.ref))
-          val ingest = IngestData(task, dataType, contentType, AuthenticatedUser(request.user.id))
+            val task = ingestTask.copy(properties = props, file = Some(data.ref))
+            val ingest = IngestData(task, dataType, contentType, AuthenticatedUser(request.user.id))
 
-          val runner = system.actorOf(Props(IngestActor()), jobId)
-          runner ! IngestJob(jobId, ingest)
-          logger.info(s"Submitted ingest job: $jobId")
+            val runner = system.actorOf(Props(IngestActor()), jobId)
+            runner ! IngestJob(jobId, ingest)
+            logger.info(s"Submitted ingest job: $jobId")
 
-          immediate {
-            if (isAjax) Ok(Json.obj(
-              "url" -> controllers.admin.routes.Tasks.taskMonitorWS(jobId).webSocketURL(globalConfig.https),
-              "jobId" -> jobId
-            ))
-            else Redirect(controllers.admin.routes.Ingest.ingestMonitor(jobId))
+            immediate {
+              if (isAjax) Ok(Json.obj(
+                "url" -> controllers.admin.routes.Tasks.taskMonitorWS(jobId).webSocketURL(globalConfig.https),
+                "jobId" -> jobId
+              ))
+              else Redirect(controllers.admin.routes.Ingest.ingestMonitor(jobId))
+            }
           }
-        }
-      )
-    }.getOrElse(showErrorForm(boundForm.withError(IngestParams.DATA_FILE, "required")))
-  }
+        )
+      }.getOrElse(showErrorForm(boundForm.withError(IngestParams.DATA_FILE, "required")))
+    }
 
   def ingestMonitor(jobId: String): Action[AnyContent] = AdminAction.apply { implicit request =>
     Ok(views.html.admin.tasks.taskMonitor(

--- a/modules/admin/app/controllers/institutions/Repositories.scala
+++ b/modules/admin/app/controllers/institutions/Repositories.scala
@@ -249,6 +249,6 @@ case class Repositories @Inject()(
   def ingest(id: String, sync: Boolean): Action[AnyContent] = (AdminAction andThen ItemPermissionAction(id)).apply { implicit request =>
     val dataType = if (sync) IngestApi.IngestDataType.EadSync else IngestApi.IngestDataType.Ead
     Ok(views.html.admin.tools.ingest(request.item, None, IngestParams.ingestForm, dataType,
-      controllers.admin.routes.Ingest.ingestPost(request.item.isA, id, dataType), sync = sync))
+      controllers.admin.routes.Ingest.ingestPost(ContentTypes.Repository, id, dataType), sync = sync))
   }
 }

--- a/modules/admin/app/controllers/sets/AuthoritativeSets.scala
+++ b/modules/admin/app/controllers/sets/AuthoritativeSets.scala
@@ -185,6 +185,6 @@ AuthoritativeSets @Inject()(
   def ingest(id: String): Action[AnyContent] = (AdminAction andThen ItemPermissionAction(id)).apply { implicit request =>
     val dataType = IngestApi.IngestDataType.Eac
     Ok(views.html.admin.tools.ingest(request.item, None, IngestParams.ingestForm, dataType,
-      controllers.admin.routes.Ingest.ingestPost(request.item.isA, id, dataType)))
+      controllers.admin.routes.Ingest.ingestPost(ContentTypes.AuthoritativeSet, id, dataType)))
   }
 }

--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -346,7 +346,8 @@ case class DocumentaryUnits @Inject()(
     request.item.holder.map { scope =>
       val dataType = IngestApi.IngestDataType.Eac
       Ok(views.html.admin.tools.ingest(scope, Some(request.item), IngestParams.ingestForm, dataType,
-        controllers.admin.routes.Ingest.ingestPost(scope.isA, scope.id, dataType, Some(id)), sync = true))
+        controllers.admin.routes.Ingest.ingestPost(ContentTypes.DocumentaryUnit,
+          scope.id, dataType, Some(id)), sync = true))
     }.getOrElse(InternalServerError(views.html.errors.fatalError()))
   }
 }

--- a/modules/admin/app/controllers/vocabularies/Vocabularies.scala
+++ b/modules/admin/app/controllers/vocabularies/Vocabularies.scala
@@ -183,10 +183,10 @@ case class Vocabularies @Inject()(
     }
   }
 
-  def ingest(id: String): Action[AnyContent] = WithParentPermissionAction(id, PermissionType.Create, ContentTypes.Concept).apply { implicit request =>
+  def ingest(id: String): Action[AnyContent] = (AdminAction andThen ItemPermissionAction(id)).apply { implicit request =>
     val dataType = IngestApi.IngestDataType.Skos
     Ok(views.html.admin.tools.ingest(request.item, None, IngestParams.ingestForm, dataType,
-      controllers.admin.routes.Ingest.ingestPost(request.item.isA, id, dataType)))
+      controllers.admin.routes.Ingest.ingestPost(ContentTypes.Vocabulary, id, dataType)))
   }
 }
 

--- a/modules/admin/app/services/ingest/IngestApiService.scala
+++ b/modules/admin/app/services/ingest/IngestApiService.scala
@@ -6,14 +6,14 @@ import java.nio.file.Files
 import java.nio.file.attribute.PosixFilePermission
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import javax.inject.Inject
 
+import javax.inject.Inject
 import akka.actor.{Actor, ActorRef, ActorSystem, Cancellable, Props}
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.fasterxml.jackson.databind.JsonMappingException
-import defines.EntityType
+import defines.{ContentTypes, EntityType}
 import play.api.http.HeaderNames
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -171,11 +171,11 @@ case class IngestApiService @Inject()(
   }
 
   // Re-index the scope in which the ingest was run
-  private def reindex(entityType: EntityType.Value, id: String)(implicit chan: ActorRef): Future[Unit] = {
-    msg(s"Reindexing... $entityType $id", chan)
+  private def reindex(scopeType: ContentTypes.Value, id: String)(implicit chan: ActorRef): Future[Unit] = {
+    msg(s"Reindexing... $scopeType $id", chan)
     indexer.clearKeyValue(SearchConstants.HOLDER_ID, id).flatMap { _ =>
       msg(s"Cleared ${SearchConstants.HOLDER_ID}: $id", chan)
-      indexer.indexChildren(entityType, id)
+      indexer.indexChildren(EntityType.withName(scopeType.toString), id)
     }
   }
 

--- a/modules/admin/app/services/ingest/IngestParams.scala
+++ b/modules/admin/app/services/ingest/IngestParams.scala
@@ -1,13 +1,13 @@
 package services.ingest
 
-import defines.EntityType
+import defines.ContentTypes
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.libs.Files.TemporaryFile
 
 
 case class IngestParams(
-  scopeType: EntityType.Value,
+  scopeType: ContentTypes.Value,
   scope: String,
   fonds: Option[String] = None,
   log: String,
@@ -41,7 +41,7 @@ object IngestParams {
 
   val ingestForm = Form(
     mapping(
-      SCOPE_TYPE -> utils.EnumUtils.enumMapping(EntityType),
+      SCOPE_TYPE -> utils.EnumUtils.enumMapping(ContentTypes),
       SCOPE -> nonEmptyText,
       FONDS -> optional(nonEmptyText),
       LOG -> nonEmptyText,

--- a/modules/admin/app/views/admin/vocabulary/adminActions.scala.html
+++ b/modules/admin/app/views/admin/vocabulary/adminActions.scala.html
@@ -38,7 +38,7 @@
 
 @views.html.admin.common.sidebarSection(Some(Messages("ingest"))) {
     @views.html.admin.common.listGroup {
-        @views.html.admin.common.sidebarAction(userOpt.exists(_.hasPermission(defines.ContentTypes.Concept, defines.PermissionType.Create))) {
+        @views.html.admin.common.sidebarAction(userOpt.forall(_.isAdmin)) {
             <a href="@controllers.vocabularies.routes.Vocabularies.ingest(item.id)">@Messages("ingest.format.skos")</a>
         }
     }

--- a/modules/admin/conf/admin.routes
+++ b/modules/admin/conf/admin.routes
@@ -15,7 +15,7 @@ GET         /updateIndex                        @controllers.admin.Indexing.upda
 GET         /updateIndexSocket                  @controllers.admin.Indexing.indexer
 
 # Ingest
-POST        /ingest                             @controllers.admin.Ingest.ingestPost(scopeType: defines.EntityType.Value, scopeId: String, dataType: services.ingest.IngestApi.IngestDataType.Value, fonds: Option[String] ?= None)
+POST        /ingest                             @controllers.admin.Ingest.ingestPost(scopeType: defines.ContentTypes.Value, scopeId: String, dataType: services.ingest.IngestApi.IngestDataType.Value, fonds: Option[String] ?= None)
 GET         /ingest                             @controllers.admin.Ingest.ingestMonitor(jobId: String)
 
 # Tasks

--- a/test/integration/admin/IngestSpec.scala
+++ b/test/integration/admin/IngestSpec.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import defines.EntityType
+import defines.ContentTypes
 import helpers.{FakeMultipartUpload, IntegrationTestRunner}
 import org.apache.commons.io.FileUtils
 import play.api.libs.json.JsString
@@ -40,9 +40,9 @@ class IngestSpec extends IntegrationTestRunner with FakeMultipartUpload {
       private implicit val mat = app.materializer
 
       val result = FakeRequest(controllers.admin.routes.Ingest
-          .ingestPost(EntityType.Repository, "r1", IngestApi.IngestDataType.EadSync))
+          .ingestPost(ContentTypes.Repository, "r1", IngestApi.IngestDataType.EadSync))
         .withFileUpload(IngestParams.DATA_FILE, getEadFile, "text/xml", data = Map(
-          IngestParams.SCOPE_TYPE -> Seq(EntityType.Repository.toString),
+          IngestParams.SCOPE_TYPE -> Seq(ContentTypes.Repository.toString),
           IngestParams.SCOPE -> Seq("r1"),
           IngestParams.EXCLUDES -> Seq("c1\nc2\nc3\nc4\nnl-r1-m19"),
           IngestParams.LOG -> Seq("test"),


### PR DESCRIPTION
Ideally users with parent permissions in e.g. a vocabulary would be able to ingest SKOS, but this is difficult without making ingest task controller-specific.