### PR TITLE
Prevent unnecessary asset concatting for main portal CSS file.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,11 +279,6 @@ lazy val portal = Project(appName + "-portal", file("modules/portal"))
     // Should really add cssCompress stage here but it's too slow currently
     pipelineStages in Assets := Seq(concat, uglify, digest, gzip),
     Concat.groups := Seq(
-      "css/portal-all.css" -> group(
-        Seq(
-          "css/portal.css"
-        )
-      ),
       "js/script-pre.js" -> group(
         Seq(
           "js/lib/jquery-1.12.4.js",

--- a/modules/portal/app/assets/css/ehri/_layouts.scss
+++ b/modules/portal/app/assets/css/ehri/_layouts.scss
@@ -38,7 +38,7 @@ body {
 }
 
 /* Set the fixed height of the footer here */
-.page-content > #push, footer {
+.page-content > #push, #portal-footer {
   height: $footer-height - 1;
 }
 

--- a/modules/portal/app/views/common/head.scala.html
+++ b/modules/portal/app/views/common/head.scala.html
@@ -4,13 +4,8 @@
     <title>EHRI - @title</title>
 
     <link rel="shortcut icon" type="image/png" href="@controllers.portal.routes.PortalAssets.versioned("img/favicon.png")">
-    <!--[if lte IE 9]>
     <link rel="stylesheet" href="@controllers.portal.routes.PortalAssets.versioned("css/font-awesome.css")">
     <link rel="stylesheet" href="@controllers.portal.routes.PortalAssets.versioned("css/portal.css")">
-    <![endif]-->
-    <!--[if !IE]> -->
-    <link rel="stylesheet" href="@controllers.portal.routes.PortalAssets.versioned("css/portal-all.css")">
-    <!-- <![endif]-->
 
     @if(messages.lang.code.startsWith("he")) {
         <!-- experimental hebrew right-to-left support -->


### PR DESCRIPTION
This once existed to bundle IE9 fixes, but it's no longer supported.