### PR TITLE
Add a boost query (bq) clause to the default search conf.

### DIFF
--- a/conf/search.conf
+++ b/conf/search.conf
@@ -1,7 +1,8 @@
 # Search-related configuration
 
 search {
-    andMode: false // default to OR for q param
+    # default to OR for q param
+    andMode: false
 
     boost {
         itemId: 15
@@ -39,24 +40,29 @@ search {
         lang: languageCode
     }
 
-    // Max descendants. HACK: Search will currently
-    // break if we exceed Solr's maxBooleanClauses value,
-    // so limit the number of item ID filter items to a
-    // hard value.
+    # Max descendants. HACK: Search will currently
+    # break if we exceed Solr's maxBooleanClauses value,
+    # so limit the number of item ID filter items to a
+    # hard value.
     vc.maxDescendants: 3072
 
-    // Specify whether facets in request and response are
-    // handled via the legacy system of newer JSON facets.
-    // JSON facets have some issues however, notably:
-    // https://issues.apache.org/jira/browse/SOLR-10122
+    # Specify whether facets in request and response are
+    # handled via the legacy system of newer JSON facets.
+    # JSON facets have some issues however, notably:
+    # https://issues.apache.org/jira/browse/SOLR-10122
     jsonFacets = false
 
-    // Enable timing debug
+    # Enable timing debug
     debugTiming = true
 
-    // Extra params. These MUST be strings and must
-    // not be overwritten, e.g. with `mm` and `mm.autoRelax`.
+    # Extra params. These MUST be strings and must
+    # not be overwritten, e.g. with `mm` and `mm.autoRelax`.
     extra {
-      mm: "5<90%"
+        mm: "5<90%"
+
+        # Ensure that repositories in a given query are
+        # always boosted a certain amount if they're in
+        # the result set...
+        bq: "type:Repository^10"
     }
 }


### PR DESCRIPTION
All things being equal, we want repositories to get a boost over other types of data when the are in a result set.