### PR TITLE
More handling for non-UTF-8 content types

### DIFF
--- a/conf/evolutions/default/1.sql
+++ b/conf/evolutions/default/1.sql
@@ -114,14 +114,15 @@ CREATE TABLE cypher_queries (
 );
 
 CREATE TABLE import_dataset (
-    repo_id  VARCHAR(50) NOT NULL,
-    id       VARCHAR(50) NOT NULL,
-    name     TEXT NOT NULL,
-    type     VARCHAR(10) NOT NULL,
-    created  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    item_id  TEXT,
-    sync     BOOLEAN DEFAULT FALSE,
-    comments TEXT,
+    repo_id         VARCHAR(50) NOT NULL,
+    id              VARCHAR(50) NOT NULL,
+    name            TEXT NOT NULL,
+    type            VARCHAR(10) NOT NULL,
+    content_type    VARCHAR(50) NULL,
+    created         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    item_id         TEXT,
+    sync            BOOLEAN DEFAULT FALSE,
+    comments        TEXT,
     PRIMARY KEY (id, repo_id),
     UNIQUE (id, repo_id),
     CONSTRAINT import_dataset_id_pattern CHECK (id ~ '^[a-z0-9_]+$') ,

--- a/etc/db_migrations/20210722_add_content_type_to_import_dataset.sql
+++ b/etc/db_migrations/20210722_add_content_type_to_import_dataset.sql
@@ -1,0 +1,1 @@
+ALTER TABLE import_dataset ADD COLUMN content_type VARCHAR(50) NULL;

--- a/modules/admin/app/actors/transformation/XmlConverterManager.scala
+++ b/modules/admin/app/actors/transformation/XmlConverterManager.scala
@@ -29,6 +29,7 @@ object XmlConverterManager {
     * @param outPrefix    the replacement output path prefix
     * @param only         a single key to convert. If not given the whole
     *                     classifier will be converted.
+    * @param contentType  the content-type of the input material
     * @param force        run conversion even if a matching file already
     *                     exists
     */
@@ -39,6 +40,7 @@ object XmlConverterManager {
     from: Option[Instant] = None,
     only: Option[String] = None,
     force: Boolean = false,
+    contentType: Option[String] = None,
   )
 
   /**

--- a/modules/admin/app/assets/js/datamanager/app.vue
+++ b/modules/admin/app/assets/js/datamanager/app.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 
-import DatasetManager from './components/_dataset-manager';
+import ManagerDatasets from './components/_manager-datasets';
 import MixinUtil from './components/_mixin-util';
 import {DatasetManagerApi} from "./api";
 
@@ -18,7 +18,7 @@ const CONFIG = (window as any).CONFIG as ConfigType;
 const SERVICE = (window as any).SERVICE as any;
 
 export default {
-  components: {DatasetManager},
+  components: {ManagerDatasets},
   mixins: [MixinUtil],
   data: function() {
     return {
@@ -32,7 +32,7 @@ export default {
 
 <template>
   <div id="app-container">
-    <dataset-manager
+    <manager-datasets
         v-bind:config="config"
         v-bind:init-tab="tab"
         v-bind:api="api" />

--- a/modules/admin/app/assets/js/datamanager/components/_manager-datasets.vue
+++ b/modules/admin/app/assets/js/datamanager/components/_manager-datasets.vue
@@ -15,7 +15,6 @@ import {DatasetManagerApi} from "../api";
 import _find from 'lodash/find';
 import _merge from 'lodash/merge';
 import _omit from 'lodash/omit';
-import _modalDatasetImport from "./_modal-dataset-import.vue";
 
 export default {
   components: {
@@ -263,6 +262,7 @@ export default {
         <manager-oaipmh
             v-if="dataset.src === 'oaipmh'"
             v-bind:dataset-id="dataset.id"
+            v-bind:dataset-content-type="dataset.contentType"
             v-bind:fileStage="config.input"
             v-bind:config="config"
             v-bind:active="tab === 'input'"
@@ -271,6 +271,7 @@ export default {
         <manager-rs
             v-else-if="dataset.src === 'rs'"
             v-bind:dataset-id="dataset.id"
+            v-bind:dataset-content-type="dataset.contentType"
             v-bind:fileStage="config.input"
             v-bind:config="config"
             v-bind:active="tab === 'input'"
@@ -279,6 +280,7 @@ export default {
         <manager-upload
             v-else
             v-bind:dataset-id="dataset.id"
+            v-bind:dataset-content-type="dataset.contentType"
             v-bind:fileStage="config.input"
             v-bind:config="config"
             v-bind:active="tab === 'input'"
@@ -288,6 +290,7 @@ export default {
       <div id="tab-convert" class="stage-tab" v-show="tab === 'convert'">
         <manager-convert
             v-bind:dataset-id="dataset.id"
+            v-bind:dataset-content-type="dataset.contentType"
             v-bind:fileStage="config.output"
             v-bind:config="config"
             v-bind:active="tab === 'convert'"

--- a/modules/admin/app/assets/js/datamanager/components/_manager-oaipmh.vue
+++ b/modules/admin/app/assets/js/datamanager/components/_manager-oaipmh.vue
@@ -24,6 +24,7 @@ export default {
   components: {FilterControl, FilesTable, ButtonDelete, ButtonValidate, PanelFilePreview, ModalOaipmhConfig, DragHandle, ModalInfo, PanelLogWindow},
   mixins: [MixinStage, MixinTwoPanel, MixinValidator, MixinError, MixinPreview, MixinUtil],
   props: {
+    datasetContentType: String,
     fileStage: String,
     config: Object,
     api: DatasetManagerApi,
@@ -211,15 +212,16 @@ export default {
         <div class="status-panels">
           <div class="status-panel" v-show="tab === 'preview'">
             <panel-file-preview v-bind:dataset-id="datasetId"
-                     v-bind:file-stage="fileStage"
-                     v-bind:previewing="previewing"
-                     v-bind:panel-size="panelSize"
-                     v-bind:config="config"
-                     v-bind:api="api"
-                     v-bind:validation-results="validationResults"
-                     v-on:validation-results="(tag, e) => this.$set(this.validationResults, tag, e)"
-                     v-on:error="showError"
-                     v-show="previewing !== null"/>
+                                v-bind:content-type="datasetContentType"
+                                v-bind:file-stage="fileStage"
+                                v-bind:previewing="previewing"
+                                v-bind:panel-size="panelSize"
+                                v-bind:config="config"
+                                v-bind:api="api"
+                                v-bind:validation-results="validationResults"
+                                v-on:validation-results="(tag, e) => this.$set(this.validationResults, tag, e)"
+                                v-on:error="showError"
+                                v-show="previewing !== null"/>
             <div class="panel-placeholder" v-if="previewing === null">
               No file selected.
             </div>

--- a/modules/admin/app/assets/js/datamanager/components/_manager-rs.vue
+++ b/modules/admin/app/assets/js/datamanager/components/_manager-rs.vue
@@ -24,6 +24,7 @@ export default {
   components: {FilterControl, FilesTable, PanelLogWindow, DragHandle, ModalInfo, PanelFilePreview, ButtonValidate, ButtonDelete, ModalRsConfig},
   mixins: [MixinStage, MixinTwoPanel, MixinPreview, MixinValidator, MixinError, MixinUtil],
   props: {
+    datasetContentType: String,
     fileStage: String,
     config: Object,
     api: DatasetManagerApi,
@@ -212,15 +213,16 @@ export default {
         <div class="status-panels">
           <div class="status-panel" v-show="tab === 'preview'">
             <panel-file-preview v-bind:dataset-id="datasetId"
-                     v-bind:file-stage="fileStage"
-                     v-bind:previewing="previewing"
-                     v-bind:panel-size="panelSize"
-                     v-bind:config="config"
-                     v-bind:api="api"
-                     v-bind:validation-results="validationResults"
-                     v-on:validation-results="(tag, e) => this.$set(this.validationResults, tag, e)"
-                     v-on:error="showError"
-                     v-show="previewing !== null"/>
+                                v-bind:content-type="datasetContentType"
+                                v-bind:file-stage="fileStage"
+                                v-bind:previewing="previewing"
+                                v-bind:panel-size="panelSize"
+                                v-bind:config="config"
+                                v-bind:api="api"
+                                v-bind:validation-results="validationResults"
+                                v-on:validation-results="(tag, e) => this.$set(this.validationResults, tag, e)"
+                                v-on:error="showError"
+                                v-show="previewing !== null"/>
             <div class="panel-placeholder" v-if="previewing === null">
               No file selected.
             </div>

--- a/modules/admin/app/assets/js/datamanager/components/_manager-upload.vue
+++ b/modules/admin/app/assets/js/datamanager/components/_manager-upload.vue
@@ -67,7 +67,7 @@ export default {
   components: {FilterControl, FilesTable, PanelLogWindow, DragHandle, ModalInfo, PanelFilePreview, ButtonValidate, ButtonDelete, UploadProgress},
   mixins: [MixinStage, MixinTwoPanel, MixinPreview, MixinValidator, MixinError, MixinUtil],
   props: {
-    datasetId: String,
+    datasetContentType: String,
     fileStage: String,
     config: Object,
     api: DatasetManagerApi,
@@ -282,15 +282,16 @@ export default {
         <div class="status-panels">
           <div class="status-panel" v-show="tab === 'preview'">
             <panel-file-preview v-bind:dataset-id="datasetId"
-                     v-bind:file-stage="fileStage"
-                     v-bind:previewing="previewing"
-                     v-bind:panel-size="panelSize"
-                     v-bind:config="config"
-                     v-bind:api="api"
-                     v-bind:validation-results="validationResults"
-                     v-on:validation-results="(tag, e) => this.$set(this.validationResults, tag, e)"
-                     v-on:error="showError"
-                     v-show="previewing !== null" />
+                                v-bind:content-type="datasetContentType"
+                                v-bind:file-stage="fileStage"
+                                v-bind:previewing="previewing"
+                                v-bind:panel-size="panelSize"
+                                v-bind:config="config"
+                                v-bind:api="api"
+                                v-bind:validation-results="validationResults"
+                                v-on:validation-results="(tag, e) => this.$set(this.validationResults, tag, e)"
+                                v-on:error="showError"
+                                v-show="previewing !== null" />
             <div class="panel-placeholder" v-if="previewing === null">
               No file selected.
             </div>

--- a/modules/admin/app/assets/js/datamanager/components/_mixin-preview-panel.vue
+++ b/modules/admin/app/assets/js/datamanager/components/_mixin-preview-panel.vue
@@ -20,6 +20,10 @@ export default {
   props: {
     api: DatasetManagerApi,
     datasetId: String,
+    contentType: {
+      type: String,
+      default: null,
+    },
     fileStage: String,
     panelSize: Number,
     previewing: Object,
@@ -160,6 +164,7 @@ export default {
           .then(data => this.worker.postMessage({
             type: 'preview',
             url: data[this.previewing.key],
+            contentType: this.contentType,
             max: this.config.maxPreviewSize,
           }))
           .catch(error => this.showError('Unable to load preview URL', error))

--- a/modules/admin/app/assets/js/datamanager/components/_modal-dataset-config.vue
+++ b/modules/admin/app/assets/js/datamanager/components/_modal-dataset-config.vue
@@ -19,6 +19,7 @@ export default {
       src: this.info ? this.info.src : null,
       fonds: this.info ? this.info.fonds : null,
       sync: this.info ? this.info.sync : false,
+      contentType: this.info ? this.info.contentType : null,
       notes: this.info ? this.info.notes : null,
       error: null,
       saving: false,
@@ -37,6 +38,7 @@ export default {
         src: this.src,
         fonds: this.fonds,
         sync: this.sync,
+        contentType: this.contentType,
         notes: this.notes,
       };
 
@@ -95,6 +97,7 @@ export default {
           || this.info.src !== this.src
           || this.info.notes !== this.notes
           || this.info.fonds !== this.fonds
+          || this.info.contentType !== this.contentType
           || Boolean(this.info.sync) !== Boolean(this.sync));
     }
   },
@@ -174,6 +177,12 @@ export default {
         <label class="form-check-label" for="opt-sync">
           Synchronise fonds with dataset
         </label>
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="dataset-content-type">
+          Content-Type Override
+        </label>
+        <input type="text" v-model="contentType" id="dataset-content-type" class="form-control" placeholder="text/xml; charset=utf-8"/>
       </div>
       <div class="form-group">
         <label class="form-label" for="dataset-notes">Notes</label>

--- a/modules/admin/app/assets/js/datamanager/types.ts
+++ b/modules/admin/app/assets/js/datamanager/types.ts
@@ -77,6 +77,7 @@ export interface ImportDatasetInfo {
   src: ImportDatasetSrc,
   fonds?: string,
   sync: boolean,
+  contentType?: string,
   notes?: string,
 }
 

--- a/modules/admin/app/assets/js/datamanager/worker.js
+++ b/modules/admin/app/assets/js/datamanager/worker.js
@@ -3,7 +3,7 @@ addEventListener('message', ({data}) => {
   let abortController = new AbortController();
 
   function getDecoder(r) {
-    let contentType = r.headers.get("Content-Type");
+    let contentType = data.contentType || r.headers.get("Content-Type");
     let re = /charset=([^()<>@,;:"/[\]?.=\s]*)/i;
     let charset = re.test(contentType) ? re.exec(contentType)[1] : 'utf8';
     console.debug("Reading file with charset", charset);

--- a/modules/admin/app/controllers/datasets/ImportConfigs.scala
+++ b/modules/admin/app/controllers/datasets/ImportConfigs.scala
@@ -91,7 +91,6 @@ case class ImportConfigs @Inject()(
       // Don't allow sync on the repository scope, because it is too dangerous.
       val idt = if (dataset.sync && request.body.files.isEmpty && dataset.fonds.isDefined)
         IngestDataType.EadSync else IngestDataType.Ead
-      println(s"Type: $idt: ${dataset.sync}, ${request.body.files.isEmpty}, ${dataset.fonds}")
 
       val ingestTask = IngestData(task, idt, contentType, implicitly[ApiUser], instance)
       val job = IngestJob(jobId, ingestTask)

--- a/modules/admin/app/models/ImportDataset.scala
+++ b/modules/admin/app/models/ImportDataset.scala
@@ -12,6 +12,7 @@ case class ImportDataset(
   id: String,
   name: String,
   src: ImportDataset.Src.Value,
+  contentType: Option[String] = None,
   created: Instant,
   fonds: Option[String] = None,
   sync: Boolean = false,
@@ -35,9 +36,10 @@ case class ImportDatasetInfo(
   id: String,
   name: String,
   src: ImportDataset.Src.Value,
+  contentType: Option[String] = None,
   fonds: Option[String] = None,
   sync: Boolean = false,
-  notes: Option[String] = None
+  notes: Option[String] = None,
 )
 
 object ImportDatasetInfo {

--- a/modules/admin/app/services/datasets/ImportDatasetService.scala
+++ b/modules/admin/app/services/datasets/ImportDatasetService.scala
@@ -24,6 +24,8 @@ trait ImportDatasetService {
 
   def listAll(): Future[Map[String, Seq[ImportDataset]]]
 
+  def find(repoId: String, datasetId: String): Future[Option[ImportDataset]]
+
   def get(repoId: String, datasetId: String): Future[ImportDataset]
 
   def list(repoId: String): Future[Seq[ImportDataset]]

--- a/modules/admin/app/services/transformation/WrappingXmlTransformer.scala
+++ b/modules/admin/app/services/transformation/WrappingXmlTransformer.scala
@@ -37,7 +37,7 @@ case class WrappingXmlTransformer @Inject()(
 
   private def transformXml(src: Source[ByteString, _], mappings: Seq[(DataTransformation.TransformationType.Value, String, JsObject)]): Source[ByteString, _] = {
     val dataF: Future[ByteString] = src
-      .runFold(ByteString(""))(_ ++ _)
+      .runFold(ByteString.empty)(_ ++ _)
       .map(_.utf8String)
       .map { data =>
         transformXml(data, mappings)

--- a/modules/admin/app/services/transformation/utils/package.scala
+++ b/modules/admin/app/services/transformation/utils/package.scala
@@ -1,8 +1,15 @@
 package services.transformation
 
-import play.api.libs.Codecs
+import akka.NotUsed
+import akka.http.scaladsl.model.ContentType
+import akka.stream.alpakka.text.scaladsl.TextFlow
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
 import models.DataTransformation
+import play.api.libs.Codecs
 import play.api.libs.json.{JsObject, Json}
+
+import java.nio.charset.StandardCharsets
 
 package object utils {
 
@@ -33,4 +40,26 @@ package object utils {
     */
   def digest(src: String, mappings: Seq[(DataTransformation.TransformationType.Value, String, JsObject)]): String =
     Codecs.md5(src + digest(mappings))
+
+  /**
+    * Given a file content type get a transcoder to convert it to UTF-8
+    * for further processing. This will only return a value of the content type
+    * has a charset argument and it's not already UTF-8.
+    *
+    * @param contentType an optional content type
+    * @return an optional transcoding flow
+    */
+  def getUtf8Transcoder(contentType: Option[String]): Option[Flow[ByteString, ByteString, NotUsed]] = {
+    // If the file has a charset and it's not UTF-8 we need to transcode it
+    // Otherwise we have to assume it's UTF-8 already, which should be the default.
+    contentType.flatMap { ct =>
+      ContentType.parse(ct) match {
+        case Left(_) => None
+        case Right(contentType) =>
+          contentType.charsetOption.map(_.nioCharset()).filter(_ != StandardCharsets.UTF_8).map { charset =>
+            TextFlow.transcoding(charset, StandardCharsets.UTF_8)
+          }
+      }
+    }
+  }
 }

--- a/modules/admin/conf/transform.xqy
+++ b/modules/admin/conf/transform.xqy
@@ -26,7 +26,7 @@ declare function local:make-children(
     for $child-source-node in local:evaluate-xquery($configuration-record/source-node/text(), $source-node, $libURI)
       let $child-value := local:evaluate-xquery($configuration-record/value/text(), $child-source-node, $libURI)
       let $child-name := $configuration-record/target-node/text()
-      (: let $f := fn:trace("Child name: "|| $child-name || ", Value: " || $child-value || ", Child source node: " || $child-source-node || ", Source node: " || $source-node) :)
+(:       let $f := fn:trace("Child name: "|| $child-name || ", Value: " || $child-value || ", Child source node: " || $child-source-node || ", Source node: " || $source-node):)
       return try {
 
         (: return an attribute :)
@@ -45,7 +45,7 @@ declare function local:make-children(
           let $child := element { $child-qname } { $child-children, $child-value }
           return if ($child-children or local:ebv($child-value)) then $child else ()
       } catch * {
-        fn:error(xs:QName("mapping-error"), "at " || $target-path || $child-name || ": " || $err:description)
+        fn:error(xs:QName("mapping-error"), $err:code || " at " || $target-path || $child-name || ": " || $err:description)
       }
 };
 

--- a/modules/admin/test/services/transformation/BaseXXQueryXmlTransformerSpec.scala
+++ b/modules/admin/test/services/transformation/BaseXXQueryXmlTransformerSpec.scala
@@ -42,7 +42,7 @@ class BaseXXQueryXmlTransformerSpec extends PlaySpecification with ResourceUtils
       val map = resourceAsString("simple-mapping.tsv") +
         "\n/ead/eadheader/\teadid\t/ead/eadheader/eadid\tinvalid-func()"
       transformer.transform(testPayload, map) must throwA[InvalidMappingError].like {
-        case e => e.getMessage must contain("at /ead: at /ead/eadheader: Unknown function: fn:invalid-func")
+        case e => e.getMessage must contain("mapping-error at /ead: err:XPST0017 at /ead/eadheader: Unknown function: fn:invalid-func")
       }
     }
   }

--- a/test/integration/admin/DataTransformationsSpec.scala
+++ b/test/integration/admin/DataTransformationsSpec.scala
@@ -99,7 +99,7 @@ class DataTransformationsSpec extends IntegrationTestRunner with ResourceUtils {
         .callWith(Json.toJson(ConvertSpec(Seq((TransformationType.XQuery, map, Json.obj())))))
 
       status(r) must_== BAD_REQUEST
-      contentAsJson(r) must_== Json.obj("error" -> "at /ead: at /ead/eadheader: Expecting valid step.")
+      contentAsJson(r) must_== Json.obj("error" -> "mapping-error at /ead: err:XPST0003 at /ead/eadheader: Expecting valid step.")
     }
   }
 }


### PR DESCRIPTION
 - Now transcode to UTF-8 when doing single-file previews
 - Add a content type field to the dataset model. This will override whatever the content type of the file is.
 - Use the dataset content type to figure out how to decode previewed
   files in the UI