### PR TITLE
Add an admin facet for items which have restricted visibility.

### DIFF
--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -74,7 +74,15 @@ case class DocumentaryUnits @Inject()(
         name = Messages("documentaryUnit.heldBy"),
         param = "holder",
         display = FacetDisplay.DropDown
-      )
+      ),
+      FieldFacetClass(
+        key = RESTRICTED_FIELD,
+        name = Messages("facet.restricted"),
+        param = "restricted",
+        render = s => Messages("facet.restricted." + s),
+        sort = FacetSort.Fixed,
+        display = FacetDisplay.List
+      ),
     )
   }
 

--- a/modules/admin/app/views/admin/documentaryUnit/listItem.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/listItem.scala.html
@@ -7,6 +7,10 @@
                 <span class="primary-identifier">@item.data.identifier</span> | @item.toStringLang
             </a>
         }
+    }.getOrElse {
+        <a href="@controllers.units.routes.DocumentaryUnits.get(item.id)">
+            <span class="primary-identifier">@item.data.identifier</span>
+        </a>
     }
 } {
     @item.data.primaryDescription(descriptionId).map { desc =>

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -516,14 +516,18 @@ facet.top.tooltip=Show top-level (broadest) items only.
 facet.vocab=Vocabulary
 facet.vocab.tooltip=The vocabulary/set to which the keyword belongs.
 facet.promotable=Promotable
-facet.promotable.tooltip=Items that can be promoted or demoted
+facet.promotable.tooltip=Items that can be promoted or demoted.
 facet.promoted=Promoted
-facet.promoted.tooltip=Items that are currently promoted or demoted
+facet.promoted.tooltip=Items that are currently promoted or demoted.
 facet.score=Promotion Score
-facet.score.tooltip=The sum total of all promotions and demotions, if any
+facet.score.tooltip=The sum total of all promotions and demotions, if any.
 facet.data=Data Availability
-facet.data.tooltip=Show only institutions for which EHRI has archival descriptions
+facet.data.tooltip=Show only institutions for which EHRI has archival descriptions.
 facet.data.yes=Archival Descriptions
+facet.restricted=Visibility
+facet.restricted.tooltip=Whether or not an item is accessible only to certain users or groups.
+facet.restricted.true=Restricted
+facet.restricted.false=Unrestricted
 
 
 


### PR DESCRIPTION
These were hard to find before. Also ensure that we can get to an item's detail page even if it has not descriptions.