### PR TITLE
Ensure locally defined i18n country names override JDK version

### DIFF
--- a/modules/core/app/utils/i18n/package.scala
+++ b/modules/core/app/utils/i18n/package.scala
@@ -89,12 +89,13 @@ package object i18n {
    * on our i18n messages file.
    */
   def countryCodeToName(code: String)(implicit messages: Messages): String = {
-    new Locale("", code).getDisplayCountry(messages.lang.toLocale) match {
-      case d if d.nonEmpty && !d.equalsIgnoreCase(code) => d
-      case c =>
-        val key = "countryCode." + c.toLowerCase
-        val i18n = Messages(key)
-        if (i18n != key) i18n else c
+    val key = "countryCode." + code.toLowerCase
+    val i18n = Messages(key)
+    if (i18n != key) i18n else {
+      new Locale("", code).getDisplayCountry(messages.lang.toLocale) match {
+        case d if d.nonEmpty => d
+        case _ => code
+      }
     }
   }
 
@@ -104,7 +105,7 @@ package object i18n {
   def countryPairList(implicit messages: Messages): List[(String,String)] = {
     val locale = messages.lang.toLocale
     java.util.Locale.getISOCountries.map { code =>
-      code -> WordUtils.capitalize(new java.util.Locale(locale.getLanguage, code).getDisplayCountry(locale))
+      code -> WordUtils.capitalize(countryCodeToName(code))
     }.toList.sortBy(_._2)
   }
 }

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -108,6 +108,7 @@ languageCode.sh=Serbo-Croatian
 # Additional/alternate country codes
 #
 countryCode.xk=Kosovo
+countryCode.mk=North Macedonia
 
 #
 # Pagination etc

--- a/modules/portal/test/views/HelpersSpec.scala
+++ b/modules/portal/test/views/HelpersSpec.scala
@@ -1,8 +1,15 @@
 package views
 
+import play.api.http.HttpConfiguration
+import play.api.{Configuration, Environment}
+import play.api.i18n._
 import play.api.test.PlaySpecification
 
-class HelpersSpec extends PlaySpecification {
+class HelpersSpec extends PlaySpecification with I18nSupport {
+  private val conf = Configuration.reference
+  implicit val messagesApi: MessagesApi = new DefaultMessagesApiProvider(Environment.simple(), conf,
+    new DefaultLangs(Seq(Lang("en"), Lang("fr"))), HttpConfiguration()).get
+
   "view helpers" should {
     "shortens correctly a normal string" in {
     	val nohtml = "This is a test and this is nice because it it not so long and funny"
@@ -18,6 +25,10 @@ class HelpersSpec extends PlaySpecification {
       Helpers.isRightToLeft("זה מימין לשמאל") must beTrue
       Helpers.isRightToLeft("אדולף-אברהם ברמן נולד בוורשה בשנת 1906. הוא למד") must beTrue
       Helpers.isRightToLeft("") must beFalse
+    }
+    "get country names with local overrides" in {
+      implicit val messages: Messages = messagesApi.preferred(Seq(Lang.defaultLang))
+      Helpers.countryCodeToName("mk") must_== "North Macedonia"
     }
   }
 }


### PR DESCRIPTION
This allows more flexibility when country names change more
frequently than JDK is updated. Fixes #41