### PR TITLE
Fix two small date issues: copyright on meta tag and year formatter.

### DIFF
--- a/modules/admin/app/services/ingest/IngestApiService.scala
+++ b/modules/admin/app/services/ingest/IngestApiService.scala
@@ -149,7 +149,7 @@ case class IngestApiService @Inject()(
       Json.prettyPrint(data).getBytes(StandardCharsets.UTF_8)))
     val classifier = config.get[String]("storage.ingest.classifier")
     val time = ZonedDateTime.now()
-    val now = time.format(DateTimeFormatter.ofPattern("YYYYMMddHHmmss"))
+    val now = time.format(DateTimeFormatter.ofPattern("uMMddHHmmss"))
     val path = s"ingest-logs/ingest-$now-${job.id}.json"
     fileStorage.putBytes(classifier, path, bytes, public = true)
   }

--- a/modules/portal/app/views/common/head.scala.html
+++ b/modules/portal/app/views/common/head.scala.html
@@ -18,7 +18,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="copyright" content="EHRI Consortium 2015">
+    <meta name="copyright" content="EHRI Consortium @(java.time.Year.now(java.time.ZoneId.systemDefault()).getValue)">
     <meta name="description" content="@meta.getOrElse("description", "The European Holocaust Research Infrastructure Online Portal")">
     <meta name="keywords" content="@meta.getOrElse("keywords", "EHRI,Portal,Holocaust,Research,Shoah,Archives,History,Deportations,Camps,Ghettos")">
 


### PR DESCRIPTION
Amazingly, YYYY on a java.time.DateTimeFormatter pattern means year of week, and is thus wrong for our purposes a few days of the year! Replaced with 'u', which apparently just means the year (of day.)