### PR TITLE
Add a dedicated method for changing doc unit identifiers via WS

### DIFF
--- a/modules/admin/app/views/admin/authoritativeSet/create.scala.html
+++ b/modules/admin/app/views/admin/authoritativeSet/create.scala.html
@@ -5,7 +5,8 @@
 @views.html.admin.layout.rightSidebar(Messages("authoritativeSet.create")) {
 	@helper.form(action = action) {
         @formHelpers.csrfToken()
-        @form(None, f)
+        @formHelpers.lineInput(f(""), Entity.IDENTIFIER)
+        @views.html.admin.authoritativeSet.form(None, f)
         @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("authoritativeSet.create.submit"))

--- a/modules/admin/app/views/admin/authoritativeSet/edit.scala.html
+++ b/modules/admin/app/views/admin/authoritativeSet/edit.scala.html
@@ -5,7 +5,8 @@
 @views.html.admin.layout.rightSidebar(Messages("authoritativeSet.update"), breadcrumbs = views.html.admin.common.breadcrumbs(List(item))) {
 	@helper.form(action = action) {
         @formHelpers.csrfToken()
-        @form(Some(item), f)
+        @formHelpers.hiddenInput(f(Entity.IDENTIFIER))
+        @views.html.admin.authoritativeSet.form(Some(item), f)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("authoritativeSet.update.submit"), cancel = views.admin.Helpers.linkToOpt(item))
 	}

--- a/modules/admin/app/views/admin/authoritativeSet/form.scala.html
+++ b/modules/admin/app/views/admin/authoritativeSet/form.scala.html
@@ -1,7 +1,6 @@
 @(item: Option[AuthoritativeSet], f: Form[models.AuthoritativeSetF])(implicit fieldConstructor: helper.FieldConstructor, messages: Messages, md: views.MarkdownRenderer)
 
 @defining("authoritativeSet") { implicit fieldPrefix =>
-    @formHelpers.lineInput(f(""), Entity.IDENTIFIER)
     @formHelpers.lineInput(f(""), AuthoritativeSetF.NAME)
     @formHelpers.textInput(f(""), AuthoritativeSetF.DESCRIPTION)
     @formHelpers.hiddenInput(f(models.AuthoritativeSetF.ALLOW_PUBLIC))

--- a/modules/admin/app/views/admin/country/create.scala.html
+++ b/modules/admin/app/views/admin/country/create.scala.html
@@ -3,7 +3,8 @@
 @views.html.admin.layout.rightSidebarWithType(Messages("country.create"), defines.EntityType.Country) {
 	@helper.form(action = action) {
         @formHelpers.csrfToken()
-        @form(None, f)
+        @formHelpers.lineInput(f(""), Entity.IDENTIFIER)
+        @views.html.admin.country.form(None, f)
         @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("country.create.submit"))

--- a/modules/admin/app/views/admin/country/edit.scala.html
+++ b/modules/admin/app/views/admin/country/edit.scala.html
@@ -3,7 +3,8 @@
 @views.html.admin.layout.rightSidebarWithType(Messages("country.update"), item.isA, breadcrumbs = views.html.admin.common.breadcrumbs(List(item))) {
 	@helper.form(action = action) {
         @formHelpers.csrfToken()
-        @form(Some(item), f)
+        @formHelpers.hiddenInput(f(Entity.IDENTIFIER))
+        @views.html.admin.country.form(Some(item), f)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("country.update.submit"), cancel = views.admin.Helpers.linkToOpt(item))
 	}

--- a/modules/admin/app/views/admin/country/form.scala.html
+++ b/modules/admin/app/views/admin/country/form.scala.html
@@ -3,7 +3,6 @@
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
 @defining("country") { implicit fieldPrefix =>
-    @formHelpers.lineInput(f(""), Entity.IDENTIFIER)
     @formHelpers.textInput(f(""), CountryF.ABSTRACT)
     @formHelpers.textInput(f(""), CountryF.HISTORY)
     @formHelpers.textInput(f(""), CountryF.SITUATION)

--- a/modules/admin/app/views/admin/documentaryUnit/create.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/create.scala.html
@@ -1,6 +1,6 @@
 @(item: models.base.Model, f: Form[DocumentaryUnitF], config: forms.FormConfig, vf: Form[Seq[String]], usersAndGroups: UsersAndGroups, action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer, prefs: utils.SessionPrefs, flash: Flash)
 
-@implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
+@implicitField = @{views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f)}
 
 @breadcrumbs = {
     @item match {
@@ -20,13 +20,14 @@
 
 @views.html.admin.layout.rightSidebarWithType(Messages("documentaryUnit.create"), defines.EntityType.DocumentaryUnit, breadcrumbs = breadcrumbs, scripts = formHelpers.dateJs()) {
 
-	@helper.form(action = action) {
+    @helper.form(action = action) {
         @formHelpers.csrfToken()
-		@views.html.admin.documentaryUnit.form(f, config)
+        @formHelpers.lineInput(f(""), Entity.IDENTIFIER)
+        @views.html.admin.documentaryUnit.form(f, config)
 
         @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
-		@formHelpers.submitButtonWithLogMessageInput(Messages("documentaryUnit.create.submit"), cancel = views.admin.Helpers.linkToOpt(item))
-	}
+        @formHelpers.submitButtonWithLogMessageInput(Messages("documentaryUnit.create.submit"), cancel = views.admin.Helpers.linkToOpt(item))
+    }
 } {
-   @formNav()
+    @views.html.admin.documentaryUnit.formNav()
 }

--- a/modules/admin/app/views/admin/documentaryUnit/edit.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/edit.scala.html
@@ -2,13 +2,18 @@
  
 @implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
 
-@views.html.admin.layout.rightSidebarWithType(Messages("documentaryUnit.update"), item.isA, breadcrumbs = breadcrumbs(item), scripts = formHelpers.dateJs()) {
+@views.html.admin.layout.rightSidebarWithType(Messages("documentaryUnit.update"), item.isA, breadcrumbs = views.html.admin.documentaryUnit.breadcrumbs(item), scripts = formHelpers.dateJs()) {
 		
 	@helper.form(action = action) {
         @formHelpers.csrfToken()
-		@form(f, config)
+
+        @formHelpers.hiddenInput(f(Entity.IDENTIFIER))
+        <p>@Messages("item.identifier"): <strong>@item.data.identifier</strong> [
+            <a href="@controllers.units.routes.DocumentaryUnits.rename(item.id)">@Messages("item.rename.title")</a>]</p>
+
+        @views.html.admin.documentaryUnit.form(f, config)
         @formHelpers.submitButtonWithLogMessageInput(Messages("documentaryUnit.update.submit"), cancel = views.admin.Helpers.linkToOpt(item))
 	}
 } {
-    @formNav()
+    @views.html.admin.documentaryUnit.formNav()
 }

--- a/modules/admin/app/views/admin/documentaryUnit/form.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/form.scala.html
@@ -1,17 +1,17 @@
 @(f: play.api.data.Form[DocumentaryUnitF], config: forms.FormConfig)(implicit userOpt: Option[UserProfile], req: RequestHeader, globalConfig: global.GlobalConfig, messages: Messages, md: views.MarkdownRenderer)
 
 @import models.IsadG._
-@import models.DocumentaryUnitF._
+    @import models.DocumentaryUnitF._
 
-@implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
+@implicitField = @{views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f)}
 
-@defining("documentaryUnit") { implicit fieldPrefix =>
-    @defining(Some(config)) { implicit implicitConfig =>
-        @formHelpers.lineInput(f(""), Entity.IDENTIFIER)
+@defining(Some(config)) { implicit implicitConfig =>
+
+    @defining("documentaryUnit") { implicit fieldPrefix =>
         @formHelpers.inlineNameSet(f(""), OTHER_IDENTIFIERS)
 
         @formHelpers.descriptionFormTabs(f) { desc =>
-            @descriptionForm(desc)
+            @views.html.admin.documentaryUnit.descriptionForm(desc)
         }
 
         @formHelpers.descriptionFormSection(ADMINISTRATION_AREA) {

--- a/modules/admin/app/views/admin/documentaryUnit/rename.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/rename.scala.html
@@ -1,0 +1,18 @@
+@(item: DocumentaryUnit, f: play.api.data.Form[String], action: Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, md: views.MarkdownRenderer, globalConfig: global.GlobalConfig, messages: Messages, prefs: utils.SessionPrefs, flash: Flash)
+ 
+@implicitField = @{ views.html.helper.FieldConstructor(formHelpers.fieldTemplate.f) }
+
+@views.html.admin.layout.rightSidebar(Messages("item.rename"), breadcrumbs = views.html.admin.documentaryUnit.breadcrumbs(item)) {
+
+    <p class="alert alert-warning">
+        @Messages("item.rename.warning")
+        <code><strong>@item.data.identifier</strong></code>
+    </p>
+	@helper.form(action = action) {
+        @formHelpers.csrfToken()
+        @formHelpers.lineInput(f(""), Entity.IDENTIFIER, '_label -> Messages("item.rename.identifier"), 'autofocus -> "autofocus")
+
+        @formHelpers.submitButtonWithLogMessageInput(Messages("item.rename.submit"), cancel = views.admin.Helpers.linkToOpt(item))
+	}
+} {
+}

--- a/modules/admin/app/views/admin/repository/create.scala.html
+++ b/modules/admin/app/views/admin/repository/create.scala.html
@@ -5,10 +5,12 @@
 @views.html.admin.layout.rightSidebarWithType(Messages("repository.create"), defines.EntityType.Repository, breadcrumbs = views.html.admin.common.breadcrumbs(List(item))) {
 	@helper.form(action = action) {
         @formHelpers.csrfToken()
-        @form(f, config)
+        @formHelpers.lineInput(f(""), Entity.IDENTIFIER, 'disabled -> "disabled")
+
+        @views.html.admin.repository.form(f, config)
         @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
         @formHelpers.submitButtonWithLogMessageInput(Messages("repository.create.submit"), cancel = views.admin.Helpers.linkToOpt(item))
 	}
 } {
-	@formNav()
+	@views.html.admin.repository.formNav()
 }

--- a/modules/admin/app/views/admin/repository/edit.scala.html
+++ b/modules/admin/app/views/admin/repository/edit.scala.html
@@ -5,10 +5,11 @@
 @views.html.admin.layout.rightSidebarWithType(Messages("repository.update"), item.isA, breadcrumbs = views.html.admin.common.breadcrumbs(List(item))) {
     @helper.form(action = action) {
         @formHelpers.csrfToken()
-        @form(f, config)
+        @formHelpers.hiddenInput(f(Entity.IDENTIFIER))
+        @views.html.admin.repository.form(f, config)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("repository.update.submit"), cancel = views.admin.Helpers.linkToOpt(item))
     }
 } {
-	@formNav()
+	@views.html.admin.repository.formNav()
 }

--- a/modules/admin/app/views/admin/repository/form.scala.html
+++ b/modules/admin/app/views/admin/repository/form.scala.html
@@ -11,8 +11,6 @@
 
 @defining("repository") { implicit fieldPrefix =>
     @defining(Some(config)) { implicit implicitConfig =>
-        @formHelpers.lineInput(f(""), IDENTIFIER)
-
         @helper.repeat(f("descriptions"), min = math.max(f("descriptions").indexes.length, 1)) { desc =>
             @descriptionForm(desc)
         }

--- a/modules/admin/app/views/admin/vocabulary/create.scala.html
+++ b/modules/admin/app/views/admin/vocabulary/create.scala.html
@@ -5,7 +5,8 @@
 @views.html.admin.layout.rightSidebarWithType(Messages("cvocVocabulary.create"), defines.EntityType.Vocabulary) {
 	@helper.form(action = action) {
         @formHelpers.csrfToken()
-        @form(None, f)
+        @formHelpers.lineInput(f(""), Entity.IDENTIFIER)
+        @views.html.admin.vocabulary.form(None, f)
         @views.html.admin.permissions.visibilityForm(vf, usersAndGroups)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("cvocVocabulary.create.submit"))

--- a/modules/admin/app/views/admin/vocabulary/edit.scala.html
+++ b/modules/admin/app/views/admin/vocabulary/edit.scala.html
@@ -5,7 +5,8 @@
 @views.html.admin.layout.rightSidebarWithType(Messages("cvocVocabulary.update"), defines.EntityType.Vocabulary, breadcrumbs = views.html.admin.common.breadcrumbs(List(item))) {
 	@helper.form(action = action) {
         @formHelpers.csrfToken()
-        @form(Some(item), f)
+        @formHelpers.hiddenInput(f(Entity.IDENTIFIER))
+        @views.html.admin.vocabulary.form(Some(item), f)
 
         @formHelpers.submitButtonWithLogMessageInput(Messages("cvocVocabulary.update.submit"), cancel = views.admin.Helpers.linkToOpt(item))
 	}

--- a/modules/admin/app/views/admin/vocabulary/form.scala.html
+++ b/modules/admin/app/views/admin/vocabulary/form.scala.html
@@ -1,7 +1,6 @@
 @(item: Option[Vocabulary], f: Form[models.VocabularyF])(implicit fieldConstructor: helper.FieldConstructor, messages: Messages, md: views.MarkdownRenderer)
 
 @defining("cvocVocabulary") { implicit fieldPrefix =>
-    @formHelpers.lineInput(f(""), Entity.IDENTIFIER)
     @formHelpers.lineInput(f(""), models.VocabularyF.NAME)
     @formHelpers.textInput(f(""), models.VocabularyF.DESCRIPTION)
     @formHelpers.hiddenInput(f(models.VocabularyF.ALLOW_PUBLIC))

--- a/modules/admin/conf/messages
+++ b/modules/admin/conf/messages
@@ -119,7 +119,7 @@ link.relatedUnitsOfDescription=Related Units of Description
 # Generic actions
 #
 item.actions=Actions
-item.identifier=Identifier(s)
+item.identifier=Identifier
 item.history=Item History
 item.history.item=Change history for item: {0}
 item.annotate.submit=Annotate Item
@@ -148,6 +148,12 @@ item.demote.confirmation=Item promotion removed
 item.noItemsFound=No items found
 item.field.add=Add Field
 item.field.remove=Remove Field
+item.rename=Change Identifier
+item.rename.warning=Changing an item''s identifier will change it's URL and the URLs of any child items. The current identifier is:
+item.rename.submit=Submit
+item.rename.identifier=New Identifier
+item.rename.confirmation=Item successfully renamed; new 301 URL redirects: {0}
+item.rename.title=Change identifier
 
 
 #

--- a/modules/admin/conf/units.routes
+++ b/modules/admin/conf/units.routes
@@ -40,3 +40,5 @@ POST    /:id/deleteAccess/:did/:accessPoint        @controllers.units.Documentar
 POST    /:id/deleteLink/:link                      @controllers.units.DocumentaryUnits.deleteLink(id: String, link: String)
 POST    /:id/deleteLink/:did/:accessPoint/:link    @controllers.units.DocumentaryUnits.deleteLinkAndAccessPoint(id: String, did: String, accessPoint: String, link: String)
 GET     /:id/ingest                                @controllers.units.DocumentaryUnits.ingest(id: String)
+GET     /:id/rename                                @controllers.units.DocumentaryUnits.rename(id: String)
+POST    /:id/rename                                @controllers.units.DocumentaryUnits.renamePost(id: String)

--- a/modules/backend/src/main/scala/services/data/DataApi.scala
+++ b/modules/backend/src/main/scala/services/data/DataApi.scala
@@ -279,6 +279,17 @@ trait DataApiHandle {
   def delete[MT: Resource](id: String, logMsg: Option[String] = None): Future[Unit]
 
   /**
+    * Rename an item.
+    *
+    * @param id    the item's id
+    * @param local the item's new local identifier
+    * @tparam MT the generic type of the item
+    * @return a mapping of old-ID to new-ID for this
+    *         item and it's children
+    */
+  def rename[MT: Resource](id: String, local: String, logMsg: Option[String]): Future[Seq[(String, String)]]
+
+  /**
     * List items with the given resource type.
     *
     * @param resource the resource type

--- a/test/integration/admin/DocumentaryUnitViewsSpec.scala
+++ b/test/integration/admin/DocumentaryUnitViewsSpec.scala
@@ -322,6 +322,19 @@ class DocumentaryUnitViewsSpec extends IntegrationTestRunner {
       indexEventBuffer.last must equalTo("c1")
     }
 
+    "allow renaming items" in new ITestApp {
+      val testData: Map[String, Seq[String]] = Map("identifier" -> Seq("z2"))
+      val cr = FakeRequest(docRoutes.renamePost("c2"))
+        .withUser(privilegedUser).callWith(testData)
+
+      status(cr) must equalTo(SEE_OTHER)
+      flash(cr).get("success") must beSome.which { m =>
+        // We've renamed 2 items (c2) and its child, for
+        // which 3 redirects are created each for a total of 6
+        m must_== message("item.rename.confirmation", 6)
+      }
+    }
+
     "disallow updating items when logged in as unprivileged user" in new ITestApp {
       val testData: Map[String, Seq[String]] = Map(
         "identifier" -> Seq("c4"),


### PR DESCRIPTION
For other hierarchical types, renaming is discouraged via the form, and should be done using the utility rename function.