### PR TITLE
More Scala 2.13 compat fixes

### DIFF
--- a/modules/admin/app/controllers/links/Links.scala
+++ b/modules/admin/app/controllers/links/Links.scala
@@ -69,7 +69,7 @@ case class Links @Inject()(
     val filters = Map(
       "hasBody" -> false,
       "targetCount" -> 2,
-      s"targetTypes:(${targetTypes.mkString(" ")})" -> Unit
+      (s"targetTypes:(${targetTypes.mkString(" ")})", ())
     )
 
     findType[Link](params, paging, filters = filters, facetBuilder = entityFacets ).map { result =>

--- a/modules/guides/app/controllers/portal/guides/Guides.scala
+++ b/modules/guides/app/controllers/portal/guides/Guides.scala
@@ -322,7 +322,7 @@ case class Guides @Inject()(
     import SearchConstants._
     vcDescendantIds(item).map { seq =>
       if (seq.isEmpty) Map(ITEM_ID -> "__NO_VALID_ID__")
-      else Map(s"$ITEM_ID:(${seq.mkString(" ")}) OR $ANCESTOR_IDS:(${seq.mkString(" ")})" -> Unit)
+      else Map((s"$ITEM_ID:(${seq.mkString(" ")}) OR $ANCESTOR_IDS:(${seq.mkString(" ")})", ()))
     }
   }
 
@@ -423,7 +423,7 @@ case class Guides @Inject()(
         for {
           ids <- searchFacets(guide, facets)
           result <- if (ids.nonEmpty) findType[DocumentaryUnit](params, paging,
-            filters = Map(s"gid:(${ids.take(1024).mkString(" ")})" -> Unit),
+            filters = Map((s"gid:(${ids.take(1024).mkString(" ")})", ())),
             sort = SearchSort.Name
           ) else immediate(SearchResult.empty)
           selectedAccessPoints <- userDataApi.fetch[Model](facets)

--- a/modules/portal/app/controllers/base/SearchVC.scala
+++ b/modules/portal/app/controllers/base/SearchVC.scala
@@ -86,11 +86,11 @@ trait SearchVC {
     item match {
       case v: VirtualUnit => vcDescendantIds(item.id).map { seq =>
         if (seq.isEmpty) Map(ITEM_ID -> "__NO_VALID_ID__")
-        else Map(s"$ITEM_ID:(${seq.mkString(" ")}) OR $ANCESTOR_IDS:(${seq.mkString(" ")})" -> Unit)
+        else Map((s"$ITEM_ID:(${seq.mkString(" ")}) OR $ANCESTOR_IDS:(${seq.mkString(" ")})", ()))
       }
       // otherwise, for documentary units, we can just query
       // all ancestors
-      case d => immediate(Map(s"$ANCESTOR_IDS:${item.id}" -> Unit))
+      case d => immediate(Map((s"$ANCESTOR_IDS:${item.id}", ())))
     }
 
   protected def buildChildSearchFilter(item: Model): Future[Map[String,Any]] =
@@ -108,9 +108,9 @@ trait SearchVC {
       item match {
         case v: VirtualUnit =>
           val pq = v.includedUnits.map(_.id)
-          if (pq.isEmpty) Map(s"$PARENT_ID:${v.id}" -> Unit)
-          else Map(s"$PARENT_ID:${v.id} OR $ITEM_ID:(${pq.mkString(" ")})" -> Unit)
-        case d => Map(s"$PARENT_ID:${d.id}" -> Unit)
+          if (pq.isEmpty) Map((s"$PARENT_ID:${v.id}", ()))
+          else Map((s"$PARENT_ID:${v.id} OR $ITEM_ID:(${pq.mkString(" ")})", ()))
+        case d => Map((s"$PARENT_ID:${d.id}", ()))
       }
     }
 }

--- a/modules/portal/app/controllers/portal/Bookmarks.scala
+++ b/modules/portal/app/controllers/portal/Bookmarks.scala
@@ -147,10 +147,10 @@ case class Bookmarks @Inject()(
 
   private def buildFilter(v: VirtualUnit): Map[String, Any] = {
     val pq = v.includedUnits.map(_.id)
-    if (pq.isEmpty) Map(s"${SearchConstants.PARENT_ID}:${v.id}" -> Unit)
+    if (pq.isEmpty) Map((s"${SearchConstants.PARENT_ID}:${v.id}", ()))
     else {
       val q = s"${SearchConstants.PARENT_ID}:${v.id} OR ${SearchConstants.ITEM_ID}:(${pq.mkString(" ")})"
-      Map(q -> Unit)
+      Map((q, ()))
     }
   }
 

--- a/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
+++ b/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
@@ -267,7 +267,7 @@ case class S3CompatibleFileStorage(
     }, r.isTruncated)
   }
 
-  private def deleteKeys(paths: Seq[String]) = {
+  private def deleteKeys(paths: Seq[String]): Seq[String] = {
     if (paths.isEmpty) paths else {
       val delete = Delete.builder()
         .objects(paths.map(key => ObjectIdentifier.builder().key(key).build()): _*)
@@ -276,7 +276,7 @@ case class S3CompatibleFileStorage(
         .bucket(name)
         .delete(delete)
         .build()
-      client.deleteObjects(dor).deleted().asScala.map(_.key)
+      client.deleteObjects(dor).deleted().asScala.map(_.key).toSeq
     }
   }
 

--- a/test/services/feedback/SqlFeedbackServiceSpec.scala
+++ b/test/services/feedback/SqlFeedbackServiceSpec.scala
@@ -2,7 +2,7 @@ package services.feedback
 
 import helpers.IntegrationTestRunner
 import models.Feedback
-import play.api.Application
+import play.api.{Application, Mode}
 import utils.{Page, PageParams}
 
 
@@ -31,7 +31,7 @@ class SqlFeedbackServiceSpec extends IntegrationTestRunner {
       val f = Feedback(text = Some("Problem..."), mode = Some(play.api.Mode.Prod))
       val id = await(feedbackService.create(f))
       val f2 = await(feedbackService.get(id))
-      f2.mode must beSome(play.api.Mode.Prod)
+      f2.mode must beSome.which((_: Mode) must_== play.api.Mode.Prod)
       // If we delete it successfully assume all good...
       await(feedbackService.delete(id)) must_== true
     }

--- a/test/services/harvesting/MockHarvestEventService.scala
+++ b/test/services/harvesting/MockHarvestEventService.scala
@@ -23,7 +23,7 @@ private class EventDb extends Actor {
   override def receive: Receive = {
     case e: HarvestEvent =>
       events :+= e
-      sender ! Unit
+      sender() ! e
 
     case Query(repoId, datasetId, jobId) =>
       sender() ! events
@@ -46,13 +46,13 @@ case class MockHarvestEventService()(implicit mat: Materializer, as: ActorSystem
     db.ask(HarvestEvent(repoId, datasetId, jobId, userOpt.map(_.id), HarvestEventType.Started, info, Instant.now())).map { _ =>
       new HarvestEventHandle {
         override def close(): Future[Unit] =
-          db.ask(HarvestEvent(repoId, datasetId, jobId, userOpt.map(_.id), HarvestEventType.Completed, info, Instant.now())).map(_ => Unit)
+          db.ask(HarvestEvent(repoId, datasetId, jobId, userOpt.map(_.id), HarvestEventType.Completed, info, Instant.now())).map(_ => ())
 
         override def cancel(): Future[Unit] =
-          db.ask(HarvestEvent(repoId, datasetId, jobId, userOpt.map(_.id), HarvestEventType.Cancelled, info, Instant.now())).map(_ => Unit)
+          db.ask(HarvestEvent(repoId, datasetId, jobId, userOpt.map(_.id), HarvestEventType.Cancelled, info, Instant.now())).map(_ => ())
 
         override def error(t: Throwable): Future[Unit] =
-          db.ask(HarvestEvent(repoId, datasetId, jobId, userOpt.map(_.id), HarvestEventType.Errored, info, Instant.now())).map(_ => Unit)
+          db.ask(HarvestEvent(repoId, datasetId, jobId, userOpt.map(_.id), HarvestEventType.Errored, info, Instant.now())).map(_ => ())
       }
     }
   }

--- a/test/services/ingest/SqlImportLogServiceSpec.scala
+++ b/test/services/ingest/SqlImportLogServiceSpec.scala
@@ -14,7 +14,7 @@ import java.util.UUID
 class SqlImportLogServiceSpec extends PlaySpecification with AfterAll {
 
   private val actorSystem = ActorSystem()
-  override def afterAll: Unit = await(actorSystem.terminate())
+  override def afterAll(): Unit = await(actorSystem.terminate())
 
   def service(implicit db: Database) = SqlImportLogService(db, actorSystem)
   private val keyVersion = "foo.ead?versionId=1"


### PR DESCRIPTION
Convert literal uses of `Unit` to `()`: where the `->` tuple builder is used these are converted to raw tuples to avoid issues with inferred arguments w/ Scala 2.12.