### PR TITLE
Make CSRF erroring less aggressive

### DIFF
--- a/modules/portal/app/views/formHelpers/csrfToken.scala.html
+++ b/modules/portal/app/views/formHelpers/csrfToken.scala.html
@@ -1,3 +1,5 @@
 @()(implicit request: RequestHeader)
 
-@helper.CSRF.formField(request)
+@play.filters.csrf.CSRF.getToken.map { token =>
+    <input type="hidden" name="@token.name" value="@token.value"/>
+}


### PR DESCRIPTION
Instead of erroring when we can't generate a token, instead skip insertion of the form, which should lead to a validation error if the form is used.