### PR TITLE
Prevent squashing on the account icon

### DIFF
--- a/modules/portal/app/assets/css/portal/_style.scss
+++ b/modules/portal/app/assets/css/portal/_style.scss
@@ -1030,6 +1030,15 @@ ul.pagination {
   width: 100%;
 }
 
+.user-img-icon {
+  float: left;
+  height: $margin-md;
+  width: $margin-md;
+  background-size: cover;
+  background-position: left;
+  margin-right: $margin-xs;
+}
+
 .user-list {
   a.gravitar {
     background-color: $ehri-gray;

--- a/modules/portal/app/views/common/accountHeaderRightMenu.scala.html
+++ b/modules/portal/app/views/common/accountHeaderRightMenu.scala.html
@@ -50,8 +50,7 @@
 
         <li class="view-options">
             <a href="#" class="@views.Helpers.maybeActive(controllers.portal.users.routes.UserProfiles.profile().url) gravitar dropdown-toggle" data-toggle="dropdown">
-                <img alt="User Avitar" height="20" width="20" class="user-img-icon"
-                     src="@views.Helpers.gravitar(user.data.imageUrl)"/>
+                <div class="user-img-icon" style="background-image: url('@views.Helpers.gravitar(user.data.imageUrl)')"></div>
                 <span class="caret"></span>
             </a>
             <ul class="boolean-preferences dropdown-menu" role="menu">


### PR DESCRIPTION
This uses a css property with background-size: cover instead of a image tag with a fixed width and height.