### PR TITLE
First steps to improving search autocomplete

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -323,7 +323,7 @@ lazy val portal = Project(appName + "-portal", file("modules/portal"))
         Seq(
           "js/lib/jquery-3.4.1.js",
           "js/lib/jquery.validate-1.19.1.js",
-          "js/lib/typeahead-1.2.1.js",
+          "js/lib/typeahead.bundle-1.3.1.js",
           "js/lib/handlebars-v4.4.3.js",
           "js/lib/jquery.cookie.js",
           "js/lib/jquery.hoverIntent.js",

--- a/modules/portal/app/views/common/primaryHeader.scala.html
+++ b/modules/portal/app/views/common/primaryHeader.scala.html
@@ -33,7 +33,7 @@
                         @helper.form(action = controllers.portal.routes.Portal.search()) {
                             <div id="site-search-controls" class="search-box">
                                 <label class="sr-only" for="quicksearch">@Messages("search.site")</label>
-                                <input class="form-control" type="search" name="q" placeholder="@Messages("search.site")" id="quicksearch" value="">
+                                <input class="form-control" type="search" name="q" placeholder="@Messages("search.site")" id="quicksearch" value="" autocomplete="off">
                                 <span class="input-group-append">
                                     <button class="btn submit-search" type="submit" aria-label="@Messages("search.site")">
                                         <i class="material-icons form-control-feedback" aria-hidden="true">search</i>

--- a/modules/portal/app/views/common/search/searchBar.scala.html
+++ b/modules/portal/app/views/common/search/searchBar.scala.html
@@ -1,4 +1,4 @@
-@(params: services.search.SearchParams, fields: Seq[services.search.SearchField.Value] = Seq.empty, autofocus: Boolean = false, tips: Boolean = true, fielded: Boolean = false, placeholder: String = "search.queryPlaceholder")(implicit request: RequestHeader, messages: Messages)
+@(params: services.search.SearchParams, fields: Seq[services.search.SearchField.Value] = Seq.empty, autofocus: Boolean = false, tips: Boolean = true, fielded: Boolean = false, placeholder: String = "search.queryPlaceholder", autocomplete: Boolean = false)(implicit request: RequestHeader, messages: Messages)
 
 @import services.search.{SearchParams,SearchField}
 
@@ -9,7 +9,11 @@
         <div class="input-group">
             <label for="id_q" class="sr-only">@Messages(placeholder)</label>
             <input type="search" id="id_q"
-                placeholder="@Messages(placeholder)" class="form-control" name="@SearchParams.QUERY" value="@params.query" @{if(autofocus) "autofocus"}>
+                placeholder="@Messages(placeholder)"
+                class="form-control" name="@SearchParams.QUERY"
+                value="@params.query"
+                    @{if(autofocus) "autofocus"}
+                    @{if(!autocomplete) "autocomplete=off"}>
             @if(fielded) {
                 <span class="input-group-addon field-selector">
                     <label for="id_field" class="sr-only">@Messages("search.field")</label>

--- a/modules/portal/app/views/layout/portalLayout.scala.html
+++ b/modules/portal/app/views/layout/portalLayout.scala.html
@@ -34,6 +34,11 @@
                 </footer>
             }
             @views.html.common.postambleScripts(extra = scripts)
+            <script>
+                jQuery(function($) {
+                    setupAutoSuggest(document.getElementById("quicksearch"), ["@defines.EntityType.Repository", "@defines.EntityType.Country"]);
+                });
+            </script>
         </body>
     }
 </html>


### PR DESCRIPTION
 - update typeahead to commonjs-typeahead 1.3.1
 - remove browser autocomplete on search boxes by default
 - limit quicksearch types to repositories and countries