### PR TITLE
Revert "Update play to 2.8.2 and clean up some dependencies."

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,8 +49,8 @@ val coreDependencies = backendDependencies ++ Seq(
   openId,
 
   // Force Akka HTTP version
-  "com.typesafe.akka" %% "akka-http"   % "10.1.12",
-  "com.typesafe.akka" %% "akka-http-xml"   % "10.1.12",
+  "com.typesafe.akka" %% "akka-http"   % "10.1.11",
+  "com.typesafe.akka" %% "akka-http-xml"   % "10.1.11",
 
   // Anorm DB lib
   "org.playframework.anorm" %% "anorm" % "2.6.2",
@@ -104,7 +104,10 @@ val portalDependencies = Seq(
 
 val testDependencies = Seq(
   specs2 % Test,
-  "com.h2database" % "h2" % "1.4.193" % Test
+  "com.h2database" % "h2" % "1.4.193" % Test,
+
+  // Used for testing JSON stream parsing...
+  "com.typesafe.akka" %% "akka-stream-testkit" % "2.6.3" % Test
 )
 
 val additionalResolvers = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 //resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.13")
 


### PR DESCRIPTION
Play 2.8.2 introduced some undesirable lazy loading behaviour that broke isolated test runs, so rolling back until it is documented or reverted by Play.