### PR TITLE
Fix a misleading error if the backend does not have correct groups

### DIFF
--- a/modules/backend/src/main/scala/services/data/DataServiceError.scala
+++ b/modules/backend/src/main/scala/services/data/DataServiceError.scala
@@ -72,8 +72,6 @@ case class ItemNotFound(
   def this(id: String) = this(Some("id"), Some(id))
 }
 
-case class ServerError(error: String) extends RuntimeException(error) with DataServiceError
-
 case class CriticalError(error: String) extends RuntimeException(error) with DataServiceError
 
 case class BadJson(

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -434,7 +434,6 @@ error.globalErrors=There were problems with that form:
 error.date=Date is incorrect or badly formatted
 error.badUrl=URL is incorrect or badly formatted. Note: for web addresses, a valid URL must be prefixed \
   be the scheme, e.g. ''http://'' or ''https://''
-
 error.required=Required
 error.emailExists=Email is either invalid or is already registered
 error.unknownUser=Unknown user

--- a/test/integration/portal/SignupSpec.scala
+++ b/test/integration/portal/SignupSpec.scala
@@ -106,6 +106,13 @@ class SignupSpec extends IntegrationTestRunner {
       }
     }
 
+    "give a 500 error if defaultGroups not present in DB" in new ITestApp(
+      specificConfig = Map("ehri.portal.defaultUserGroups" -> Seq("BAD_GROUP"))) {
+      val signup = FakeRequest(accountRoutes.signupPost()).withCsrf.callWith(data)
+      status(signup) must equalTo(INTERNAL_SERVER_ERROR)
+    }
+
+
     "allow log in after sign up" in new ITestApp {
       val testEmail2 = "newuser@example.com"
       val data2 = data.updated(SignupData.EMAIL, Seq(testEmail2))


### PR DESCRIPTION
If the portal's default groups aren't present on the backend dev environment the current ItemNotFound error is very confusing. Log an error in this case to the console and return 500 instead of 404.

Fixes #1369