### PR TITLE
Switch of default AND mode and add means to read Solr params from config

### DIFF
--- a/conf/search.conf
+++ b/conf/search.conf
@@ -1,7 +1,7 @@
 # Search-related configuration
 
 search {
-    andMode: true // default to OR for q param
+    andMode: false // default to OR for q param
 
     boost {
         itemId: 15
@@ -52,4 +52,10 @@ search {
 
     // Enable timing debug
     debugTiming = true
+
+    // Extra params. These MUST be strings and must
+    // not be overwritten, e.g. with `mm` and `mm.autoRelax`.
+    extra {
+      mm: "5<90%"
+    }
 }


### PR DESCRIPTION
This allows adding, e.g. the mm parameter and other arbitrary Solr tuning params, subject to certain constraints such as the keys not overlapping.