### PR TITLE
Fix an error when deleting a storage prefix with no matching files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Build and test
       run: |
-        sbt -v -Dfile.encoding=UTF-8 "+testOnly actors.harvesting.OaiPmhHarvesterManagerSpec"
+        sbt -v -Dfile.encoding=UTF-8 "+test"
         rm -rf "$HOME/.ivy2/local" || true
         find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
         find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true

--- a/test/services/storage/S3CompatibleFileStorageSpec.scala
+++ b/test/services/storage/S3CompatibleFileStorageSpec.scala
@@ -79,6 +79,12 @@ class S3CompatibleFileStorageSpec extends PlaySpecification with TestConfigurati
       items.files.size must_== 2
     }
 
+    "do nothing on delete when no files match prefix" in {
+      val storage = putTestItems._1
+      val deleted = await(storage.deleteFilesWithPrefix("NOPE"))
+      deleted.size must_== 0
+    }
+
     "get item info with version ID" in {
       val storage = putTestItems._1
       val info: Option[(FileMeta, Map[String, String])] = await(storage.info("baz"))


### PR DESCRIPTION
This should have been a no-op, but instead we issued an S3 API call.

Also fix the stupid CI config error that prevented me noticing this for so long - shouldn't have doubted the CircleCI setup!