### PR TITLE
Allow setting Solr op mode to AND as local param in q text

### DIFF
--- a/conf/search.conf
+++ b/conf/search.conf
@@ -1,6 +1,8 @@
 # Search-related configuration
 
 search {
+    andMode: true // default to OR for q param
+
     boost {
         itemId: 15
         identifier: 10


### PR DESCRIPTION
This should (hopefully) fix #746 without breaking any other behaviour, since the setting is local to the text query.