### PR TITLE
Change behaviour of vocabs and sets pages to query contents.

### DIFF
--- a/modules/portal/app/views/authoritativeSet/list.scala.html
+++ b/modules/portal/app/views/authoritativeSet/list.scala.html
@@ -1,4 +1,4 @@
-@(result: services.search.SearchResult[(AuthoritativeSet,services.search.SearchHit)], action: Call, watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: utils.SessionPrefs, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, flash: Flash, context: Option[models.base.Holder[_]] = None)
+@(result: services.search.SearchResult[(models.base.Model,services.search.SearchHit)], action: Call, watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: utils.SessionPrefs, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, flash: Flash, context: Option[models.base.Holder[_]] = None)
 
 @views.html.layout.searchLayout(Messages("type.AuthoritativeSet"), EntityType.AuthoritativeSet.toString, result) {
     @views.html.common.search.searchForm(result, action, autofocus = false, key = "search.AuthoritativeSet") {

--- a/modules/portal/app/views/vocabulary/list.scala.html
+++ b/modules/portal/app/views/vocabulary/list.scala.html
@@ -1,4 +1,4 @@
-@(result: services.search.SearchResult[(Vocabulary,services.search.SearchHit)], action: Call, watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: utils.SessionPrefs, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, flash: Flash, context: Option[models.base.Holder[_]] = None)
+@(result: services.search.SearchResult[(models.base.Model,services.search.SearchHit)], action: Call, watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: utils.SessionPrefs, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, flash: Flash, context: Option[models.base.Holder[_]] = None)
 
 @views.html.layout.searchLayout(Messages("type.CvocVocabulary"), EntityType.Vocabulary.toString, result) {
     @views.html.common.search.searchForm(result, action, autofocus = false, key = "search.CvocVocabulary") {


### PR DESCRIPTION
Previously the vocabularies and authoritative sets pages allowed users to search only (promoted) vocabs and sets. However this is pretty useless and counter-intuitive since there are only a handful of either.

This change returns results for their *contents* instead of the holders.

The main problem here is that it's different behaviour to the other search pages.