### PR TITLE
Don't update a user's name when logging in via OAuth2 accounts

### DIFF
--- a/modules/portal/test/auth/oauth2/providers/MicrosoftOAuth2ProviderSpec.scala
+++ b/modules/portal/test/auth/oauth2/providers/MicrosoftOAuth2ProviderSpec.scala
@@ -1,6 +1,6 @@
 package auth.oauth2.providers
 
-import auth.oauth2.{OAuth2Constants, OAuth2Info}
+import auth.oauth2.OAuth2Info
 import helpers.ResourceUtils
 import play.api.http.HeaderNames
 import play.api.inject.guice.GuiceApplicationBuilder


### PR DESCRIPTION
They might have set it explicitly or via other means.