### PR TITLE
Prevent deleting the last description from an item.

### DIFF
--- a/modules/admin/app/views/admin/documentaryUnit/deleteDescription.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/deleteDescription.scala.html
@@ -4,25 +4,33 @@
 
 @views.html.admin.layout.rightSidebar(Messages("describedEntity.deleteDescription"), breadcrumbs = breadcrumbs(item), scripts = formHelpers.dateJs()) {
 
-    <p>@Messages("describedEntity.deleteDescription.info", did)</p>
-    @defining("documentaryUnit") { implicit fieldPrefix =>
-        @helper.form(action = action, 'class -> "entity-form form-horizontal") {
-            @formHelpers.csrfToken()
+    @if(item.descriptions.size > 1) {
+        <p>@Messages("describedEntity.deleteDescription.info", did)</p>
+        @defining("documentaryUnit") { implicit fieldPrefix =>
+            @helper.form(action = action, 'class -> "entity-form form-horizontal") {
+                @formHelpers.csrfToken()
 
-            @views.html.admin.documentaryUnit.hiddenFormWrapper(f) {
-                @helper.repeat(f("descriptions"), min = 0) { desc =>
-                    @if(!desc(Entity.ID).value.contains(did)) {
-                        @views.html.admin.documentaryUnit.hiddenDescriptionForm(desc)
-                    } else {
+                @views.html.admin.documentaryUnit.hiddenFormWrapper(f) {
+                    @helper.repeat(f("descriptions"), min = 0) { desc =>
+                        @if(!desc(Entity.ID).value.contains(did)) {
+                            @views.html.admin.documentaryUnit.hiddenDescriptionForm(desc)
+                        } else {
+                        }
                     }
                 }
-            }
 
-            @formHelpers.submitButtonWithLogMessageInput(
-                Messages("describedEntity.deleteDescription.submit"),
-                defaultLogMessage = Messages("describedEntity.deleteDescription.logMessage", did),
-                cancel = views.admin.Helpers.linkToOpt(item))
+                @formHelpers.submitButtonWithLogMessageInput(
+                    Messages("describedEntity.deleteDescription.submit"),
+                    defaultLogMessage = Messages("describedEntity.deleteDescription.logMessage", did),
+                    cancel = views.admin.Helpers.linkToOpt(item))
+            }
         }
+    } else {
+        <p class="alert alert-danger">
+            @Messages("describedEntity.deleteDescription.lastError")
+
+            <strong><a href="@views.admin.Helpers.linkTo(item)">@Messages("admin.goBack")</a></strong>
+        </p>
     }
 } {
 }

--- a/modules/admin/app/views/admin/documentaryUnit/descriptionActions.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/descriptionActions.scala.html
@@ -19,11 +19,13 @@
                             @Messages("describedEntity.editDescription")
                         </a>
                     </li>
-                    <li>
-                        <a class="alert alert-danger" href="@controllers.units.routes.DocumentaryUnits.deleteDescription(item.id, did)">
+                    @if(item.descriptions.size > 1) {
+                        <li>
+                            <a class="alert alert-danger" href="@controllers.units.routes.DocumentaryUnits.deleteDescription(item.id, did)">
                             @Messages("describedEntity.deleteDescription")
-                        </a>
-                    </li>
+                            </a>
+                        </li>
+                    }
                 </ul>
             </div>
         }

--- a/modules/admin/conf/messages
+++ b/modules/admin/conf/messages
@@ -12,6 +12,7 @@ admin.recentlyViewed=Recently Viewed
 admin.home.title=Welcome to the EHRI Administration interface
 admin.metrics=Data Metrics
 admin.metrics.show=Data Overview Graphs
+admin.goBack=Go back
 
 facet.group=Group
 facet.admin=Administrators
@@ -186,6 +187,7 @@ describedEntity.deleteDescription=Delete Description
 describedEntity.deleteDescription.submit=Delete
 describedEntity.deleteDescription.logMessage=Deleted description ''{0}''
 describedEntity.deleteDescription.info=Are you sure you want to delete item description: "{0}"?  This action cannot be undone.
+describedEntity.deleteDescription.lastError=You cannot delete the last description from an item. Delete the item instead.
 describedEntity.noData=No information given
 describedEntity.notGiven=Not Given
 describedEntity.createDescription=Add Description


### PR DESCRIPTION
This prevents the situation where an item is unfindable because all it's indexed descriptions have been removed.

Fixes #1010