### PR TITLE
Sort search groups with those matching the current language top.

### DIFF
--- a/modules/core/app/controllers/generic/Search.scala
+++ b/modules/core/app/controllers/generic/Search.scala
@@ -81,7 +81,8 @@ trait Search extends CoreActionBuilders {
       paging,
       appliedFacets = appliedFacets,
       facetClasses = facetClasses,
-      user = userOpt
+      user = userOpt,
+      lang = request.lang
     )
   }
 

--- a/modules/core/app/services/search/SearchQuery.scala
+++ b/modules/core/app/services/search/SearchQuery.scala
@@ -1,6 +1,7 @@
 package services.search
 
 import models.UserProfile
+import play.api.i18n.Lang
 import utils.PageParams
 
 /**
@@ -15,5 +16,6 @@ case class SearchQuery(
   facetClasses: Seq[FacetClass[Facet]] = Seq.empty,
   extraParams: Map[String, Any] = Map.empty,
   mode: SearchMode.Value = SearchMode.DefaultAll,
-  user: Option[UserProfile] = None
+  user: Option[UserProfile] = None,
+  lang: Lang
 )


### PR DESCRIPTION
This is a way of favouring the description that is most appropriate to the user's current language, without affecting actual query results.