### PR TITLE
Fix the create description form

### DIFF
--- a/modules/admin/app/views/admin/documentaryUnit/createDescription.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/createDescription.scala.html
@@ -8,8 +8,10 @@
             @helper.form(action = action, 'class -> "entity-form form-horizontal") {
                 @formHelpers.csrfToken()
                 @views.html.admin.documentaryUnit.hiddenFormWrapper(f) {
-                    @helper.repeat(f("descriptions"), min = 0) { desc =>
-                        @views.html.admin.documentaryUnit.hiddenDescriptionForm(desc)
+                    @helper.repeatWithIndex(f("descriptions"), min = 0) { (desc, i) =>
+                        @if(i < item.descriptions.length) {
+                            @views.html.admin.documentaryUnit.hiddenDescriptionForm(desc)
+                        }
                     }
                     @views.html.admin.documentaryUnit.descriptionForm(f("descriptions[" + item.descriptions.length + "]"))
                 }

--- a/modules/admin/app/views/admin/virtualUnit/createDescription.scala.html
+++ b/modules/admin/app/views/admin/virtualUnit/createDescription.scala.html
@@ -9,8 +9,10 @@
                 @formHelpers.csrfToken()
 
                 @formHelpers.hiddenInput(f(Entity.IDENTIFIER))
-                @helper.repeat(f("descriptions"), min = 0) { desc =>
-                    @views.html.admin.documentaryUnit.hiddenDescriptionForm(desc)
+                @helper.repeatWithIndex(f("descriptions"), min = 0) { (desc, i) =>
+                    @if(i < item.descriptions.length) {
+                        @views.html.admin.documentaryUnit.hiddenDescriptionForm(desc)
+                    }
                 }
                 @views.html.admin.documentaryUnit.descriptionForm(f("descriptions[" + item.descriptions.length + "]"))
 


### PR DESCRIPTION
When there's an error in the form is was rerendering the errored description as hidden, which meant you couldn't update it.