### PR TITLE
Reinstate GID index mediator but fix bug w/ indexer

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -66,7 +66,7 @@ class Module extends AbstractModule {
     bind(classOf[QueryBuilder]).to(classOf[SolrQueryBuilder])
     bind(classOf[SearchIndexMediator]).to(classOf[AkkaStreamsIndexMediator])
     bind(classOf[SearchEngine]).to(classOf[SolrSearchEngine])
-    bind(classOf[SearchItemResolver]).to(classOf[IdSearchResolver])
+    bind(classOf[SearchItemResolver]).to(classOf[GidSearchResolver])
     bind(classOf[EventHandler]).to(classOf[IndexingEventHandler])
     bind(classOf[ItemLifecycle]).to(classOf[GeocodingItemLifecycle])
     bind(classOf[DataApi]).to(classOf[DataApiService])

--- a/modules/admin/app/controllers/units/DocumentaryUnits.scala
+++ b/modules/admin/app/controllers/units/DocumentaryUnits.scala
@@ -257,11 +257,11 @@ case class DocumentaryUnits @Inject()(
 
   def delete(id: String): Action[AnyContent] = CheckDeleteAction(id).apply { implicit request =>
     Ok(views.html.admin.delete(
-      request.item, docRoutes.deletePost(id), docRoutes.get(id)))
+      request.item, docRoutes.deletePost(id, goToId = request.item.parent.map(_.id)), docRoutes.get(id)))
   }
 
-  def deletePost(id: String): Action[AnyContent] = DeleteAction(id).apply { implicit request =>
-    Redirect(docRoutes.search())
+  def deletePost(id: String, goToId: Option[String]): Action[AnyContent] = DeleteAction(id).apply { implicit request =>
+    Redirect(goToId.map(p => docRoutes.get(p)).getOrElse(docRoutes.search()))
       .flashing("success" -> "item.delete.confirmation")
   }
 

--- a/modules/admin/conf/units.routes
+++ b/modules/admin/conf/units.routes
@@ -5,7 +5,7 @@ GET     /list                                      @controllers.units.Documentar
 GET     /:id                                       @controllers.units.DocumentaryUnits.get(id: String, dlid: Option[String] ?= None, params: services.search.SearchParams ?= services.search.SearchParams.empty, paging: utils.PageParams ?= utils.PageParams.empty)
 GET     /:id/history                               @controllers.units.DocumentaryUnits.history(id: String, range: utils.RangeParams ?= utils.RangeParams.empty)
 GET     /:id/delete                                @controllers.units.DocumentaryUnits.delete(id: String)
-POST    /:id/delete                                @controllers.units.DocumentaryUnits.deletePost(id: String)
+POST    /:id/delete                                @controllers.units.DocumentaryUnits.deletePost(id: String, goToId: Option[String] ?= None)
 GET     /:id/update                                @controllers.units.DocumentaryUnits.update(id: String)
 POST    /:id/update                                @controllers.units.DocumentaryUnits.updatePost(id: String)
 GET     /:id/create                                @controllers.units.DocumentaryUnits.createDoc(id: String)

--- a/modules/core/app/services/search/GidSearchResolver.scala
+++ b/modules/core/app/services/search/GidSearchResolver.scala
@@ -1,5 +1,6 @@
 package services.search
 
+import play.api.Logger
 import services.data
 import services.data.{ApiUser, DataApi}
 
@@ -10,6 +11,9 @@ import scala.concurrent.{ExecutionContext, Future}
   * Resolve search hits to DB items by the GID field
   */
 case class GidSearchResolver @Inject()(dataApi: DataApi)(implicit executionContext: ExecutionContext) extends SearchItemResolver {
-  def resolve[MT: data.Readable](docs: Seq[SearchHit])(implicit apiUser: ApiUser): Future[Seq[Option[MT]]] =
+  private val logger = Logger(classOf[GidSearchResolver])
+  def resolve[MT: data.Readable](docs: Seq[SearchHit])(implicit apiUser: ApiUser): Future[Seq[Option[MT]]] = {
+    logger.debug(s"Fetching GIDs: ${docs.map(_.gid)}")
     dataApi.withContext(apiUser).fetch(gids = docs.map(_.gid))
+  }
 }

--- a/modules/portal/app/services/search/AkkaStreamsIndexMediator.scala
+++ b/modules/portal/app/services/search/AkkaStreamsIndexMediator.scala
@@ -16,6 +16,8 @@ import config.serviceBaseUrl
 import eu.ehri.project.indexing.converter.impl.JsonConverter
 import play.api.libs.json.Json
 import play.api.{Configuration, Logger}
+import services.data.Constants.{AUTH_HEADER_NAME, STREAM_HEADER_NAME}
+import services.search.SearchConstants.{ID, ITEM_ID, TYPE}
 
 import java.io.StringWriter
 import java.time
@@ -116,7 +118,7 @@ case class AkkaStreamsIndexMediatorHandle(
 
   private def urisToRequests(uris: List[HttpRequest]): List[(HttpRequest, Uri)] = uris.map { r =>
     val req = r
-      .withHeaders(RawHeader("X-Stream", "true"), RawHeader("X-User", "admin"))
+      .withHeaders(RawHeader(STREAM_HEADER_NAME, "true"), RawHeader(AUTH_HEADER_NAME, "admin"))
     req -> r.uri
   }
 
@@ -223,13 +225,14 @@ case class AkkaStreamsIndexMediatorHandle(
     index(childrenToRequests(entityType, id))
   }
 
-  override def clearAll(): Future[Unit] = deleteByQuery("id:*")
+  override def clearAll(): Future[Unit] =
+    deleteByQuery(s"$ID:*")
 
   override def clearTypes(entityTypes: Seq[defines.EntityType.Value]): Future[Unit] =
-    deleteByQuery(entityTypes.map(et => s"type:$et"):_*)
+    deleteByQuery(entityTypes.map(et => s"$TYPE:$et"):_*)
 
   override def clearIds(ids: String*): Future[Unit] =
-    deleteByQuery(ids.map(id => s"id:$id"): _*)
+    deleteByQuery(ids.map(id => s"$ITEM_ID:$id"): _*)
 
   override def clearKeyValue(key: String, value: String): Future[Unit] =
     deleteByQuery(s"$key:$value")


### PR DESCRIPTION
Akka indexer was not clearing the right IDs on deletion, which corrupted the index in some cases.

Additional tweak to redirect to the parent item on child delete.