### PR TITLE
Fix some issues with virtual collection searching and listing

### DIFF
--- a/modules/portal/app/assets/js/common.js
+++ b/modules/portal/app/assets/js/common.js
@@ -109,14 +109,22 @@ jQuery(function($) {
   // Inline tree navigation
   // Add inline load class to all item-children items
   function addInlineLoadLinks(scope) {
-    $(".item-children > a.child-items-inline-load.collapsed", scope)
+    if (window.URLSearchParams) {
+      $(".item-children > a.child-items-inline-load.collapsed", scope)
         .map(function () {
-          $(this)
-              .attr("href", this.href.replace(/([^#]*)(\?inline=true)?(#.*)?$/, "$1?inline=true$3"));
+          var url = new URL(this.href),
+            params = new URLSearchParams(url.search);
+          params.set("inline", true)
+          url.search = params.toString();
+          $(this).attr("href", url.toString());
         });
+    }
   }
 
   addInlineLoadLinks(document);
+  $(document).ajaxComplete(function () {
+    addInlineLoadLinks(document);
+  });
 
   // remove inline lists when the [-] is clicked
   $(document).on("click", "a.child-items-inline-load.expanded", function(e) {

--- a/modules/portal/app/assets/js/portal.js
+++ b/modules/portal/app/assets/js/portal.js
@@ -232,11 +232,6 @@ jQuery(function ($) {
     $link.addClass("loading");
     $data.load(this.href, function () {
       $link.removeClass("loading").addClass("loaded");
-      if ($.fn.select2) {
-        $data.find(".select2").each(function (i) {
-          $(this).select2(select2Opts);
-        });
-      }
       $link.hide();
     });
   });

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrQueryBuilder.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrQueryBuilder.scala
@@ -142,7 +142,7 @@ private[solr] object SolrQueryBuilder {
         // Have to quote strings
         case s: String => key + ":\"" + value + "\""
         // not value means the key is a query!
-        case Unit => key
+        case () => key
         case _ => s"$key:$value"
       }
       "fq" -> filter

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.4.1
+sbt.version=1.3.13
 logLevel := Level.Info


### PR DESCRIPTION
 - JS to append inline=true query param was broken
 - pattern matching against `Unit` in the query builder also broken

Also downgrade to SBT 1.3.13 since 1.4.0 has an issue with swallowing Play crash reporting in the browser.