### PR TITLE
Re-add form wrapper including description IDs.

### DIFF
--- a/modules/admin/app/views/admin/documentaryUnit/descriptionForm.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/descriptionForm.scala.html
@@ -8,7 +8,7 @@
 
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
-@defining(Some(config)) { implicit implicitConfig =>
+@views.html.admin.common.descriptionForm(desc) {
     @choiceInput(desc, LANG_CODE, views.Helpers.languagePairList, '_blank -> true)
 
     @descriptionFormSection(IDENTITY_AREA) {

--- a/test/integration/admin/DocumentaryUnitViewsSpec.scala
+++ b/test/integration/admin/DocumentaryUnitViewsSpec.scala
@@ -131,6 +131,11 @@ class DocumentaryUnitViewsSpec extends IntegrationTestRunner {
       contentAsString(form) must contain("SOME RANDOM VALUE")
     }
 
+    "include description IDs in form when editing items" in new ITestApp {
+      val form = FakeRequest(docRoutes.update("c1")).withUser(privilegedUser).call()
+      contentAsString(form) must contain("name=\"descriptions[0].id\" value=\"cd1\"")
+    }
+
     "NOT show default values in the form when editing items" in new ITestApp(
       Map("formConfig.DocumentaryUnit.rulesAndConventions.default" -> "SOME RANDOM VALUE")) {
       val form = FakeRequest(docRoutes.update("c1")).withUser(privilegedUser).call()


### PR DESCRIPTION
This was erroneously removed, which caused edited descriptions to be created anew, which was a major screwup.

Fixes #1085, though some additional work is needed on the backend to ensure the two-descriptions-with-same ID corruption cannot occur.