### PR TITLE
Add an endpoint to facilitate integration with Discourse Connect

### DIFF
--- a/modules/backend/src/main/scala/utils/http/package.scala
+++ b/modules/backend/src/main/scala/utils/http/package.scala
@@ -2,6 +2,8 @@ package utils
 
 import org.apache.jena.iri.IRIFactory
 
+import java.net.URLDecoder
+
 package object http {
 
   import java.net.URLEncoder
@@ -38,4 +40,19 @@ package object http {
   def iriToUri(iri: String): String = {
     IRIFactory.iriImplementation().create(iri).toURI.toASCIIString
   }
+
+  /**
+    * Parse a query string into parameters.
+    *
+    * This only handles the &foo=bar form and should not be considered
+    * a complete implementation.
+    *
+    * @param s a query string
+    * @return a sequence of key, value pairs
+    */
+  def parseQueryString(s: String): Seq[(String, String)] = s.split('&')
+    .map(_.split('=').toList)
+    .collect { case key :: value :: Nil =>
+      URLDecoder.decode(key, "UTF-8") -> URLDecoder.decode(value, "UTF-8")
+    }.toSeq
 }

--- a/modules/core/src/main/scala/auth/sso/DiscourseSSO.scala
+++ b/modules/core/src/main/scala/auth/sso/DiscourseSSO.scala
@@ -1,0 +1,93 @@
+package auth.sso
+
+/**
+  * Implementation of Discourse Connect (previously known as Discourse SSO.)
+  *
+  * See here for how this works:
+  *
+  * https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045
+  */
+
+import com.google.common.hash.Hashing
+import play.api.Configuration
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+case class DiscourseSSOError(msg: String) extends Exception(msg)
+case class DiscourseSSONotEnabledError() extends Exception("Discourse SSO not enabled")
+
+object DiscourseSSO {
+  /**
+    * Alternative constructor for looking up details from config
+    * based on the {client} parameter. This allows multiple sites
+    * to use SSO.
+    *
+    * @param client a config-safe key with which to look up config in the `sso` dict
+    * @param config the application config instance
+    * @throws DiscourseSSONotEnabledError if the configuration is not found
+    * @return a {DiscourseSSO} instance
+    */
+  @throws[DiscourseSSONotEnabledError]
+  def apply(client: String, config: Configuration): DiscourseSSO = {
+    (for {
+      secret <- config.getOptional[String](s"sso.$client.discourse_connect_secret")
+      endpoint <- config.getOptional[String](s"sso.$client.discourse_endpoint")
+    } yield DiscourseSSO(endpoint, secret)).getOrElse {
+      throw DiscourseSSONotEnabledError()
+    }
+  }
+}
+
+case class DiscourseSSO(endpoint: String, secret: String) {
+  private val utf8 = StandardCharsets.UTF_8
+  private val base64encoder = Base64.getMimeEncoder
+  private val base64decoder = Base64.getMimeDecoder
+
+  /**
+    * Encode SSO response data and return an URL-encoded payload
+    * string and a signature.
+    *
+    * @param data a set of query string pairs, typically including a nonce
+    * @return a non-URL-encoded tuple consisting of an encoded payload string and a signed
+    *         signature value
+    */
+  def encode(data: Seq[(String, String)]): (String, String) = {
+    val payload = utils.http.joinQueryString(data)
+    // NB: Ruby Base64 adds a trailing line break.
+    val base64Payload = base64encoder.encodeToString(payload.getBytes(utf8)) + "\n"
+    val newSig = Hashing.hmacSha256(secret.getBytes(utf8)).hashString(base64Payload, utf8).toString
+    base64Payload -> newSig
+  }
+
+  /**
+    * Create an URL to redirect the data back to the SSO client site.
+    *
+    * @param data the SSO data
+    * @return an URL string
+    */
+  def toUrl(data: Seq[(String, String)]): String = {
+    val (payload, sig) = encode(data)
+    endpoint + "?" + utils.http.joinQueryString(Seq("sso" -> payload, "sig" -> sig))
+  }
+
+  /**
+    * Decode an SSO payload and check it against the supplied signature.
+    *
+    * @param payload an non-URL-encoded payload string containing the SSO nonce
+    * @param sig a signed signature value
+    * @return a sequence of key/value pairs.
+    */
+  @throws[DiscourseSSOError]
+  def decode(payload: String, sig: String): Seq[(String, String)] = {
+    val check = Hashing.hmacSha256(secret.getBytes(utf8)).hashString(payload, utf8).toString
+    if (check != sig) {
+      throw DiscourseSSOError("Mismatched signature")
+    }
+
+    val urlDecoded = URLDecoder.decode(payload, utf8.name())
+    val decoded: String = new String(base64decoder.decode(urlDecoded.getBytes(utf8)))
+    utils.http.parseQueryString(decoded)
+  }
+}

--- a/modules/core/src/main/scala/models/UserProfile.scala
+++ b/modules/core/src/main/scala/models/UserProfile.scala
@@ -113,7 +113,7 @@ object UserProfile {
 
   def quickUnapply(up: UserProfile) = Some((up.data, up.groups, up.accessors, up.latestEvent, up.meta))
 
-  val form = Form(
+  val form: Form[UserProfileF] = Form(
     mapping(
       ISA -> ignored(EntityType.UserProfile),
       ID -> optional(nonEmptyText),

--- a/modules/core/src/test/scala/auth/sso/DiscourseSSOSpec.scala
+++ b/modules/core/src/test/scala/auth/sso/DiscourseSSOSpec.scala
@@ -1,0 +1,30 @@
+package auth.sso
+
+import play.api.test.PlaySpecification
+
+/**
+  * Tests and literal values taken from Discourse SSO example:
+  *
+  * https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045
+  */
+class DiscourseSSOSpec extends PlaySpecification {
+  private val ENDPOINT = "http://discuss.example.com/session/sso_login"
+  private val SECRET = "d836444a9e4084d5b224a60c208dce14"
+  val NONCE = "cb68251eefb5211e58c00ff1395f0c0b"
+  val PAYLOAD = "bm9uY2U9Y2I2ODI1MWVlZmI1MjExZTU4YzAwZmYxMzk1ZjBjMGI=\n"
+  val SIG = "2828aa29899722b35a2f191d34ef9b3ce695e0e6eeec47deb46d588d70c7cb56"
+  val SSO = DiscourseSSO(ENDPOINT, SECRET)
+
+  "Discourse SSO" should {
+    "encode data correctly" in {
+      val (payload, sig) = SSO.encode(Seq("nonce" -> NONCE))
+      payload must_== PAYLOAD
+      sig must_== SIG
+    }
+
+    "decode data correctly" in {
+      val data = SSO.decode(PAYLOAD, SIG)
+      data must_== Seq("nonce" -> NONCE)
+    }
+  }
+}

--- a/modules/portal/app/views/errors/verifiedOnly.scala.html
+++ b/modules/portal/app/views/errors/verifiedOnly.scala.html
@@ -1,8 +1,15 @@
 @()(implicit userOpt: Option[UserProfile] = None, req: RequestHeader, conf: AppConfig, messages: Messages, flash: Flash)
 
+@common.flash(flash)
 <p class="error-notice">
     @Messages("errors.verifiedOnlyMessage")
 </p>
+@helper.form(controllers.portal.account.routes.Accounts.resendVerificationPost()) {
+    <p>
+        @formHelpers.csrfToken()
+        <button class="btn btn-info" type="submit">@Messages("mail.unverifiedEmailSubmit")</button>
+    </p>
+}
 <p>
     <a href="@controllers.portal.account.routes.Accounts.logout()">@Messages("logout")</a>
 </p>

--- a/modules/portal/app/views/userProfile/unverified.scala.html
+++ b/modules/portal/app/views/userProfile/unverified.scala.html
@@ -1,4 +1,4 @@
-@()(implicit request: RequestHeader, messages: Messages)
+@()(implicit request: RequestHeader, messages: Messages, flash: Flash)
 
 <div class="alert alert-warning">
     @helper.form(action = controllers.portal.account.routes.Accounts.resendVerificationPost) {

--- a/modules/portal/conf/account.routes
+++ b/modules/portal/conf/account.routes
@@ -7,6 +7,7 @@ GET         /authenticate/:provider         @controllers.portal.account.Accounts
 GET         /login-with/:provider           @controllers.portal.account.Accounts.oauth2Login(provider: String, code: Option[String] ?= None, state: Option[String] ?= None)
 GET         /register-with/:provider        @controllers.portal.account.Accounts.oauth2Register(provider: String, code: Option[String] ?= None, state: Option[String] ?= None)
 GET         /logout                         @controllers.portal.account.Accounts.logout()
+GET         /sso/$client<[a-z0-9]+>         @controllers.portal.account.Accounts.sso(client: String, sso: String, sig: String)
 
 GET         /signup                         @controllers.portal.account.Accounts.signup()
 POST        /signup                         @controllers.portal.account.Accounts.signupPost()

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -61,8 +61,10 @@ format.boolean=On/Off
 
 errors.staffOnly=Restricted
 errors.staffOnlyMessage=This page is currently restricted to EHRI staff only.
-errors.verifiedOnly=Restricted
-errors.verifiedOnlyMessage=This page is currently restricted to verified users only.
+errors.verifiedOnly=Email Verification Required
+errors.verifiedOnlyMessage=Access to this resource is restricted to users with a verified email address. \
+  Click the button below to send a verification mail to your address. Be sure to check your spam folder \
+  if the email does not arrive.
 errors.readonly=The EHRI portal is currently in read-only mode while we conduct maintenance.\
          Normal service should be resumed in due course. Thanks for your patience.
 errors.itemNotFound=Item Not Found
@@ -95,6 +97,8 @@ errors.imageTooLarge=This image was too large. Please select one smaller than 5 
 errors.badFileType=The uploaded file was not a supported image type.
 errors.noFileGiven=No image file was selected.
 errors.invalidUrl=Web URL is invalid
+errors.sso.notEnabled=Single sign-on is not enabled on this site.
+errors.sso.badData=Unable to validate single sign-on.
 
 identifier=Identifier
 identifier.description=An item identifier that is unique with the scope of it''s parent item. \
@@ -334,6 +338,7 @@ mail.unverifiedEmailWarning=Unverified Account
 mail.unverifiedEmailWarningMessage=The email associated with your account has not yet been verified.
 mail.unverifiedEmailResend=To re-send a verification email
 mail.unverifiedEmailResendSubmit=click here
+mail.unverifiedEmailSubmit=Send Verification Email
 mail.emailConfirmationResent=We''ve sent you an email which you can use to confirm your email address.
 mail.message.subject=EHRI: Message from {0}: {1}
 mail.message.copy.subject=EHRI: Your message to {0}: {1}

--- a/modules/portal/conf/messages.de
+++ b/modules/portal/conf/messages.de
@@ -43,8 +43,6 @@ constraints.uniqueness.failed=Es existiert bereits ein Element mit diesem Wert
 format.boolean=Ein/Aus
 errors.staffOnly=Eingeschränkt
 errors.staffOnlyMessage=Der Zugriff auf diese Seite ist momentan auf EHRI-Mitarbeiter eingeschränkt.
-errors.verifiedOnly=Eingeschränkt
-errors.verifiedOnlyMessage=Der Zugriff auf diese Seite ist momentan auf verifizierte Nutzer eingeschränkt.
 errors.readonly=Das EHRI-Portal befindet sich wegen Wartungsarbeiten momentan im Read-Only-Modus.\
            Die normale Nutzung sollte in Kürze wieder möglich sein. Vielen Dank für Ihre Geduld.
 errors.itemNotFound=Element nicht gefunden

--- a/modules/portal/conf/messages.fr
+++ b/modules/portal/conf/messages.fr
@@ -41,10 +41,7 @@ constraints.honeypot.failed=Le formulaire de vérification des spams a échoué.
 constraints.uniqueness=Doit être unique
 constraints.uniqueness.failed=Un article avec cette valeur existe déjà
 format.boolean=Activé/désactivé
-errors.staffOnly=Restreint
 errors.staffOnlyMessage=L''accès à cette page est actuellement limité au personnel de l''EHRI.
-errors.verifiedOnly=Restreint
-errors.verifiedOnlyMessage=L''accès à cette page est actuellement limité à des utilisateurs autorisés.
 errors.readonly=Le portail de l''EHRI est pour l''instant uniquement en mode lecture, pendant que nous effectuons une opération de maintenance.\
               Un service normal reprendra en temps voulu. Merci pour votre patience.
 errors.itemNotFound=Objet non trouvé

--- a/modules/portal/conf/messages.pl
+++ b/modules/portal/conf/messages.pl
@@ -43,8 +43,6 @@ constraints.uniqueness.failed=Pozycja o tej wartości już istnieje
 format.boolean=Wł./wył.
 errors.staffOnly=Dostęp ograniczony
 errors.staffOnlyMessage=Dostęp do tej strony jest obecnie ograniczony do pracowników EHRI.
-errors.verifiedOnly=Dostęp ograniczony
-errors.verifiedOnlyMessage=Dostęp do tej strony jest obecnie ograniczony do zweryfikowanych użytkowników.
 errors.readonly=Portal EHRI jest obecnie dostępny w trybie tylko do odczytu ze względu na prowadzone prace konserwacyjne.\
            Wkrótce powinno zostać wznowione normalne działanie. Dziękujemy za cierpliwość.
 errors.itemNotFound=Nie znaleziono pozycji

--- a/test/integration/portal/AccountsSpec.scala
+++ b/test/integration/portal/AccountsSpec.scala
@@ -2,13 +2,17 @@ package integration.portal
 
 import auth.HashedPassword
 import auth.oauth2.providers.GoogleOAuth2Provider
-import helpers.IntegrationTestRunner
-import models.SignupData
-import play.api.i18n.MessagesApi
-import play.api.cache.SyncCacheApi
-import play.api.test.{FakeRequest, Injecting, WithApplication}
+import auth.sso.DiscourseSSO
 import forms.HoneyPotForm._
 import forms.TimeCheckForm._
+import helpers.IntegrationTestRunner
+import mockdata.unprivilegedUser
+import models.SignupData
+import play.api.cache.SyncCacheApi
+import play.api.i18n.MessagesApi
+import play.api.test.{FakeRequest, Injecting, WithApplication}
+
+import java.util.UUID
 
 
 class AccountsSpec extends IntegrationTestRunner {
@@ -135,6 +139,66 @@ class AccountsSpec extends IntegrationTestRunner {
     "error with bad provider" in new ITestApp {
       val login = FakeRequest(accountRoutes.oauth2Register("no-provider")).call()
       status(login) must equalTo(NOT_FOUND)
+    }
+  }
+
+  "Discourse SSO" should {
+
+    val CLIENT = "forums"
+    val KEY = "DISCOURSE_TEST_SECRET"
+    val URL = "https://discuss.ehri-project.eu"
+
+    "deny access to unverified users" in new ITestApp {
+      await(mockAccounts.update(unprivilegedUser.copy(verified = false)))
+      val ssoLogin = FakeRequest(accountRoutes.sso(CLIENT, "foo", "bar"))
+        .withUser(unprivilegedUser)
+        .call()
+      status(ssoLogin) must_== UNAUTHORIZED
+    }
+
+    "give a bad request when SSO not configured" in new ITestApp {
+      val ssoLogin = FakeRequest(accountRoutes.sso(CLIENT, "foo", "bar"))
+        .withUser(unprivilegedUser)
+        .call()
+      status(ssoLogin) must_== BAD_REQUEST
+    }
+
+    "correctly parse data" in new ITestApp(specificConfig = Map(
+      s"sso.$CLIENT.discourse_connect_secret" -> KEY,
+      s"sso.$CLIENT.discourse_endpoint" -> URL
+    )) {
+
+      val helper = DiscourseSSO(URL, KEY)
+
+      val nonce = UUID.randomUUID().toString
+      val (payload, sig) = helper.encode(Seq("nonce" -> nonce))
+
+      val ssoLogin = FakeRequest(accountRoutes.sso(CLIENT, payload, sig))
+        .withUser(privilegedUser)
+        .call()
+      status(ssoLogin) must_== SEE_OTHER
+      val loc = redirectLocation(ssoLogin)
+      loc must beSome.which { (s:String) =>
+        s must startWith(URL)
+
+        val qs = s.substring(s.lastIndexOf('?') + 1)
+        val data: Map[String, String] = utils.http.parseQueryString(qs).toMap
+
+        val sso = data.get("sso")
+        sso must beSome
+        val newSig = data.get("sig")
+        newSig must beSome
+
+        val outPayload = helper.decode(sso.get, newSig.get)
+        outPayload must_== Seq(
+          "nonce" -> nonce,
+          "external_id" -> privilegedUser.id,
+          "email" -> privilegedUser.email,
+          "name" -> "Mike",
+          "admin" -> "true",
+          "moderator" -> "false"
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
This is an SSO mechanism to allow us to set up client sites that use the portal's user credentials for login. Discourse is the obvious first candidate but eventually the editions could also use this mechanism, since it seems relatively simple.