### PR TITLE
Revise trailing-slash routing behaviour

### DIFF
--- a/app/ErrorHandler.scala
+++ b/app/ErrorHandler.scala
@@ -47,7 +47,10 @@ with SessionPreferences[SessionPrefs] {
 
   override def onNotFound(request: RequestHeader, message: String): Future[Result] = {
     implicit val r: RequestHeader = request
-    pageRelocator.hasMovedTo(request.path).map {
+    // if the page has a trailing slash, permanently redirect without the slash...
+    if (request.path.endsWith("/")) {
+      immediate(MovedPermanently(request.path.dropRight(1)))
+    } else pageRelocator.hasMovedTo(request.path).map {
       case Some(newPath) => MovedPermanently(utils.http.iriToUri(newPath))
       case None => NotFound(renderError("errors.pageNotFound", pageNotFound()))
     }

--- a/modules/portal/app/controllers/portal/PortalData.scala
+++ b/modules/portal/app/controllers/portal/PortalData.scala
@@ -78,14 +78,6 @@ case class PortalData @Inject()(
     }
   }
 
-  /**
-    * Handle trailing slashes with a permanent redirect.
-    */
-  def untrail(path: String): Action[AnyContent] = controllerComponents.actionBuilder { request =>
-    val query = if (request.rawQueryString != "") "?" + request.rawQueryString else ""
-    MovedPermanently("/" + path + query)
-  }
-
   def localeData(lang: String): EssentialAction = appComponents.statusCache.status((_: RequestHeader) => "pages:localeData", OK, cacheTime) {
     controllerComponents.actionBuilder { implicit request =>
       //implicit val locale: Lang = request.lang

--- a/modules/portal/conf/portal.routes
+++ b/modules/portal/conf/portal.routes
@@ -22,9 +22,7 @@ POST        /prefs                                @controllers.portal.Portal.upd
 GET         /locale/:lang                         @controllers.portal.Portal.changeLocale(lang: String)
 GET         /localeData                           @controllers.portal.PortalData.localeData(lang: String ?= "en")
 
-# Remove trailing slash from all URL and redirect to slashless path
-GET         /*path/                               @controllers.portal.PortalData.untrail(path)
-
+# Feedback
 GET         /feedback                             @controllers.portal.Feedback.feedback
 POST        /feedback                             @controllers.portal.Feedback.feedbackPost
 GET         /feedback/list                        @controllers.portal.Feedback.list(paging: utils.PageParams ?= utils.PageParams.empty)

--- a/test/integration/admin/ApplicationSpec.scala
+++ b/test/integration/admin/ApplicationSpec.scala
@@ -121,7 +121,7 @@ class ApplicationSpec extends PlaySpecification with TestConfiguration with User
     }
 
     "redirect 301 for trailing-slash URLs" in new ITestApp {
-      val home = FakeRequest(GET, controllers.admin.routes.Home.index().url + "/")
+      val home = FakeRequest(GET, controllers.admin.routes.Home.overview().url + "/")
         .withUser(mockdata.publicUser)
         .call()
       status(home) must equalTo(MOVED_PERMANENTLY)


### PR DESCRIPTION
Rather than redirecting all trailing slash requests, only do so if they trigger a 404. Ideally we'd check if the non-slash route matches anything, but not sure how to do this yet. This should be more
compatible with Play 2.7.x.