### PR TITLE
Start of better handling for non-UTF-8 input datasets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,6 +122,7 @@ val adminDependencies = Seq(
 
   // XML parsing
   "com.lightbend.akka" %% "akka-stream-alpakka-xml" % alpakkaVersion,
+  "com.lightbend.akka" %% "akka-stream-alpakka-text" % alpakkaVersion,
 )
 
 val testDependencies = Seq(

--- a/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
+++ b/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
@@ -184,7 +184,7 @@ case class S3CompatibleFileStorage(
         f.size,
         // NB: S3 returns eTags wrapped in quotes, but Alpakka doesn't
         // hence for compatibility we add it here.
-        Some(f.eTag).map(f => "\"" + f + "\"")
+        Some(f.eTag).map(f => "\"" + f + "\""),
       ))
   }
 
@@ -298,7 +298,7 @@ case class S3CompatibleFileStorage(
         f.key,
         f.lastModified,
         f.size,
-        Some(f.eTag),
+        Some(f.eTag)
       )
     }.toList, resp.isTruncated)
   }


### PR DESCRIPTION
 - EAD manager UI can read non-UTF8 input sources correctly
 - XML converter will transcode to UTF-8 automatically when needed

However: there's currently no way to upload non-UTF-8 files since the browser apparently doesn't set this info. Presumably this would be a dataset-level setting that would prompt a transcoding step.