### PR TITLE
Downgrade SBT back to 0.13.17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -217,7 +217,7 @@ val webAppSettings = Seq(
     }
     val allMessages = messagesFiles(baseDirectory.value)
     if (allMessages.nonEmpty) {
-      sLog.value.debug(s"Validating ${allMessages.size} messages file(s) in ${baseDirectory.value}")
+      streams.value.log.debug(s"Validating ${allMessages.size} messages file(s) in ${baseDirectory.value}")
       allMessages.foreach(validate)
     }
   },

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.7
+sbt.version=0.13.17
 logLevel := Level.Warn


### PR DESCRIPTION
1.2.7 seems to be incredibly slow to run a refresh, takes longer to load, and seems to leak memory like crazy.