### PR TITLE
Workaround Firefox not supporting clipboard.readText

### DIFF
--- a/modules/admin/app/assets/css/datasets.scss
+++ b/modules/admin/app/assets/css/datasets.scss
@@ -572,6 +572,12 @@ $active-table-row: #e7f1ff;
   overflow-x: unset;
 }
 
+.textarea-paste-helper {
+  @extend %expanding-column;
+  @extend %overflow-contents;
+  border: 1px solid $ehri-border-gray;
+}
+
 .tabular-editor-toolbar {
   display: flex;
   justify-content: right;

--- a/modules/admin/app/assets/js/datasets/components/_editor-xslt.vue
+++ b/modules/admin/app/assets/js/datasets/components/_editor-xslt.vue
@@ -12,10 +12,15 @@ export default {
       // it does not reflect the actual value of the panel
       type: Number,
     },
+    timestamp: String,
   },
   watch: {
     resize: function() {
       this.editor.refresh();
+    },
+    timestamp: function() {
+      console.debug("XSLT editor value updated...")
+      this.editor.setValue(this.value);
     }
   },
   mounted: function () {


### PR DESCRIPTION
This also fixes an issue where the XSLT input wouldn't refresh after a paste import