### PR TITLE
Add a minimally functional ResourceSync implementation

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -15,9 +15,9 @@ import services.accounts.{AccountManager, SqlAccountManager}
 import services.cypher.{CypherQueryService, CypherService, Neo4jCypherService, SqlCypherQueryService}
 import services.data.{GidSearchResolver, _}
 import services.feedback.{FeedbackService, SqlFeedbackService}
-import services.harvesting.{HarvestEventService, OaiPmhClient, WSOaiPmhClient, SqlHarvestEventService}
+import services.harvesting.{HarvestEventService, OaiPmhClient, ResourceSyncClient, SqlHarvestEventService, WSOaiPmhClient, WSResourceSyncClient}
 import services.htmlpages.{GoogleDocsHtmlPages, HtmlPages}
-import services.ingest.{EadValidator, RelaxNGEadValidator, IngestService, WSIngestService}
+import services.ingest.{EadValidator, IngestService, RelaxNGEadValidator, WSIngestService}
 import services.oauth2.{OAuth2Service, WebOAuth2Service}
 import services.redirects.{MovedPageLookup, SqlMovedPageLookup}
 import services.search.{AkkaStreamsIndexMediator, SearchEngine, SearchIndexMediator, SearchItemResolver}
@@ -80,6 +80,7 @@ class Module extends AbstractModule {
     bind(classOf[IngestService]).to(classOf[WSIngestService])
     bind(classOf[EadValidator]).to(classOf[RelaxNGEadValidator])
     bind(classOf[OaiPmhClient]).to(classOf[WSOaiPmhClient])
+    bind(classOf[ResourceSyncClient]).to(classOf[WSResourceSyncClient])
     bind(classOf[HarvestEventService]).to(classOf[SqlHarvestEventService])
   }
 }

--- a/conf/evolutions/default/1.sql
+++ b/conf/evolutions/default/1.sql
@@ -140,6 +140,20 @@ CREATE TABLE oaipmh_config (
         ON DELETE CASCADE
 );
 
+CREATE TABLE resourcesync_config (
+    repo_id             VARCHAR(50) NOT NULL,
+    import_dataset_id   VARCHAR(50) NOT NULL,
+    endpoint_url        VARCHAR (512) NOT NULL,
+    filter_spec         VARCHAR (512),
+    created             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    comments            TEXT,
+    PRIMARY KEY (repo_id, import_dataset_id),
+    CONSTRAINT resourcesync_config_repo_id_import_dataset_id
+        FOREIGN KEY (repo_id, import_dataset_id)
+        REFERENCES import_dataset(repo_id, id)
+        ON DELETE CASCADE
+);
+
 CREATE TABLE harvest_event (
     id                  SERIAL PRIMARY KEY,
     repo_id             VARCHAR(50) NOT NULL,
@@ -217,6 +231,7 @@ DROP TABLE IF EXISTS import_log;
 DROP TABLE IF EXISTS data_transformation CASCADE;
 DROP TABLE IF EXISTS transformation_config CASCADE;
 DROP TABLE IF EXISTS harvest_event CASCADE;
+DROP TABLE IF EXISTS resourcesync_config CASCADE;
 DROP TABLE IF EXISTS oaipmh_config CASCADE;
 DROP TABLE IF EXISTS import_dataset CASCADE;
 DROP TABLE IF EXISTS cypher_queries CASCADE;

--- a/etc/db_migrations/20201216_add_resourcesync_config_table.sql
+++ b/etc/db_migrations/20201216_add_resourcesync_config_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE resourcesync_config (
+    repo_id             VARCHAR(50) NOT NULL,
+    import_dataset_id   VARCHAR(50) NOT NULL,
+    endpoint_url        VARCHAR (512) NOT NULL,
+    filter_spec         VARCHAR (512),
+    created             TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    comments            TEXT,
+    PRIMARY KEY (repo_id, import_dataset_id),
+    CONSTRAINT resourcesync_config_repo_id_import_dataset_id
+        FOREIGN KEY (repo_id, import_dataset_id)
+            REFERENCES import_dataset(repo_id, id)
+            ON DELETE CASCADE
+);
+

--- a/modules/admin/app/actors/harvesting/ResourceSyncHarvester.scala
+++ b/modules/admin/app/actors/harvesting/ResourceSyncHarvester.scala
@@ -1,0 +1,135 @@
+package actors.harvesting
+
+import java.time.{Duration, LocalDateTime}
+
+import actors.harvesting.ResourceSyncHarvesterManager.ResourceSyncJob
+import akka.actor.Status.Failure
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import models.{FileLink, UserProfile}
+import services.harvesting.ResourceSyncClient
+import services.storage.FileStorage
+
+import scala.concurrent.Future.{successful => immediate}
+import scala.concurrent.{ExecutionContext, Future}
+
+
+object ResourceSyncHarvester {
+
+  // Internal message we send ourselves
+  private case class Fetch(ids: List[FileLink], prefix: String, count: Int) extends Action
+
+  // Other messages we can handle
+  sealed trait Action
+  case object Initial extends Action
+  case object Starting extends Action
+  case class ToDo(num: Int) extends Action
+  case class Completed(total: Int, secs: Long) extends Action
+  case class Error(e: Throwable) extends Action
+  case class DoneFile(name: String) extends Action
+  case class Cancelled(total: Int, secs: Long) extends Action
+  case object Cancel extends Action
+}
+
+
+case class ResourceSyncHarvester (job: ResourceSyncJob, client: ResourceSyncClient, storage: FileStorage)(
+    implicit userOpt: Option[UserProfile], ec: ExecutionContext) extends Actor with ActorLogging {
+  import ResourceSyncHarvester._
+  import akka.pattern.pipe
+
+  override def receive: Receive = {
+    // Start the initial harvest
+    case Initial =>
+      val msgTo = sender()
+      context.become(running(msgTo, 0, LocalDateTime.now()))
+      msgTo ! Starting
+      client.list(job.data.config)
+        .map {list =>
+          msgTo ! ToDo(list.size)
+          Fetch(list.toList, commonDirPrefix(list.toList), 0)
+        }
+        .pipeTo(self)
+  }
+
+
+  // The harvest is running
+  def running(msgTo: ActorRef, done: Int, start: LocalDateTime): Receive = {
+    // Harvest an individual item
+    case Fetch(item :: rest, prefix, count) =>
+      log.debug(s"Calling become with new total: $count")
+      context.become(running(msgTo, count, start))
+
+      copyItem(item, prefix).map { name =>
+        msgTo ! DoneFile(name)
+        Fetch(rest, prefix, count + 1)
+      }.pipeTo(self)
+
+    // Finished harvesting this resource list
+    case Fetch(Nil, _, done) =>
+      msgTo ! Completed(done, time(start))
+
+    // Cancel harvest
+    case Cancel =>
+      msgTo ! Cancelled(done, time(start))
+      context.stop(self)
+
+    case Failure(e) =>
+      msgTo ! e
+      context.stop(self)
+
+    case m =>
+      log.error(s"Unexpected message: $m: ${m.getClass}")
+  }
+
+  private def copyItem(item: FileLink, prefix: String): Future[String] = {
+    // get the basename, or unique segment, for this file
+    // in most cases this will be the basename, but not always
+    val name = item.loc.replace(prefix, "")
+
+    // file metadata
+    val meta = Map(
+      "source" -> "rs",
+      "rs-endpoint" -> job.data.config.url,
+      "rs-filter" -> job.data.config.filter.getOrElse(""),
+      "rs-job-id" -> job.jobId,
+    ) ++ item.hash.map(h => "hash" -> h)
+
+    // Get the storage metadata for checking the file hash...
+    storage.info(job.data.classifier, job.data.prefix + name).flatMap {
+      // If it exists and matches we've got nowt to do..
+      case Some((_, userMeta)) if userMeta.contains("hash") && userMeta.get("hash") == item.hash =>
+        immediate("~ " + name)
+
+      // Either the hash doesn't match or the file's not there yet
+      // so upload it now...
+      case _ =>
+        val bytes = client.get(item)
+        storage.putBytes(
+          job.data.classifier,
+          job.data.prefix + name,
+          bytes,
+          item.contentType,
+          meta = meta
+        ).map { _ => "+ " + name }
+    }
+  }
+
+  private def commonDirPrefix(resLinks: List[FileLink]): String = resLinks match {
+    case Nil => ""
+    case head :: Nil => head.loc.substring(0, head.loc.lastIndexOf('/') + 1)
+    case list =>
+      // Get the common string prefix...
+      // Pinched from Rosetta code because I'm too lazy to write this:
+      // https://rosettacode.org/wiki/Longest_common_prefix#Scala
+      def lcp(list: Seq[String]): String = list.foldLeft("") { (_, _) =>
+        (list.min.view, list.max.view).zipped.takeWhile(v => v._1 == v._2).map(_._1).mkString
+      }
+
+      // Now get the dirname of the common string prefix
+      val prefix = lcp(list.map(_.loc).sorted)
+      if (prefix.endsWith("/")) prefix
+      else prefix.substring(0, prefix.lastIndexOf('/') + 1)
+  }
+
+  private def time(from: LocalDateTime): Long =
+    Duration.between(from, LocalDateTime.now()).toMillis / 1000
+}

--- a/modules/admin/app/actors/harvesting/ResourceSyncHarvesterManager.scala
+++ b/modules/admin/app/actors/harvesting/ResourceSyncHarvesterManager.scala
@@ -1,0 +1,136 @@
+package actors.harvesting
+
+import actors.harvesting.ResourceSyncHarvesterManager.ResourceSyncJob
+import akka.actor.SupervisorStrategy.Stop
+import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
+import models.{ResourceSyncConfig, UserProfile}
+import services.harvesting.{HarvestEventHandle, HarvestEventService, ResourceSyncClient}
+import services.storage.FileStorage
+import utils.WebsocketConstants
+
+import scala.concurrent.ExecutionContext
+
+
+object ResourceSyncHarvesterManager {
+
+  /**
+    * A description of an OAI-ResourceSync harvest task.
+    *
+    * @param config     the endpoint configuration
+    * @param classifier the storage classifier on which to save files
+    * @param prefix     the path prefix on which to save files, after
+    *                   which the item identifier will be appended
+    */
+  case class ResourceSyncData(
+    config: ResourceSyncConfig,
+    classifier: String,
+    prefix: String,
+  )
+
+  /**
+    * A single harvest job with a unique ID.
+    */
+  case class ResourceSyncJob(repoId: String, datasetId: String, jobId: String, data: ResourceSyncData)
+
+}
+
+
+case class ResourceSyncHarvesterManager(job: ResourceSyncJob, client: ResourceSyncClient, storage: FileStorage, eventLog: HarvestEventService)(
+  implicit userOpt: Option[UserProfile], ec: ExecutionContext) extends Actor with ActorLogging {
+
+  import ResourceSyncHarvester._
+  import akka.pattern.pipe
+
+  override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() {
+    case e =>
+      self ! Error(e)
+      Stop
+  }
+
+ // Ready state: we've received a job but won't actually start
+  // until there is a channel to talk through
+  override def receive: Receive = {
+    case chan: ActorRef =>
+      log.debug("Received initial subscriber, starting...")
+      val runner = context.actorOf(Props(ResourceSyncHarvester(job, client, storage)))
+      context.become(running(runner, Set(chan), Option.empty))
+      runner ! Initial
+  }
+
+  /**
+    * Running state.
+    *
+    * @param runner the harvest runner actor
+    * @param subs   a set of subscribers to message w/ updates
+    * @param handle a handle through which the job logging can be concluded
+    */
+  def running(runner: ActorRef, subs: Set[ActorRef], handle: Option[HarvestEventHandle]): Receive = {
+
+    // Add a new message subscriber
+    case chan: ActorRef =>
+      log.debug(s"Added new message subscriber, ${subs.size}")
+      context.watch(chan)
+      context.become(running(runner, subs + chan, handle))
+
+    case Terminated(actor) if actor == runner =>
+      context.stop(self)
+
+    // Remove terminated subscribers
+    case Terminated(chan) =>
+      log.debug(s"Removing subscriber: $chan")
+      context.unwatch(chan)
+      context.become(running(runner, subs - chan, handle))
+
+    // Confirmation the runner has started
+    case Starting =>
+      msg(s"Starting harvest with job id: ${job.jobId}", subs)
+
+    case ToDo(num) =>
+      msg(s"Syncing $num file(s)", subs)
+
+    // Cancel harvest.. here we tell the runner to exit
+    // and shut down on its termination signal...
+    case Cancel => runner ! Cancel
+
+    // A file has been harvested
+    case DoneFile(id) =>
+      msg(id, subs)
+      if (handle.isEmpty) {
+        eventLog.save(job.repoId, job.datasetId, job.jobId).pipeTo(self)
+      }
+
+      // We've received a log handle which we can use to say how
+      // this job finished: via error, cancellation, or otherwise
+    case handle: HarvestEventHandle =>
+      context.become(running(runner, subs, Some(handle)))
+
+    // Received confirmation that the runner has shut down
+    case Cancelled(count, secs) =>
+      msg(s"${WebsocketConstants.ERR_MESSAGE}: cancelled after $count file(s) in $secs seconds", subs)
+      handle.foreach(_.cancel())
+      context.stop(self)
+
+    // The runner has completed, so we log the
+    // event and shut down too
+    case Completed(count, secs) =>
+      msg(s"${WebsocketConstants.DONE_MESSAGE}: " +
+        s"harvested $count file(s) in $secs seconds", subs)
+      handle.foreach(_.close())
+      context.stop(self)
+
+    // The runner has thrown an unexpected error. Log the event
+    // and shut down
+    case Error(e) =>
+      msg(s"${WebsocketConstants.ERR_MESSAGE}: sync error: ${e.getMessage}", subs)
+      handle.foreach(_.error(e))
+      context.stop(self)
+
+    case m =>
+      log.error(s"Unexpected message: $m")
+  }
+
+  private def msg(s: String, subs: Set[ActorRef]): Unit = {
+    log.info(s + s" (subscribers: ${subs.size})")
+    subs.foreach(_ ! s)
+  }
+}

--- a/modules/admin/app/actors/transformation/XmlConverter.scala
+++ b/modules/admin/app/actors/transformation/XmlConverter.scala
@@ -75,7 +75,7 @@ case class XmlConverter (job: XmlConvertJob, transformer: XmlTransformer, storag
       job.data.only.map { key =>
         storage.info(job.data.classifier, job.data.inPrefix + key)
           .map {
-            case Some(meta) => Convert(List(meta), truncated = false, None, done)
+            case Some((meta, _)) => Convert(List(meta), truncated = false, None, done)
             case None =>
               msgTo ! Error(s"Key not found: ${job.data.inPrefix + key}",
                 new RuntimeException(s"Missing key: ${job.data.inPrefix + key}"))

--- a/modules/admin/app/assets/js/components/ingest-manager.js
+++ b/modules/admin/app/assets/js/components/ingest-manager.js
@@ -253,28 +253,20 @@ Vue.component("ingest-manager", {
           v-on:filter="filterFiles" 
           v-on:clear="clearFilter"
           v-on:refresh="load" />
-        
-        <button v-bind:disabled="files.length===0 || validationRunning" class="btn btn-sm btn-default"
-                v-on:click.prevent="validateFiles(selectedTags)" v-if="selectedKeys.length">
-          <i class="fa fa-fw" v-bind:class="{'fa-flag-o': !validationRunning, 'fa-circle-o-notch fa-spin': validationRunning}"/>
-          Validate Selected ({{selectedKeys.length}})
-        </button>
-        <button v-bind:disabled="files.length===0 || validationRunning" class="btn btn-sm btn-default"
-                v-on:click.prevent="validateAll" v-else>
-          <i class="fa fa-fw" v-bind:class="{'fa-flag-o': !validationRunning, 'fa-circle-o-notch fa-spin': validationRunning}"/>
-          Validate All
-        </button>
 
-        <button v-bind:disabled="files.length === 0 || ingestJobId" class="btn btn-sm btn-default"
-                v-on:click.prevent="deleteFiles(selectedKeys)" v-if="selectedKeys.length > 0">
-          <i class="fa fa-trash-o"/>
-          Delete Selected ({{selectedKeys.length}})
-        </button>
-        <button v-bind:disabled="files.length === 0 || ingestJobId" class="btn btn-sm btn-default" v-on:click.prevent="deleteAll()"
-                v-else>
-          <i class="fa fa-trash-o"/>
-          Delete All
-        </button>
+        <validate-button
+          v-bind:selected="selectedKeys.length"
+          v-bind:disabled="files.length === 0 || ingestJobId !== null"
+          v-bind:active="validationRunning"
+          v-on:validate="selectedKeys.length ? validateFiles(selectedKeys) : validateAll()"
+        />
+
+        <delete-button
+          v-bind:selected="selectedKeys.length"
+          v-bind:disabled="files.length === 0 || ingestJobId !== null"
+          v-bind:active="!_.isEmpty(deleting)"
+          v-on:delete="selectedKeys.length ? deleteFiles(selectedKeys) : deleteAll()"
+        />
 
         <button v-bind:disabled="files.length === 0 || ingestJobId" class="btn btn-sm btn-default"
                 v-on:click.prevent="showOptions = !showOptions" v-if="selectedKeys.length">
@@ -340,7 +332,7 @@ Vue.component("ingest-manager", {
               <a href="#" class="nav-link" v-bind:class="{'active': tab === 'preview'}"
                  v-on:click.prevent="tab = 'preview'">
                 File Preview
-                <template v-if="previewing"> - {{previewing.key}}</template>
+                <template v-if="previewing"> - {{previewing.key|decodeUri}}</template>
               </a>
             </li>
             <li class="nav-item">

--- a/modules/admin/app/assets/js/components/upload-manager.js
+++ b/modules/admin/app/assets/js/components/upload-manager.js
@@ -204,28 +204,20 @@ Vue.component("upload-manager", {
         <filter-control v-bind:filter="filter"
                         v-on:filter="filterFiles"
                         v-on:clear="clearFilter"/>
-        
-        <button v-bind:disabled="files.length===0" class="btn btn-sm btn-default"
-                v-on:click.prevent="validateFiles(selectedTags)" v-if="selectedKeys.length">
-          <i class="fa fa-fw" v-bind:class="{'fa-flag-o': !validationRunning, 'fa-circle-o-notch fa-spin': validationRunning}"/>
-          Validate Selected ({{selectedKeys.length}})
-        </button>
-        <button v-bind:disabled="files.length===0 || validationRunning" class="btn btn-sm btn-default"
-                v-on:click.prevent="validateAll" v-else>
-          <i class="fa fa-fw" v-bind:class="{'fa-flag-o': !validationRunning, 'fa-circle-o-notch fa-spin': validationRunning}"/>
-          Validate All
-        </button>
 
-        <button v-bind:disabled="files.length===0" class="btn btn-sm btn-default"
-                v-on:click.prevent="deleteFiles(selectedKeys)" v-if="selectedKeys.length > 0">
-          <i class="fa fa-trash-o"/>
-          Delete Selected ({{selectedKeys.length}})
-        </button>
-        <button v-bind:disabled="files.length===0" class="btn btn-sm btn-default" v-on:click.prevent="deleteAll()"
-                v-else>
-          <i class="fa fa-trash-o"/>
-          Delete All
-        </button>
+        <validate-button
+          v-bind:selected="selectedKeys.length"
+          v-bind:disabled="files.length === 0 || uploading.length > 0"
+          v-bind:active="validationRunning"
+          v-on:validate="selectedKeys.length ? validateFiles(selectedKeys) : validateAll()"
+        />
+
+        <delete-button
+          v-bind:selected="selectedKeys.length"
+          v-bind:disabled="files.length === 0 || uploading.length > 0"
+          v-bind:active="!_.isEmpty(deleting)"
+          v-on:delete="selectedKeys.length ? deleteFiles(selectedKeys) : deleteAll()"
+        />
 
         <button class="file-upload-button btn btn-sm btn-default">
           <input class="file-selector-input"

--- a/modules/admin/app/assets/js/datamanager-common.js
+++ b/modules/admin/app/assets/js/datamanager-common.js
@@ -31,9 +31,14 @@ Vue.filter("stageName", function(code, config) {
   switch (code) {
     case "oaipmh": return "Harvesting";
     case "upload": return "Uploads";
+    case "rs": return "ResourceSync";
     default: return code;
   }
-})
+});
+
+Vue.filter("decodeUri", function(s) {
+  return decodeURI(s);
+});
 
 Vue.filter("prettyDate", function (time) {
   let f = time => {
@@ -154,7 +159,7 @@ let validatorMixin = {
       } else {
         errs.forEach(item => {
           if (item.errors.length > 0) {
-            this.validationLog.push('<span class="text-danger">' + item.key + ':</span>')
+            this.validationLog.push('<span class="text-danger">' + decodeURI(item.key) + ':</span>')
             item.errors.forEach(err => {
               this.validationLog.push("    " + err.line + "/" + err.pos + " - " + err.error);
             })
@@ -623,7 +628,7 @@ Vue.component("files-table", {
           <td v-on:click.stop="toggleItem(file, selected[file.key])">
             <input type="checkbox" v-bind:checked="selected[file.key]">
           </td>
-          <td>{{file.key}}</td>
+          <td>{{file.key|decodeUri}}</td>
           <td v-bind:title="file.lastModified">{{file.lastModified | prettyDate}}</td>
           <td>{{file.size | humanFileSize(true)}}</td>
 
@@ -687,7 +692,7 @@ Vue.component("file-picker-suggestion", {
   props: {selected: Boolean, item: Object,},
   template: `
     <div @click="$emit('selected', item)" class="file-picker-suggestion" v-bind:class="{'selected': selected}">
-        {{ item.key }} 
+        {{ item.key|decodeUri }} 
     </div>
   `
 });
@@ -793,7 +798,7 @@ Vue.component("info-modal", {
   },
   template: `
     <modal-window v-on:close="$emit('close')">
-      <template v-slot:title>{{fileInfo.meta.key}}</template>
+      <template v-slot:title>{{fileInfo.meta.key|decodeUri}}</template>
       <dl>
         <dt>File size:</dt>
         <dd>{{fileInfo.meta.size|humanFileSize}}</dd>
@@ -838,6 +843,44 @@ Vue.component("filter-control", {
     </div>
   `
 });
+
+Vue.component("validate-button", {
+  props: {
+    disabled: Boolean,
+    selected: Number,
+    active: Boolean,
+  },
+  template: `
+    <button v-bind:disabled="disabled" v-on:click.prevent="$emit('validate')" class="btn btn-sm btn-default">
+      <i class="fa fa-fw" v-bind:class="{'fa-flag-o': !active, 'fa-circle-o-notch fa-spin': active}"/>
+      <template v-if="selected > 0">
+        Validate Selected ({{selected}})
+      </template>
+      <template v-else>
+        Validate All
+      </template>
+    </button>
+ `
+});
+
+Vue.component("delete-button", {
+  props: {
+    disabled: Boolean,
+    selected: Number,
+    active: Boolean,
+  },
+  template: `
+    <button v-bind:disabled="disabled" v-on:click.prevent="$emit('delete')" class="btn btn-sm btn-default">
+      <i class="fa fa-fw" v-bind:class="{'fa-trash-o': !active, 'fa-circle-o-notch fa-spin': active}"/>
+      <template v-if="selected > 0">
+        Delete Selected ({{selected}})
+      </template>
+      <template v-else>
+        Delete All
+      </template>
+    </button>
+  `
+})
 
 Vue.component("log-window", {
   props: {

--- a/modules/admin/app/assets/js/datamanager-dao.js
+++ b/modules/admin/app/assets/js/datamanager-dao.js
@@ -108,6 +108,30 @@ let DAO = class {
     return this.call(this.service.OaiPmhConfigs.cancelHarvest(this.repoId, jobId));
   }
 
+  sync(ds, config) {
+    return this.call(this.service.ResourceSyncConfigs.sync(this.repoId, ds), config);
+  }
+
+  cancelSync(jobId) {
+    return this.call(this.service.ResourceSyncConfigs.cancelSync(this.repoId, jobId));
+  }
+
+  getSyncConfig(ds) {
+    return this.call(this.service.ResourceSyncConfigs.get(this.repoId, ds));
+  }
+
+  saveSyncConfig(ds, config) {
+    return this.call(this.service.ResourceSyncConfigs.save(this.repoId, ds), config);
+  }
+
+  deleteSyncConfig(ds) {
+    return this.call(this.service.ResourceSyncConfigs.delete(this.repoId, ds));
+  }
+
+  testSyncConfig(ds, config) {
+    return this.call(this.service.ResourceSyncConfigs.test(this.repoId, ds), config);
+  }
+
   getConfig(ds) {
     return this.call(this.service.OaiPmhConfigs.get(this.repoId, ds));
   }

--- a/modules/admin/app/assets/js/datamanager.js
+++ b/modules/admin/app/assets/js/datamanager.js
@@ -139,6 +139,7 @@ Vue.component("dataset-form", {
             <option v-bind:value="null" disabled selected hidden>(required)</option>
             <option value="upload">Uploads</option>
             <option value="oaipmh">OAI-PMH Harvesting</option>
+            <option value="rs">ResourceSync</option>
           </select>
         </div>
         <div class="form-group">
@@ -312,6 +313,11 @@ Vue.component("dataset-manager", {
               <i class="fa fw-fw fa-cloud-download"></i>
               Harvest Data
             </a>
+            <a v-if="dataset.src === 'rs'" href="#tab-input" class="nav-link" v-bind:class="{'active': tab === 'input'}"
+               v-on:click.prevent="switchTab('input')">
+              <i class="fa fw-fw fa-clone"></i>
+              Sync Data
+            </a>
             <a v-if="dataset.src === 'upload'" href="#tab-input" class="nav-link" v-bind:class="{'active': tab === 'input'}"
                v-on:click.prevent="switchTab('input')">
               <i class="fa fw-fw fa-upload"></i>
@@ -367,6 +373,14 @@ Vue.component("dataset-manager", {
         <div id="tab-input" class="stage-tab" v-show="tab === 'input'">
           <oaipmh-manager
             v-if="dataset.src === 'oaipmh'"
+            v-bind:dataset-id="dataset.id"
+            v-bind:fileStage="config.input"
+            v-bind:config="config"
+            v-bind:active="tab === 'input'"
+            v-bind:api="api"
+            v-on:error="setError"  />
+          <rs-manager
+            v-if="dataset.src === 'rs'"
             v-bind:dataset-id="dataset.id"
             v-bind:fileStage="config.input"
             v-bind:config="config"

--- a/modules/admin/app/controllers/institutions/DataTransformations.scala
+++ b/modules/admin/app/controllers/institutions/DataTransformations.scala
@@ -109,7 +109,7 @@ case class DataTransformations @Inject()(
 
       val path = prefix(id, ds, stage) + fileName
       storage.info(bucket, path).flatMap {
-        case Some(meta) =>
+        case Some((meta, _)) =>
           val outF = meta.eTag match {
             // If we have an eTag for the file contents, cache the transformation against it
             case Some(tag) => transformCache.getOrElseUpdate(digest(tag, m))(downloadAndConvertFile(path, m))

--- a/modules/admin/app/controllers/institutions/ImportFiles.scala
+++ b/modules/admin/app/controllers/institutions/ImportFiles.scala
@@ -133,7 +133,7 @@ case class ImportFiles @Inject()(
     val pre = prefix(id, ds, stage)
     val path = pre + fileName
     for {
-      Some(meta) <- storage.info(bucket, path, versionId)
+      Some((meta, _)) <- storage.info(bucket, path, versionId)
       versions <- storage.listVersions(bucket, path)
     } yield Ok(Json.obj(
       "meta" -> meta.copy(key = meta.key.replace(pre, "")),
@@ -253,7 +253,7 @@ case class ImportFiles @Inject()(
     // limit parallelism to the specified amount
     Source(keys.toList)
       .mapAsync(4)(path => storage.info(bucket, path).map(info => path -> info))
-      .collect { case (path, Some(meta)) =>
+      .collect { case (path, Some((meta, _))) =>
         val id = meta.versionId.map(vid => s"$path?versionId=$vid").getOrElse(path)
         id -> storage.uri(meta.classifier, meta.key, duration = 2.hours, versionId = meta.versionId)
       }

--- a/modules/admin/app/controllers/institutions/ResourceSyncConfigs.scala
+++ b/modules/admin/app/controllers/institutions/ResourceSyncConfigs.scala
@@ -1,0 +1,93 @@
+package controllers.institutions
+
+import java.util.UUID
+
+import actors.harvesting.ResourceSyncHarvesterManager.{ResourceSyncData, ResourceSyncJob}
+import actors.harvesting.{ResourceSyncHarvester, ResourceSyncHarvesterManager}
+import akka.actor.Props
+import akka.stream.Materializer
+import controllers.AppComponents
+import controllers.base.AdminController
+import controllers.generic._
+import defines.FileStage
+import javax.inject._
+import models._
+import play.api.Logger
+import play.api.http.HeaderNames
+import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+import services.harvesting.{HarvestEventService, ResourceSyncClient, ResourceSyncConfigService}
+import services.storage.FileStorage
+
+
+@Singleton
+case class ResourceSyncConfigs @Inject()(
+  controllerComponents: ControllerComponents,
+  @Named("dam") storage: FileStorage,
+  appComponents: AppComponents,
+  rsClient: ResourceSyncClient,
+  ws: WSClient,
+  configs: ResourceSyncConfigService,
+  harvestEvents: HarvestEventService,
+)(implicit mat: Materializer) extends AdminController with StorageHelpers with Update[Repository] {
+
+  private val logger: Logger = Logger(classOf[ResourceSyncConfigs])
+
+  def get(id: String, ds: String): Action[AnyContent] = EditAction(id).async { implicit request =>
+    configs.get(id, ds).map { opt =>
+      Ok(Json.toJson(opt))
+    }
+  }
+
+  def save(id: String, ds: String): Action[ResourceSyncConfig] = EditAction(id).async(parse.json[ResourceSyncConfig]) { implicit request =>
+    configs.save(id, ds, request.body).map { r =>
+      Ok(Json.toJson(r))
+    }
+  }
+
+  def delete(id: String, ds: String): Action[AnyContent] = EditAction(id).async { implicit request =>
+    configs.delete(id, ds).map { r =>
+      Ok(Json.toJson(r))
+    }
+  }
+
+  def test(id: String, ds: String): Action[ResourceSyncConfig] = EditAction(id).async(parse.json[ResourceSyncConfig]) { implicit request =>
+    ws.url(request.body.url).head().map { r =>
+      if (r.status != 200)
+        BadRequest(Json.obj("error" -> s"Unexpected status: ${r.status}"))
+      else if (r.header(HeaderNames.CONTENT_LENGTH).map(_.toLong).getOrElse(0L) <= 0)
+        BadRequest(Json.obj("error" -> "Changelist is of zero or unknown length"))
+      else if (!r.header(HeaderNames.CONTENT_TYPE).forall(s => s == "text/xml" || s == "application/xml"))
+        BadRequest(Json.obj("error" -> s"Unexpected content type"))
+      else
+        Ok(Json.toJson("ok" -> true))
+    }
+  }
+
+
+  def sync(id: String, ds: String): Action[ResourceSyncConfig] = EditAction(id).apply(parse.json[ResourceSyncConfig]) { implicit request =>
+      val endpoint = request.body
+      val jobId = UUID.randomUUID().toString
+      val data = ResourceSyncData(endpoint, bucket, prefix = prefix(id, ds, FileStage.Input))
+      val job = ResourceSyncJob(id, ds, jobId, data = data)
+      mat.system.actorOf(Props(ResourceSyncHarvesterManager(job, rsClient, storage, harvestEvents)), jobId)
+
+      Ok(Json.obj(
+        "url" -> controllers.admin.routes.Tasks
+          .taskMonitorWS(jobId).webSocketURL(globalConfig.https),
+        "jobId" -> jobId
+      ))
+  }
+
+  def cancelSync(id: String, jobId: String): Action[AnyContent] = EditAction(id).async { implicit request =>
+    import scala.concurrent.duration._
+    mat.system.actorSelection("user/" + jobId).resolveOne(5.seconds).map { ref =>
+      logger.info(s"Monitoring job: $jobId")
+      ref ! ResourceSyncHarvester.Cancel
+      Ok(Json.obj("ok" -> true))
+    }.recover {
+      case e => InternalServerError(Json.obj("error" -> e.getMessage))
+    }
+  }
+}

--- a/modules/admin/app/models/ImportDataset.scala
+++ b/modules/admin/app/models/ImportDataset.scala
@@ -19,6 +19,7 @@ object ImportDataset {
   object Src extends Enumeration with StorableEnum {
     val Upload = Value("upload")
     val OaiPmh = Value("oaipmh")
+    val Rs = Value("rs")
 
     implicit val _format: Format[ImportDataset.Src.Value] = EnumUtils.enumFormat(ImportDataset.Src)
   }

--- a/modules/admin/app/models/OaiPmhConfig.scala
+++ b/modules/admin/app/models/OaiPmhConfig.scala
@@ -17,8 +17,7 @@ object OaiPmhConfig {
   import play.api.libs.functional.syntax._
   import play.api.libs.json._
   implicit val _reads: Reads[OaiPmhConfig] = (
-    (__ \ URL).read[String](Reads.filter(
-      JsonValidationError("errors.badUrlPattern"))(url => utils.forms.isValidUrl(url))) and
+    (__ \ URL).read[String](Reads.filter(JsonValidationError("errors.invalidUrl"))(utils.forms.isValidUrl)) and
     (__ \ METADATA_FORMAT).read[String] and
     (__ \ SET).readNullable[String]
   )(OaiPmhConfig.apply _)
@@ -27,9 +26,7 @@ object OaiPmhConfig {
   implicit val _format: Format[OaiPmhConfig] = Format(_reads, _writes)
 
   val form: Form[OaiPmhConfig] = Form(mapping(
-    URL -> nonEmptyText.verifying("errors.badUrlPattern",
-      url => utils.forms.isValidUrl(url)
-    ),
+    URL -> nonEmptyText.verifying("errors.invalidUrl", utils.forms.isValidUrl),
     METADATA_FORMAT -> nonEmptyText,
     SET -> optional(text).transform[Option[String]](_.filterNot(_.trim.isEmpty), identity)
   )(OaiPmhConfig.apply)(OaiPmhConfig.unapply))

--- a/modules/admin/app/models/ResourceSyncConfig.scala
+++ b/modules/admin/app/models/ResourceSyncConfig.scala
@@ -1,0 +1,39 @@
+package models
+
+import java.util.regex.{Pattern, PatternSyntaxException}
+
+import play.api.data.Form
+import play.api.data.Forms.{mapping, nonEmptyText, optional}
+
+case class ResourceSyncConfig(
+  url: String,
+  filter: Option[String] = None
+)
+
+
+object ResourceSyncConfig {
+  final val URL = "url"
+  final val FILTER = "filter"
+
+  private val isValidRegex: (String => Boolean) = s => try {
+    Pattern.compile(s);
+    true
+  } catch {
+    case _: PatternSyntaxException => false
+  }
+
+  import play.api.libs.functional.syntax._
+  import play.api.libs.json._
+  implicit val _reads: Reads[ResourceSyncConfig] = (
+    (__ \ URL).read(Reads.filter(JsonValidationError("errors.invalidUrl"))(utils.forms.isValidUrl)) and
+    (__ \ FILTER).readNullable[String](Reads.filter(JsonValidationError("errors.badRegexPattern"))(isValidRegex))
+  )(ResourceSyncConfig.apply _)
+
+  implicit val _writes: Writes[ResourceSyncConfig] = Json.writes[ResourceSyncConfig]
+  implicit val _format: Format[ResourceSyncConfig] = Format(_reads, _writes)
+
+  val form: Form[ResourceSyncConfig] = Form(mapping(
+    URL -> nonEmptyText.verifying("errors.invalidUrl", utils.forms.isValidUrl),
+    FILTER -> optional(nonEmptyText.verifying("errors.badRegexPattern", isValidRegex))
+  )(ResourceSyncConfig.apply)(ResourceSyncConfig.unapply))
+}

--- a/modules/admin/app/models/ResourceSyncItem.scala
+++ b/modules/admin/app/models/ResourceSyncItem.scala
@@ -1,0 +1,18 @@
+package models
+
+import java.time.Instant
+
+sealed trait ResourceSyncItem {
+  def loc: String
+}
+case class ResourceList(loc: String) extends ResourceSyncItem
+case class CapabilityList(loc: String) extends ResourceSyncItem
+
+case class FileLink(
+  loc: String,
+  updated: Option[Instant] = None,
+  length: Option[Long] = None,
+  contentType: Option[String] = None,
+  hash: Option[String] = None,
+) extends ResourceSyncItem
+

--- a/modules/admin/app/services/harvesting/OaiPmhClient.scala
+++ b/modules/admin/app/services/harvesting/OaiPmhClient.scala
@@ -6,8 +6,13 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import models.{OaiPmhConfig, OaiPmhIdentity}
 import org.w3c.dom.Element
+import play.api.i18n.Messages
 
 import scala.concurrent.Future
+
+case class OaiPmhError(code: String, value: String = "") extends RuntimeException(code) {
+  def errorMessage(implicit messages: Messages): String = Messages(s"oaipmh.error.$code", value)
+}
 
 /**
   * Interact with OAI-PMH endpoints.

--- a/modules/admin/app/services/harvesting/ResourceSyncClient.scala
+++ b/modules/admin/app/services/harvesting/ResourceSyncClient.scala
@@ -1,0 +1,46 @@
+package services.harvesting
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import models.{FileLink, ResourceSyncConfig}
+import play.api.i18n.Messages
+
+import scala.concurrent.Future
+
+case class ResourceSyncError(code: String, value: String = "") extends RuntimeException(code) {
+  def errorMessage(implicit messages: Messages): String = Messages(s"resourceSync.error.$code", value)
+}
+
+/**
+  * Minimally functional client for the OAI ResourceSync spec.
+  *
+  * Currently this does nothing except:
+  *
+  *  - parse a capabilitylist.xml for resourcelist links
+  *  - read resource URLs out of those resourcelist.xml docs
+  *
+  * There is so far no support for changelists, resourcedumps,
+  * changedumps and smart synchronisation using timestamps etc.
+  */
+trait ResourceSyncClient {
+  /**
+    * Given a config, which consists of a capabilitylist URL and
+    * a regex filter, fetch a list of file URLs.
+    *
+    * @param config an RS config
+    * @return a list of files in linked resourcelists
+    */
+  def list(config: ResourceSyncConfig): Future[Seq[FileLink]]
+
+  /**
+    * Fetch the byte source for a file item.
+    *
+    * @throws ResourceSyncError if attempting to fetch the
+    *                           file's data does not return
+    *                           the correct HTTP status code
+    * @param link a [[FileLink]] item
+    * @return the source of bytes
+    */
+  @throws[ResourceSyncError]
+  def get(link: FileLink): Source[ByteString, _]
+}

--- a/modules/admin/app/services/harvesting/ResourceSyncConfigService.scala
+++ b/modules/admin/app/services/harvesting/ResourceSyncConfigService.scala
@@ -1,0 +1,17 @@
+package services.harvesting
+
+import com.google.inject.ImplementedBy
+import models.ResourceSyncConfig
+
+import scala.concurrent.Future
+
+/**
+ * Data access object trait for managing OAI-PMH
+  * configurations.
+ */
+@ImplementedBy(classOf[SqlResourceSyncConfigService])
+trait ResourceSyncConfigService {
+  def get(id: String, ds: String): Future[Option[ResourceSyncConfig]]
+  def save(id: String, ds: String, config: ResourceSyncConfig): Future[ResourceSyncConfig]
+  def delete(id: String, ds: String): Future[Boolean]
+}

--- a/modules/admin/app/services/harvesting/SqlResourceSyncConfigService.scala
+++ b/modules/admin/app/services/harvesting/SqlResourceSyncConfigService.scala
@@ -1,0 +1,50 @@
+package services.harvesting
+
+import akka.actor.ActorSystem
+import anorm.{Macro, RowParser, _}
+import javax.inject.{Inject, Singleton}
+import models.ResourceSyncConfig
+import play.api.db.Database
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+case class SqlResourceSyncConfigService @Inject()(db: Database, actorSystem: ActorSystem) extends ResourceSyncConfigService {
+
+  private implicit def executionContext: ExecutionContext =
+    actorSystem.dispatchers.lookup("contexts.simple-db-lookups")
+
+  private implicit val parser: RowParser[ResourceSyncConfig] =
+    Macro.parser[ResourceSyncConfig]("endpoint_url", "filter_spec")
+
+  override def get(id: String, ds: String): Future[Option[ResourceSyncConfig]] = Future {
+    db.withConnection { implicit conn =>
+      SQL"SELECT * FROM resourcesync_config WHERE repo_id = $id AND import_dataset_id = $ds"
+        .as(parser.singleOpt)
+    }
+  }
+
+  override def delete(id: String, ds: String): Future[Boolean] = Future {
+    db.withConnection { implicit conn =>
+      SQL"DELETE FROM resourcesync_config WHERE repo_id = $id AND import_dataset_id = $ds".executeUpdate() == 1
+    }
+  }
+
+  override def save(id: String, ds: String, data: ResourceSyncConfig): Future[ResourceSyncConfig] = Future {
+    db.withTransaction { implicit conn =>
+      SQL"""INSERT INTO resourcesync_config
+        (repo_id, import_dataset_id, endpoint_url, filter_spec)
+        VALUES (
+          $id,
+          $ds,
+          ${data.url},
+          ${data.filter}
+      ) ON CONFLICT (repo_id, import_dataset_id) DO UPDATE
+        SET
+          endpoint_url = ${data.url},
+          filter_spec = ${data.filter}
+        RETURNING *
+      """.executeInsert(parser.single)
+    }
+  }
+}

--- a/modules/admin/app/services/harvesting/WSOaiPmhClient.scala
+++ b/modules/admin/app/services/harvesting/WSOaiPmhClient.scala
@@ -14,7 +14,6 @@ import models.OaiPmhIdentity.Granularity
 import models.{OaiPmhConfig, OaiPmhIdentity}
 import org.w3c.dom.Element
 import play.api.Logger
-import play.api.i18n.Messages
 import play.api.libs.ws.{WSClient, WSResponse}
 import services.ingest.XmlFormatter
 
@@ -33,11 +32,6 @@ case object Initial extends TokenState
 case class Resume(token: String) extends TokenState
 
 case object Final extends TokenState
-
-case class OaiPmhError(code: String, value: String = "") extends RuntimeException(code) {
-  def errorMessage(implicit messages: Messages): String = Messages(s"oaipmh.error.$code", value)
-}
-
 
 case class WSOaiPmhClient @Inject()(ws: WSClient)(implicit ec: ExecutionContext, mat: Materializer) extends OaiPmhClient {
 

--- a/modules/admin/app/services/harvesting/WSResourceSyncClient.scala
+++ b/modules/admin/app/services/harvesting/WSResourceSyncClient.scala
@@ -1,0 +1,78 @@
+package services.harvesting
+
+import java.util.regex.Pattern
+
+import akka.NotUsed
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+import akka.util.ByteString
+import javax.inject.Inject
+import models._
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.xml.{Node, NodeSeq}
+
+
+case class WSResourceSyncClient @Inject ()(ws: WSClient)(implicit mat: Materializer) extends ResourceSyncClient {
+
+  private implicit val ec: ExecutionContext = mat.executionContext
+
+  private def parseAttr(nodes: NodeSeq, key: String): Option[String] =
+    nodes.headOption.flatMap(n => parseAttr(n, key))
+
+  private def parseAttr(node: Node, key: String): Option[String] =
+    node.attribute(key).flatMap(_.headOption.map(_.text))
+
+  private def readUrlSet(url: String, filter: String => Boolean): Future[Seq[ResourceSyncItem]] = {
+    ws.url(url).get().map { r =>
+      (r.xml \ "url").flatMap { urlNode =>
+        val md = urlNode \ "md"
+        val lastMod = urlNode \ "lastmod"
+        val capability = parseAttr(md, "capability")
+
+        (urlNode \ "loc").flatMap { locNode =>
+          val loc = locNode.text
+          capability match {
+            case Some("resourcelist") => Some(ResourceList(loc))
+            case Some("capabilitylist") => Some(CapabilityList(loc))
+            case None if filter(loc) => Some(FileLink(
+              loc,
+              contentType = parseAttr(md, "type"),
+              hash = parseAttr(md, "hash"),
+              length = parseAttr(md, "length").map(_.toLong),
+              updated = lastMod.headOption.map(n => java.time.Instant.parse(n.text))
+            ))
+            case _ => None
+          }
+        }
+      }
+    }
+  }
+
+  override def list(config: ResourceSyncConfig): Future[Seq[FileLink]] = {
+
+    val test: String => Boolean = config.filter.fold(ifEmpty = (_:String) => true)(
+      s => t => Pattern.compile(s).matcher(t).find())
+
+    readUrlSet(config.url, test).flatMap { list =>
+
+      val s: Source[FileLink, NotUsed] = Source(list.toList)
+        .collect { case rl: ResourceList => rl }
+        .mapAsync(1) { urlItem => readUrlSet(urlItem.loc, test) }
+        .flatMapConcat(s => Source(s.toList))
+        .collect { case link: FileLink => link }
+
+      s.runWith(Sink.seq)
+    }
+  }
+
+  override def get(link: FileLink): Source[ByteString, _] =
+    Source.future(ws.url(link.loc).withFollowRedirects(true).get().map { r =>
+      if (r.status == 404) {
+        Source.failed(ResourceSyncError("notFound", link.loc))
+      } else if (r.status != 200) {
+        Source.failed(ResourceSyncError("unexpectedStatus", r.status.toString))
+      } else r.bodyAsSource
+    }).flatMapConcat(src => src)
+}

--- a/modules/admin/app/views/admin/repository/datamanager.scala.html
+++ b/modules/admin/app/views/admin/repository/datamanager.scala.html
@@ -42,6 +42,12 @@
             controllers.institutions.routes.javascript.OaiPmhConfigs.save,
             controllers.institutions.routes.javascript.OaiPmhConfigs.delete,
             controllers.institutions.routes.javascript.OaiPmhConfigs.test,
+            controllers.institutions.routes.javascript.ResourceSyncConfigs.sync,
+            controllers.institutions.routes.javascript.ResourceSyncConfigs.cancelSync,
+            controllers.institutions.routes.javascript.ResourceSyncConfigs.get,
+            controllers.institutions.routes.javascript.ResourceSyncConfigs.save,
+            controllers.institutions.routes.javascript.ResourceSyncConfigs.delete,
+            controllers.institutions.routes.javascript.ResourceSyncConfigs.test,
             controllers.institutions.routes.javascript.DataTransformations.convertFile,
             controllers.institutions.routes.javascript.DataTransformations.convert,
             controllers.institutions.routes.javascript.DataTransformations.cancelConvert,
@@ -111,6 +117,7 @@
       <script src="@controllers.admin.routes.AdminAssets.versioned("js/datamanager-dao.js")"></script>
       <script src="@controllers.admin.routes.AdminAssets.versioned("js/datamanager-common.js")"></script>
       <script src="@controllers.admin.routes.AdminAssets.versioned("js/components/transformation-editor.js")"></script>
+      <script src="@controllers.admin.routes.AdminAssets.versioned("js/components/rs-manager.js")"></script>
       <script src="@controllers.admin.routes.AdminAssets.versioned("js/components/oaipmh-manager.js")"></script>
       <script src="@controllers.admin.routes.AdminAssets.versioned("js/components/upload-manager.js")"></script>
       <script src="@controllers.admin.routes.AdminAssets.versioned("js/components/ingest-manager.js")"></script>

--- a/modules/admin/conf/institutions.routes
+++ b/modules/admin/conf/institutions.routes
@@ -61,6 +61,14 @@ DELETE      /:id/oaipmh/:ds/config                    @controllers.institutions.
 POST        /:id/oaipmh/:ds                           @controllers.institutions.OaiPmhConfigs.harvest(id: String, ds: String, fromLast: Boolean ?= true)
 DELETE      /:id/oaipmh                               @controllers.institutions.OaiPmhConfigs.cancelHarvest(id: String, jobId: String)
 
+GET         /:id/rs/:ds/config                        @controllers.institutions.ResourceSyncConfigs.get(id: String, ds: String)
+PUT         /:id/rs/:ds/config                        @controllers.institutions.ResourceSyncConfigs.save(id: String, ds: String)
+POST        /:id/rs/:ds/config                        @controllers.institutions.ResourceSyncConfigs.test(id: String, ds: String)
+DELETE      /:id/rs/:ds/config                        @controllers.institutions.ResourceSyncConfigs.delete(id: String, ds: String)
+
+POST        /:id/rs/:ds                               @controllers.institutions.ResourceSyncConfigs.sync(id: String, ds: String)
+DELETE      /:id/rs                                   @controllers.institutions.ResourceSyncConfigs.cancelSync(id: String, jobId: String)
+
 DELETE      /:id/convert                              @controllers.institutions.DataTransformations.cancelConvert(id: String, jobId: String)
 POST        /:id/convert/:ds                          @controllers.institutions.DataTransformations.convert(id: String, ds: String, key: Option[String] ?= None)
 POST        /:id/convert/:ds/:stage/:fileName         @controllers.institutions.DataTransformations.convertFile(id: String, ds: String, stage: defines.FileStage.Value, fileName: String)

--- a/modules/admin/conf/messages
+++ b/modules/admin/conf/messages
@@ -21,6 +21,11 @@ facet.linkType=Link Type
 facet.linkField=Link Field
 
 #
+# Errors
+#
+errors.badRegexPattern=Regular expression syntax error
+
+#
 #
 # Friendly names for content types
 contentTypes=Content types
@@ -1122,6 +1127,9 @@ oaipmh.error.idDoesNotExist=The repository reported that item with id ''{0}'' do
 oaipmh.error.url=Endpoint URL responded with invalid status: {0}
 oaipmh.error.invalidXml=Endpoint URL responded with invalid XML content
 
+
+resourceSync.error.notFound=Resource not found: {0}
+resourceSync.error.unexpectedStatus=Unexpected HTTP status code: {0}
 
 # Authority i18n messages
 

--- a/modules/core/app/utils/forms/package.scala
+++ b/modules/core/app/utils/forms/package.scala
@@ -12,16 +12,12 @@ package object forms {
 
   /**
    * Check if a string is a valid URL.
-   * @param s url string
-   * @return
    */
-  def isValidUrl(s: String): Boolean = {
-    try {
-      new URL(s)
-      true
-    } catch {
-      case s: MalformedURLException => false
-    }
+  val isValidUrl: String => Boolean = s => try {
+    new URL(s)
+    true
+  } catch {
+    case _: MalformedURLException => false
   }
 
   import play.api.data.format.Formatter

--- a/modules/portal/app/forms/AccountForms.scala
+++ b/modules/portal/app/forms/AccountForms.scala
@@ -17,7 +17,7 @@ case class AccountForms @Inject() (config: Configuration, globalConfig: GlobalCo
 
   val openidForm: Form[String] = Form(single(
     "openid_identifier" -> nonEmptyText
-  ) verifying("error.badUrl", url => utils.forms.isValidUrl(url)))
+  ) verifying("errors.invalidUrl", utils.forms.isValidUrl))
 
   val passwordLoginForm: Form[(String, String)] = Form(
     tuple(
@@ -41,7 +41,7 @@ case class AccountForms @Inject() (config: Configuration, globalConfig: GlobalCo
     ) verifying("login.error.passwordsDoNotMatch", pc => pc._1 == pc._2)
   )
 
-  val forgotPasswordForm = Form(Forms.single("email" -> email))
+  val forgotPasswordForm: Form[String] = Form(Forms.single("email" -> email))
 
   //
   // Signup data validation. This does several checks:

--- a/modules/portal/app/services/storage/FileStorage.scala
+++ b/modules/portal/app/services/storage/FileStorage.scala
@@ -27,7 +27,7 @@ trait FileStorage {
     * @param path       additional file path, including the file name with extension
     * @return a file-meta object
     */
-  def info(classifier: String, path: String, versionId: Option[String] = None): Future[Option[FileMeta]]
+  def info(classifier: String, path: String, versionId: Option[String] = None): Future[Option[(FileMeta, Map[String, String])]]
 
   /**
     * Get the URI for a stored file with the given classifier and key.

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -94,6 +94,7 @@ errors.noFurtherInfo=No additional information is available.
 errors.imageTooLarge=This image was too large. Please select one smaller than 5 megabytes in size.
 errors.badFileType=The uploaded file was not a supported image type.
 errors.noFileGiven=No image file was selected.
+errors.invalidUrl=Web URL is invalid
 
 identifier=Identifier
 identifier.description=A locally-unique item identifier.

--- a/test/actors/harvesting/ResourceSyncHarvesterSpec.scala
+++ b/test/actors/harvesting/ResourceSyncHarvesterSpec.scala
@@ -1,0 +1,58 @@
+package actors.harvesting
+
+import actors.harvesting
+import actors.harvesting.ResourceSyncHarvesterManager.{ResourceSyncData, ResourceSyncJob}
+import akka.actor.Props
+import helpers.{AkkaTestkitSpecs2Support, IntegrationTestRunner}
+import mockdata.adminUserProfile
+import models.{ResourceSyncConfig, UserProfile}
+import play.api.{Application, Configuration}
+import services.harvesting.ResourceSyncClient
+import services.storage.FileStorage
+
+class ResourceSyncHarvesterSpec extends AkkaTestkitSpecs2Support with IntegrationTestRunner {
+
+  private def client(implicit app: Application): ResourceSyncClient = app.injector.instanceOf[ResourceSyncClient]
+  private def storage(implicit app: Application): FileStorage = app.injector.instanceOf[FileStorage]
+  private def config(implicit app: Application): Configuration = app.injector.instanceOf[Configuration]
+
+  private val jobId = "test-job-id"
+  private val datasetId = "default"
+  private implicit val userOpt: Option[UserProfile] = Some(adminUserProfile)
+
+  private def job(implicit app: Application): ResourceSyncJob = ResourceSyncJob("r1", datasetId, jobId, ResourceSyncData(
+    // where we're harvesting from:
+    config = ResourceSyncConfig(s"https://example.com/resourcesync/capabilitylist.xml"),
+    // on-storage location:
+    classifier = "test-bucket",
+    prefix = "r1/input/"
+  ))
+
+  import ResourceSyncHarvester._
+
+  "ResourceSync harvest" should {
+
+    "send correct messages when syncing a capabilitylist" in new ITestApp {
+      val runner = system.actorOf(Props(ResourceSyncHarvester(job, client, storage)))
+
+      runner ! Initial
+      expectMsg(Starting)
+      expectMsg(ToDo(3))
+      expectMsg(DoneFile("+ test1.xml"))
+      expectMsg(DoneFile("+ test2.xml"))
+      expectMsg(DoneFile("+ test2.xml"))
+      expectMsgClass(classOf[Completed])
+    }
+
+    "allow cancellation" in new ITestApp {
+      val runner = system.actorOf(Props(harvesting.ResourceSyncHarvester(job, client, storage)))
+
+      // NB: this test is slightly non-deterministic in that the first `ToDo` can
+      // sometimes arrive before cancellation is processed...
+      runner ! Initial
+      expectMsg(Starting)
+      runner ! Cancel
+      expectMsgClass(classOf[Cancelled])
+    }
+  }
+}

--- a/test/actors/ingest/DataImporterManagerSpec.scala
+++ b/test/actors/ingest/DataImporterManagerSpec.scala
@@ -35,7 +35,7 @@ class DataImporterManagerSpec extends AkkaTestkitSpecs2Support with IntegrationT
   "Data Import manager" should {
 
     "send correct messages when importing files" in new ITestApp {
-      val importApi = MockIngestServiceService(ImportLog())
+      val importApi = MockIngestService(ImportLog())
       val importManager = system.actorOf(Props(DataImporterManager(job, importApi)))
 
       importManager ! self
@@ -49,7 +49,7 @@ class DataImporterManagerSpec extends AkkaTestkitSpecs2Support with IntegrationT
     }
 
     "send correct messages when imports throw an error" in new ITestApp {
-      val importApi = MockIngestServiceService(ErrorLog("identifier", "Missing field"))
+      val importApi = MockIngestService(ErrorLog("identifier", "Missing field"))
       val importManager = system.actorOf(Props(DataImporterManager(job, importApi)))
 
       importManager ! self

--- a/test/helpers/TestConfiguration.scala
+++ b/test/helpers/TestConfiguration.scala
@@ -27,6 +27,7 @@ import services.accounts.{AccountManager, MockAccountManager}
 import services.cypher.{CypherQueryService, MockCypherQueryService}
 import services.data.{IdSearchResolver, _}
 import services.feedback.{FeedbackService, MockFeedbackService}
+import services.harvesting.{MockResourceSyncClient, ResourceSyncClient}
 import services.htmlpages.{HtmlPages, MockHtmlPages}
 import services.ingest.{EadValidator, MockEadValidatorService}
 import services.oauth2.OAuth2Service
@@ -113,10 +114,11 @@ trait TestConfiguration {
       bind[HtmlPages].toInstance(mockHtmlPages),
       bind[ItemLifecycle].to(classOf[NoopItemLifecycle]),
       bind[EadValidator].to(mockEadValidator),
+      bind[ResourceSyncClient].to[MockResourceSyncClient],
       // NB: Graph IDs are not stable during testing due to
       // DB churn, so using the String ID resolver rather than
       // the more efficient GID one used in production
-      bind[SearchItemResolver].to[IdSearchResolver]
+      bind[SearchItemResolver].to[IdSearchResolver],
     ).bindings(
       bind[SearchLogger].toInstance(searchLogger)
     )

--- a/test/resources/capabilitylist.xml
+++ b/test/resources/capabilitylist.xml
@@ -1,0 +1,8 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:rs="http://www.openarchives.org/rs/terms/">
+    <rs:ln href="/.well-known/resourcesync" rel="up"/>
+    <rs:md capability="capabilitylist"/>
+    <url>
+        <loc>/resourcesync/resourcelist.xml</loc>
+        <rs:md capability="resourcelist"/>
+    </url>
+</urlset>

--- a/test/resources/resourcelist.xml
+++ b/test/resources/resourcelist.xml
@@ -1,0 +1,19 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:rs="http://www.openarchives.org/rs/terms/">
+    <rs:ln href="/resourcesync/capabilitylist.xml" rel="up"/>
+    <rs:md at="2020-12-11T15:00:00Z" capability="resourcelist" completed="2020-12-11T15:00:00Z"/>
+    <url>
+        <loc>/resourcesync/hierarchical-ead.xml</loc>
+        <lastmod>2020-12-11T15:00:00Z</lastmod>
+        <rs:md hash="md5:777da8d34a7763ac939440ffbfa2de4f" length="3668" type="text/xml"/>
+    </url>
+    <url>
+        <loc>/resourcesync/test1.xml</loc>
+        <lastmod>2020-12-11T15:00:00Z</lastmod>
+        <rs:md hash="md5:d41d8cd98f00b204e9800998ecf8427e" length="0" type="text/xml"/>
+    </url>
+    <url>
+        <loc>/resourcesync/test2.xml</loc>
+        <lastmod>2020-12-11T15:00:00Z</lastmod>
+        <rs:md hash="md5:d41d8cd98f00b204e9800998ecf8427e" length="0" type="text/xml"/>
+    </url>
+</urlset>

--- a/test/resources/resourcesync-config-fixtures.sql
+++ b/test/resources/resourcesync-config-fixtures.sql
@@ -1,0 +1,5 @@
+INSERT INTO import_dataset (repo_id, id, name, type, comments)
+VALUES ('r1', 'default', 'Default', 'rs', 'test');
+
+INSERT INTO resourcesync_config
+VALUES ('r1', 'default', 'http://example.com', NULL, '2020-06-12 10:00:00', NULL);

--- a/test/services/harvesting/MockResourceSyncClient.scala
+++ b/test/services/harvesting/MockResourceSyncClient.scala
@@ -1,0 +1,21 @@
+package services.harvesting
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import javax.inject.Inject
+import models.{FileLink, ResourceSyncConfig}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class MockResourceSyncClient @Inject()()(implicit ec: ExecutionContext) extends ResourceSyncClient {
+  override def list(config: ResourceSyncConfig): Future[Seq[FileLink]] = Future {
+    Thread.sleep(100)
+    Seq(
+      FileLink("http://www.example.com/test1.xml"),
+      FileLink("http://www.example.com/test2.xml"),
+      FileLink("http://www.example.com/test2.xml")
+    )
+  }
+
+  override def get(link: FileLink): Source[ByteString, _] =
+    Source.single(ByteString.fromString("""<ead></ead>"""))
+}

--- a/test/services/harvesting/SqlResourceSyncConfigServiceSpec.scala
+++ b/test/services/harvesting/SqlResourceSyncConfigServiceSpec.scala
@@ -1,0 +1,31 @@
+package services.harvesting
+
+import akka.actor.ActorSystem
+import helpers._
+import models.ResourceSyncConfig
+import play.api.db.Database
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.PlaySpecification
+
+class SqlResourceSyncConfigServiceSpec extends PlaySpecification {
+
+  private val actorSystem = new GuiceApplicationBuilder().build().injector.instanceOf[ActorSystem]
+
+  def service(implicit db: Database) = SqlResourceSyncConfigService(db, actorSystem)
+
+  "ResourceSync config service" should {
+    "locate items" in withDatabaseFixture("resourcesync-config-fixtures.sql") { implicit db =>
+      val config = await(service.get("r1", "default"))
+      config must beSome
+    }
+
+    "delete items" in withDatabaseFixture("resourcesync-config-fixtures.sql") { implicit db =>
+      await(service.delete("r1", "default")) must_== true
+    }
+
+    "create items" in withDatabaseFixture("resourcesync-config-fixtures.sql") { implicit db =>
+      val config = ResourceSyncConfig("https://test.com/testing")
+      await(service.save("r1", "default", config)) must_== config
+    }
+  }
+}

--- a/test/services/harvesting/WSResourceSyncClientSpec.scala
+++ b/test/services/harvesting/WSResourceSyncClientSpec.scala
@@ -1,0 +1,62 @@
+package services.harvesting
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import helpers.TestConfiguration
+import models.ResourceSyncConfig
+import play.api.BuiltInComponentsFromContext
+import play.api.routing.Router
+import play.api.test.PlaySpecification
+import play.filters.HttpFiltersComponents
+
+class WSResourceSyncClientSpec extends PlaySpecification with TestConfiguration {
+
+  private implicit val as: ActorSystem = ActorSystem("test")
+  private implicit val mat: Materializer = Materializer(as)
+
+  def withResourceSyncClient[T](block: WSResourceSyncClient => T): T = {
+    import play.api.mvc._
+    import play.api.routing.sird._
+    import play.api.test._
+    import play.core.server.Server
+    Server.withApplicationFromContext() { context =>
+      new BuiltInComponentsFromContext(context) with HttpFiltersComponents {
+        override def router: Router = Router.from {
+          case play.api.routing.sird.GET(p"/resourcesync/$file") =>
+            Action { implicit req =>
+              Results.Ok.sendResource(file)(executionContext, fileMimeTypes)
+            }
+        }
+      }.application
+    } { implicit port =>
+      WsTestClient.withClient { client =>
+        block(WSResourceSyncClient(client))
+      }
+    }
+  }
+
+  private val endpoint = ResourceSyncConfig("/resourcesync/capabilitylist.xml")
+
+  "OAI RS client service" should {
+    "list items" in withResourceSyncClient { client =>
+
+      val list = await(client.list(endpoint))
+      list.headOption must beSome.which { link =>
+        link.loc must_== "/resourcesync/hierarchical-ead.xml"
+      }
+      list.size must_== 3
+    }
+
+    "list items with filter" in withResourceSyncClient { client =>
+      val list = await(client.list(endpoint.copy(filter = Some("hier"))))
+      list.headOption must beSome
+      list.size must_== 1
+    }
+
+    "list items with RegExp filter" in withResourceSyncClient { client =>
+      val list = await(client.list(endpoint.copy(filter = Some("test\\d\\.xml$"))))
+      list.headOption must beSome
+      list.size must_== 2
+    }
+  }
+}

--- a/test/services/ingest/MockIngestService.scala
+++ b/test/services/ingest/MockIngestService.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
   * No-op importer. Does nothing, nowt, nada, but on the
   * plus side has no dependencies.
   */
-case class MockIngestServiceService(res: IngestResult) extends IngestService {
+case class MockIngestService(res: IngestResult) extends IngestService {
   override def importData(job: IngestService.IngestJob) =
     Future.successful(res)
 

--- a/test/services/storage/MockFileStorageSpec.scala
+++ b/test/services/storage/MockFileStorageSpec.scala
@@ -76,15 +76,15 @@ class MockFileStorageSpec extends PlaySpecification with TestConfiguration {
 
     "get item info with version ID" in {
       val storage = putTestItems._1
-      val info: Option[FileMeta] = await(storage.info(bucket, "baz"))
-      info must beSome.which(_.versionId must_== Some("1"))
+      val info: Option[(FileMeta, Map[String, String])] = await(storage.info(bucket, "baz"))
+      info must beSome.which(_._1.versionId must_== Some("1"))
 
       await(storage.putBytes(bucket, "baz", Source.single(ByteString("Bye, world"))))
-      val info2: Option[FileMeta] = await(storage.info(bucket, "baz"))
-      info2 must beSome.which(_.versionId must_== Some("2"))
+      val info2: Option[(FileMeta, Map[String, String])] = await(storage.info(bucket, "baz"))
+      info2 must beSome.which(_._1.versionId must_== Some("2"))
 
-      val info3: Option[FileMeta] = await(storage.info(bucket, "baz", versionId = Some("1")))
-      info3 must beSome.which(_.versionId must_== Some("1"))
+      val info3: Option[(FileMeta, Map[String, String])] = await(storage.info(bucket, "baz", versionId = Some("1")))
+      info3 must beSome.which(_._1.versionId must_== Some("1"))
     }
 
     "get item data with version ID" in {


### PR DESCRIPTION
 - only handles simplest case of fetching a single capabilitylist containing a list of plain resources
 - some mucking about the FileStorage API to facilitate user metadata retrieval, since this is used to store the RS hash (different from the eTag) for no-op syncs
 - no deletion of resource or any changelist support