### PR TITLE
Replace a custom exception with a standard one for compatibility

### DIFF
--- a/modules/admin/app/views/admin/Helpers.scala
+++ b/modules/admin/app/views/admin/Helpers.scala
@@ -8,8 +8,6 @@ import play.api.mvc.Call
  */
 object Helpers {
 
-  import scala.util.control.Exception.catching
-
   val mainMenu = Seq(
     ("contentTypes.Country",          controllers.countries.routes.Countries.search().url),
     ("contentTypes.Repository",       controllers.institutions.routes.Repositories.search().url),

--- a/modules/portal/app/controllers/base/ImageHelpers.scala
+++ b/modules/portal/app/controllers/base/ImageHelpers.scala
@@ -29,7 +29,7 @@ trait ImageHelpers {
     else if (pixels > config.get[Long]("ehri.portal.profile.maxImagePixels"))
       throw ResolutionTooHigh()
   } catch {
-    case _: ImageSniffer.UnsupportedImageTypeException => throw UnrecognizedType()
+    case _: UnsupportedOperationException => throw UnrecognizedType()
   }
 
   /**

--- a/modules/portal/app/utils/ImageSniffer.java
+++ b/modules/portal/app/utils/ImageSniffer.java
@@ -17,16 +17,28 @@ import java.util.Iterator;
  */
 public class ImageSniffer {
 
-    public static class UnsupportedImageTypeException extends Exception {
-        public UnsupportedImageTypeException(String msg) {
-            super(msg);
-        }
-    }
-
-    public static long getTotalPixels(File file) throws IOException, UnsupportedImageTypeException {
+    /**
+     * Get the total number of image pixels, e.g. the product of the width and height.
+     *
+     * @param file an image file object
+     * @return the pixel count
+     * @throws IOException if an error occurs reading the image
+     * @throws UnsupportedOperationException if a reader cannot be found for the image type
+     */
+    public static long getTotalPixels(File file) throws IOException {
         return getTotalPixels(file, file.getName());
     }
-    public static long getTotalPixels(File file, String name) throws IOException, UnsupportedImageTypeException {
+
+    /**
+     * Get the total number of image pixels, e.g. the product of the width and height.
+     *
+     * @param file an image file object
+     * @param name the image file name, for determining the file type
+     * @return the pixel count
+     * @throws IOException if an error occurs reading the image
+     * @throws UnsupportedOperationException if a reader cannot be found for the image type
+     */
+    public static long getTotalPixels(File file, String name) throws IOException {
         final String extension = FilenameUtils.getExtension(name);
         final Iterator<ImageReader> readers = ImageIO.getImageReadersBySuffix(extension);
         if (readers.hasNext()) {
@@ -40,7 +52,7 @@ public class ImageSniffer {
                 reader.dispose();
             }
         }
-        throw new UnsupportedImageTypeException(
+        throw new UnsupportedOperationException(
                 String.format("Unable to find a reader for image type: '%s'", extension));
     }
 }

--- a/modules/portal/test/utils/ImageSnifferSpec.scala
+++ b/modules/portal/test/utils/ImageSnifferSpec.scala
@@ -13,7 +13,7 @@ class ImageSnifferSpec extends PlaySpecification with ResourceUtils {
       jpgPixels must_== 26*23
     }
     "throw an error with a non-image type" in {
-      ImageSniffer.getTotalPixels(resourcePath("non-image.txt").toFile) must throwA[ImageSniffer.UnsupportedImageTypeException]
+      ImageSniffer.getTotalPixels(resourcePath("non-image.txt").toFile) must throwA[UnsupportedOperationException]
     }
   }
 }


### PR DESCRIPTION
For as-yet-to-be-determined reasons, building on JDK11 caused an error.