### PR TITLE
Improvements to the admin pages

### DIFF
--- a/modules/admin/app/controllers/admin/AdminSearch.scala
+++ b/modules/admin/app/controllers/admin/AdminSearch.scala
@@ -60,10 +60,7 @@ case class AdminSearch @Inject()(
     EntityType.Concept,
     EntityType.Vocabulary,
     EntityType.AuthoritativeSet,
-    EntityType.UserProfile,
-    EntityType.Group,
     EntityType.VirtualUnit,
-    EntityType.Link
   )
 
   def search(params: SearchParams, paging: PageParams): Action[AnyContent] = OptionalUserAction.async { implicit request =>

--- a/modules/admin/app/controllers/institutions/Repositories.scala
+++ b/modules/admin/app/controllers/institutions/Repositories.scala
@@ -115,6 +115,7 @@ case class Repositories @Inject()(
     findType[DocumentaryUnit](params, paging, filters = filters,
       facetBuilder = repositoryFacets, sort = SearchSort.Id).map { result =>
       if(isAjax) Ok(views.html.admin.search.inlineItemList(result = result))
+        .withHeaders("more" -> result.page.hasMore.toString)
       else Ok(views.html.admin.repository.show(request.item, result,
         repositoryRoutes.get(id), request.annotations, request.links))
         .withPreferences(preferences.withRecentItem(id))

--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -119,6 +119,7 @@ case class DocumentaryUnits @Inject()(
     findType[DocumentaryUnit](params, paging, filters = Map(SearchConstants.PARENT_ID -> request.item.id),
       facetBuilder = entityFacets, sort = SearchSort.Id).map { result =>
       if (isAjax) Ok(views.html.admin.search.inlineItemList(result = result))
+        .withHeaders("more" -> result.page.hasMore.toString)
       else Ok(views.html.admin.documentaryUnit.show(request.item, result,
         docRoutes.get(id), request.annotations, request.links, dlid))
           .withPreferences(preferences.withRecentItem(id))

--- a/modules/admin/app/controllers/virtual/VirtualUnits.scala
+++ b/modules/admin/app/controllers/virtual/VirtualUnits.scala
@@ -113,6 +113,7 @@ case class VirtualUnits @Inject()(
         entities = List(EntityType.VirtualUnit, EntityType.DocumentaryUnit), facetBuilder = entityFacets)
     } yield {
       if (isAjax) Ok(views.html.admin.search.inlineItemList(result))
+        .withHeaders("more" -> result.page.hasMore.toString)
       else Ok(views.html.admin.virtualUnit.show(request.item, result,
         vuRoutes.get(id), request.annotations, request.links, dlid, Seq.empty))
     }

--- a/modules/admin/app/views/admin/country/searchItem.scala.html
+++ b/modules/admin/app/views/admin/country/searchItem.scala.html
@@ -5,7 +5,7 @@
 } {
     @views.html.common.childCount(item) { count =>
         <ul class="search-item-details">
-            <li><a href="@controllers.countries.routes.Countries.get(item.id)#search-items">@Messages("country.childCount", count)</a></li>
+            <li><a href="@controllers.countries.routes.Countries.get(item.id)#@(item.id)-child-item-search">@Messages("country.childCount", count)</a></li>
         </ul>
     }
     @item.data.displayText.map(views.Helpers.ellipsize(_, 600)).map { sc =>

--- a/modules/admin/app/views/admin/country/show.scala.html
+++ b/modules/admin/app/views/admin/country/show.scala.html
@@ -15,13 +15,14 @@
     }
 
     @views.html.admin.search.searchSection(item, Messages("country.searchItems", item.toStringAbbr), result) {
-        @views.html.common.search.searchForm(result, action, autofocus = false) {
+        @views.html.common.search.searchForm(result, action) {
             @views.html.admin.search.searchItemList(result)
         } {
             @common.search.facetList(result.facetClasses, action)
         }
     }
 } {
+    @views.html.common.childItemSidebar(item, EntityType.Repository)
     @views.html.admin.common.visibility(item, controllers.countries.routes.Countries.visibility(item.id), ContentTypes.Country)
     @views.html.admin.common.latestAction(item, controllers.countries.routes.Countries.history(item.id))
 

--- a/modules/admin/app/views/admin/documentaryUnit/searchItemBody.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/searchItemBody.scala.html
@@ -37,7 +37,7 @@
 }
 
 @views.html.common.childCount(item) { count =>
-    @views.html.admin.helpers.linkToWithBody(item, fragment = "#search-items", attributes = Seq('class -> "child-items-inline-load collapsed")) {
+    @views.html.admin.helpers.linkToWithBody(item, fragment = s"#${item.id}-child-item-search", attributes = Seq('class -> "child-items-inline-load collapsed")) {
         <i class="fa fa-fw fa-plus-square-o" aria-hidden="true"></i>
         @Messages("documentaryUnit.childCount", count)
     }

--- a/modules/admin/app/views/admin/documentaryUnit/show.scala.html
+++ b/modules/admin/app/views/admin/documentaryUnit/show.scala.html
@@ -28,6 +28,7 @@
                     } {
                         @common.typeLabel(item.isA) {
                         }
+                        @views.html.common.childItemSidebar(item, EntityType.DocumentaryUnit)
                     } {
                         @views.html.admin.common.identifiers(item.data.identifier, item.data.otherIdentifiers)
                         @views.html.admin.common.latestAction(item, controllers.units.routes.DocumentaryUnits.history(item.id))

--- a/modules/admin/app/views/admin/link/linkSourceList.scala.html
+++ b/modules/admin/app/views/admin/link/linkSourceList.scala.html
@@ -1,7 +1,7 @@
 @(item: models.base.Model, result: services.search.SearchResult[(models.base.Model, services.search.SearchHit)], entityType: defines.EntityType.Value, action: Call, linkAction: (String, Boolean) => Call)(implicit userOpt: Option[UserProfile], req: RequestHeader, conf: AppConfig, messages: Messages, md: MarkdownRenderer, prefs: SessionPrefs, flash: Flash)
 
 @views.html.admin.layout.adminSearchLayout(Messages("link.create"), result, action, breadcrumbs = views.html.admin.common.breadcrumbs(List(item))) {
-    <div class="search-section link-source-list" id="search-items">
+    <div class="search-section link-source-list" id="@(item.id)-child-item-search">
         <h4>@Messages("contentTypes." + entityType.toString)</h4>
         @if(result.nonEmpty) {
             @views.html.admin.search.searchItemListWithAdditionalContent(result) { otherItem =>

--- a/modules/admin/app/views/admin/repository/inlineListItem.scala.html
+++ b/modules/admin/app/views/admin/repository/inlineListItem.scala.html
@@ -8,7 +8,7 @@
     </ul>
 }
 @views.html.common.childCount(item) { count =>
-    @views.html.admin.helpers.linkToWithBody(item, fragment = "#search-items", attributes = Seq('class -> "child-items-inline-load collapsed")) {
+    @views.html.admin.helpers.linkToWithBody(item, fragment = s"#${item.id}-child-item-search", attributes = Seq('class -> "child-items-inline-load collapsed")) {
         <i class="fa fa-fw fa-plus-square-o" aria-hidden="true"></i>
         @Messages("repository.childCount", count)
     }

--- a/modules/admin/app/views/admin/repository/listItem.scala.html
+++ b/modules/admin/app/views/admin/repository/listItem.scala.html
@@ -29,7 +29,7 @@
     }
 
     @views.html.common.childCount(item) { count =>
-        @views.html.admin.helpers.linkToWithBody(item, fragment = "#search-items", attributes = Seq('class -> "child-items-inline-load collapsed")) {
+        @views.html.admin.helpers.linkToWithBody(item, fragment = s"#${item.id}-child-item-search", attributes = Seq('class -> "child-items-inline-load collapsed")) {
             <i class="fa fa-fw fa-plus-square-o" aria-hidden="true"></i>
             @Messages("repository.childCount", count)
         }

--- a/modules/admin/app/views/admin/repository/show.scala.html
+++ b/modules/admin/app/views/admin/repository/show.scala.html
@@ -37,6 +37,7 @@
                             </a>
 
                         }
+                        @views.html.common.childItemSidebar(item, EntityType.DocumentaryUnit)
                     } {
                         @views.html.admin.common.latestAction(item, controllers.institutions.routes.Repositories.history(item.id))
                         @views.html.admin.common.visibility(item, controllers.institutions.routes.Repositories.visibility(item.id), ContentTypes.Repository)
@@ -45,7 +46,7 @@
                 }
 
                 @views.html.admin.search.searchSection(item, Messages("repository.searchInside", item.toStringAbbr(messages)), result) {
-                    @views.html.common.search.searchForm(result, action, autofocus = false) {
+                    @views.html.common.search.searchForm(result, action) {
                         @views.html.admin.search.searchItemList(result)
                     } {
 

--- a/modules/admin/app/views/admin/search/searchSection.scala.html
+++ b/modules/admin/app/views/admin/search/searchSection.scala.html
@@ -1,7 +1,7 @@
 @(item: models.base.Holder[_], title: String, result: services.search.SearchResult[_])(html: Html)(implicit userOpt: Option[UserProfile], req: RequestHeader, conf: AppConfig, messages: Messages)
 
 @if(result.nonEmpty) {
-    <section class="search-section" id="search-items">
+    <section class="search-section" id="@(item.id)-child-item-search">
         <h3>@title</h3>
         @html
     </section>

--- a/modules/admin/app/views/admin/virtualUnit/inlineListItem.scala.html
+++ b/modules/admin/app/views/admin/virtualUnit/inlineListItem.scala.html
@@ -8,7 +8,7 @@
     }
 
     @views.html.common.childCount(d) { count =>
-        @views.html.admin.helpers.linkToWithBody(item, fragment = "#search-items", attributes = Seq('class -> "child-items-inline-load collapsed")) {
+        @views.html.admin.helpers.linkToWithBody(item, fragment = s"#${item.id}-child-item-search", attributes = Seq('class -> "child-items-inline-load collapsed")) {
             <i class="fa fa-fw fa-plus-square-o" aria-hidden="true"></i>
             @Messages("documentaryUnit.childCount", count)
         }

--- a/modules/admin/app/views/admin/virtualUnit/searchItemBody.scala.html
+++ b/modules/admin/app/views/admin/virtualUnit/searchItemBody.scala.html
@@ -34,7 +34,7 @@
 }
 
 @views.html.common.childCount(item) { count =>
-    @views.html.admin.helpers.linkToWithBody(item, fragment = "#search-items", attributes = Seq('class -> "child-items-inline-load collapsed")) {
+    @views.html.admin.helpers.linkToWithBody(item, fragment = s"#${item.id}-child-item-search", attributes = Seq('class -> "child-items-inline-load collapsed")) {
         <i class="fa fa-fw fa-plus-square-o" aria-hidden="true"></i>
         @Messages("documentaryUnit.childCount", count)
     }

--- a/modules/guides/app/views/guides/doc/childItemSearch.scala.html
+++ b/modules/guides/app/views/guides/doc/childItemSearch.scala.html
@@ -1,7 +1,7 @@
 @(guide: Guide, item: DocumentaryUnit, result: services.search.SearchResult[(DocumentaryUnit,services.search.SearchHit)], action: Call, watched: Seq[String])(implicit userOpt: Option[UserProfile], req: RequestHeader, conf: AppConfig, messages: Messages, md: MarkdownRenderer, prefs: SessionPrefs, context: Option[models.base.Holder[_]] = None)
 
 @if(result.nonEmpty) {
-    <ul id="search-items" class="search-result-list">
+    <ul id="@(item.id)-child-item-search" class="search-result-list">
         @result.page.map { case (doc, hit) =>
             <li>
                 @views.html.common.searchItemOutline(doc, watched.contains(doc.id)) {

--- a/modules/guides/app/views/guides/doc/listItemBody.scala.html
+++ b/modules/guides/app/views/guides/doc/listItemBody.scala.html
@@ -25,7 +25,7 @@
     </ul>
     @views.html.common.childCount(item) { count =>
         @if(count > 0) {
-            <a href="@controllers.portal.guides.routes.DocumentaryUnits.browse(guide.path, item.id)#search-items">@Messages("documentaryUnit.childCount", count)</a>
+            <a href="@controllers.portal.guides.routes.DocumentaryUnits.browse(guide.path, item.id)#@(item.id)-child-item-search">@Messages("documentaryUnit.childCount", count)</a>
         }
     }
 

--- a/modules/portal/app/views/documentaryUnit/itemDetails.scala.html
+++ b/modules/portal/app/views/documentaryUnit/itemDetails.scala.html
@@ -14,7 +14,7 @@
                 @views.html.common.typeLabelWithWatchButton(item, watched.contains(item.id))
             } {
                 @views.html.common.sidepanelToc {
-                    @archivalContext(item)
+                    @views.html.documentaryUnit.archivalContext(item)
                     @views.html.common.childItemSidebar(item, EntityType.DocumentaryUnit)
                     @views.html.common.exportItem(
                         Map("ead" -> controllers.portal.routes.DocumentaryUnits.export(item.topLevel.id, asFile = true)))


### PR DESCRIPTION
 - removed less-used types from the main search page
 - added skip link to child items on country, repo and doc pages
 - fixed inline child navigation by setting appropriate 'more' header