### PR TITLE
Use HTTPS for EHRI and Docker websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This app has a few depependencies in addition to the backend:
  - Solr, running configurated as per the config in [EHRI Search Tools](https://github.com/EHRI/ehri-search-tools)
 
 The setup docs to get these dependencies up and running ended up horribly out-of-date, so rather than
-actively mislead people they've been temporarily removed pending the completion of some [Docker](http://www.docker.com)
+actively mislead people they've been temporarily removed pending the completion of some [Docker](https://www.docker.com)
 -based dev setup instructions. In the meantime, here's how they'll start:
 
  - Set up the search engine on port 8983: 

--- a/modules/portal/app/views/about.scala.html
+++ b/modules/portal/app/views/about.scala.html
@@ -17,8 +17,8 @@
     <p>@Messages("about.p3")</p>
     <p>@Html(Messages(
         "about.p4",
-        s"<a href='http://training.ehri-project.eu'>${Messages("about.p4.a1")}</a>",
-        s"<a href='http://ehri-project.eu'>${Messages("about.p4.a2")}</a>"
+        s"<a href='https://training.ehri-project.eu'>${Messages("about.p4.a1")}</a>",
+        s"<a href='https://ehri-project.eu'>${Messages("about.p4.a2")}</a>"
     ))</p>
     <p>@Messages("about.p5")</p>
 }

--- a/modules/portal/app/views/country/introNotice.scala.html
+++ b/modules/portal/app/views/country/introNotice.scala.html
@@ -1,7 +1,7 @@
 @()(implicit messages: Messages)
 
 <div class="description-notice-text">
-    @defining("http://www.ehri-project.eu/national-reports") { url =>
+    @defining("https://www.ehri-project.eu/national-reports") { url =>
         @Html(Messages(
             "country.report.intro",
             s"<a href='$url'>${Messages("project.site")}</a>")

--- a/modules/portal/app/views/terms.scala.html
+++ b/modules/portal/app/views/terms.scala.html
@@ -18,6 +18,6 @@
     <p>@Messages("copyright.holder")</p>
     <p>@Html(Messages(
         "copyright.statement",
-        "<a href='http://www.ehri-project.eu'>http://www.ehri-project.eu</a>"
+        "<a href='https://www.ehri-project.eu'>https://www.ehri-project.eu</a>"
     ))</p>
 }

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -6,7 +6,7 @@ language=Language
 contact=Contact
 welcome.blurb=The EHRI portal offers access to information on Holocaust-related archival \
   material held in institutions across Europe and beyond. \
-  For more information on the EHRI project visit http://ehri-project.eu.
+  For more information on the EHRI project visit https://ehri-project.eu.
 welcome.video.heading=A 3-Minute Introduction to the EHRI Portal
 footerText=This is a development version of the EHRI portal interface.
 footer.funding=The EHRI Project is supported by the European Commission

--- a/modules/portal/conf/messages.de
+++ b/modules/portal/conf/messages.de
@@ -6,7 +6,7 @@ language=Sprache
 contact=Kontakt
 welcome.blurb=Das EHRI-Portal ermöglicht den Zugang zu Daten über Archivmaterial\
   zum Holocaust, das in Institutionen in und außerhalb von Europa verwahrt wird.\
-  Weitere Informationen zum EHRI-Projekt erhalten Sie auf http://ehri-project.eu.
+  Weitere Informationen zum EHRI-Projekt erhalten Sie auf https://ehri-project.eu.
 footerText=Dies ist eine Entwicklungsversion des EHRI-Portal-Interface.
 footer.funding=Das EHRI-Projekt wird von der Europäischen Kommission gefördert
 close=Schließen

--- a/modules/portal/conf/messages.fr
+++ b/modules/portal/conf/messages.fr
@@ -6,7 +6,7 @@ language=Langue
 contact=Contact
 welcome.blurb=Le portail de l''EHRI permet d''accéder à des informations sur des documents d''archives concernant l''Holocauste \
   conservés dans des institutions à travers l''Europe et au-delà. \
-  Pour obtenir plus d''informations sur le projet EHRI, veuillez-vous rendre sur le site : http://ehri-project.eu.
+  Pour obtenir plus d''informations sur le projet EHRI, veuillez-vous rendre sur le site : https://ehri-project.eu.
 footerText=Il s''agit d''une version en cours du développement de l''interface du portail de l''EHRI
 footer.funding=Le projet EHRI est soutenu par la Commission européenne
 close=Fermer

--- a/modules/portal/conf/messages.pl
+++ b/modules/portal/conf/messages.pl
@@ -6,7 +6,7 @@ language=Język
 contact=Kontakt
 welcome.blurb=Portal EHRI oferuje dostęp do informacji związanych z materiałami archiwalnymi dotyczącymi zagłady Żydów \
   dostępnymi w instytucjach w całej Europie i poza nią. \
-  Więcej informacji na temat projektu EHRI można znaleźć na stronie http://ehri-project.eu.
+  Więcej informacji na temat projektu EHRI można znaleźć na stronie https://ehri-project.eu.
 footerText=To jest rozwojowa wersja interfejsu portalu EHRI.
 footer.funding=Projekt EHRI jest wspierany przez Komisję Europejską
 close=Zamknij


### PR DESCRIPTION
... except in fixtures.

Linking to HTTPS websites can help secure connections to the EHRI infrastructure.