### PR TITLE
Export proxy URL configuration

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -281,6 +281,17 @@ ehri {
         }
     }
 
+    # Provide links to externalised URLs that are able to export items as specific formats
+    # Config consists of an Entity type name and a set of format keys, each of which contains
+    # a format name and the URL to the export proxy
+    # Within the URL the placeholder `ITEM_ID` should be substituted with the actual item ID.
+    exportProxies {
+        DocumentaryUnit = [
+            # Example for RiC Turtle RDF export (uncomment to test)
+            #{name = "RiC TTL", url = "/units/ITEM_ID/export-rdf?format=Turtle"},
+        ]
+    }
+
     api {
         v1 {
             status: "Example API status"

--- a/modules/core/src/main/scala/config/AppConfig.scala
+++ b/modules/core/src/main/scala/config/AppConfig.scala
@@ -1,8 +1,12 @@
 package config
 
+import models.EntityType
+import play.api.Configuration
+import play.api.http.HttpVerbs
+import play.api.mvc.{Call, RequestHeader}
+
 import java.io.File
 import javax.inject.{Inject, Singleton}
-import play.api.mvc.RequestHeader
 
 @Singleton
 case class AppConfig @Inject()(configuration: play.api.Configuration) {
@@ -26,10 +30,10 @@ case class AppConfig @Inject()(configuration: play.api.Configuration) {
     .getOrElse(6)
 
   /**
-   * Flag to indicate whether we're running a testing config or not.
-   * This is different from the usual dev/prod run configuration because
-   * we might be running experimental stuff on a real life server.
-   */
+    * Flag to indicate whether we're running a testing config or not.
+    * This is different from the usual dev/prod run configuration because
+    * we might be running experimental stuff on a real life server.
+    */
   def isTestMode: Boolean = configuration.getOptional[Boolean]("ehri.testing").getOrElse(true)
 
   def isStageMode: Boolean = configuration.getOptional[Boolean]("ehri.staging").getOrElse(false)
@@ -116,5 +120,14 @@ case class AppConfig @Inject()(configuration: play.api.Configuration) {
         else Some(ips)
       } else None
     }
+  }
+
+  def exportProxies(isA: EntityType.Value, id: String): Seq[(String, Call)] = {
+    for {
+      config <- configuration.getOptional[Seq[Configuration]](s"ehri.exportProxies.$isA").toSeq
+      proxy <- config
+      name <- proxy.getOptional[String]("name")
+      url <- proxy.getOptional[String]("url")
+    } yield (name, Call(HttpVerbs.GET, url.replace("ITEM_ID", id)))
   }
 }

--- a/modules/portal/app/views/authoritativeSet/itemDetails.scala.html
+++ b/modules/portal/app/views/authoritativeSet/itemDetails.scala.html
@@ -1,4 +1,4 @@
-@(item: AuthoritativeSet, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: SessionPrefs, conf: AppConfig, messages: Messages, md: MarkdownRenderer)
+@(item: AuthoritativeSet, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: cookies.SessionPrefs, conf: config.AppConfig, messages: Messages, md: MarkdownRenderer)
 
 @views.html.common.itemDetails {
     @views.html.common.rightSidebar {
@@ -7,8 +7,9 @@
             @Markdown(desc)
         }
     } {
-        @views.html.common.typeLabelWithWatchButton(item, watched.contains(item.id), introNotice())
+        @views.html.common.typeLabelWithWatchButton(item, watched.contains(item.id), views.html.country.introNotice())
         @views.html.common.childItemSidebar(item, EntityType.HistoricalAgent)
+        @views.html.common.exportItem(conf.exportProxies(item.isA, item.id))
         @views.html.common.latestAction(item, controllers.portal.routes.Portal.itemHistory(item.id, modal = true))
     }
 }

--- a/modules/portal/app/views/common/exportItem.scala.html
+++ b/modules/portal/app/views/common/exportItem.scala.html
@@ -1,4 +1,4 @@
-@(fmts: Map[String, Call])(implicit request: RequestHeader, messages: Messages)
+@(fmts: Seq[(String, Call)])(implicit request: RequestHeader, messages: Messages)
 
 @if(fmts.nonEmpty) {
     @views.html.common.sidebarSection(Messages("export.metadata"), cls = "export") {
@@ -7,7 +7,9 @@
             <li class="export-format-item">
                 <a rel="nofollow" href="@url">
                     <i class="fa fa-download" aria-hidden="true"></i>
-                    @Messages(s"export.format.$fmt")
+                    @defining(s"export.format.$fmt") { key =>
+                        @(if(Messages(key) == key) fmt else Messages(key))
+                    }
                 </a>
             </li>
         }

--- a/modules/portal/app/views/concept/itemDetails.scala.html
+++ b/modules/portal/app/views/concept/itemDetails.scala.html
@@ -1,4 +1,4 @@
-@(item: Concept, annotations: Seq[Annotation], result: services.search.SearchResult[(Model, services.search.SearchHit)], action: Call, watched: Seq[String], dlid: Option[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: SessionPrefs, conf: AppConfig, messages: Messages, md: MarkdownRenderer)
+@(item: Concept, annotations: Seq[Annotation], result: services.search.SearchResult[(Model, services.search.SearchHit)], action: Call, watched: Seq[String], dlid: Option[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: cookies.SessionPrefs, conf: config.AppConfig, messages: Messages, md: MarkdownRenderer)
 
 @views.html.common.itemDetails {
     @defining("cvocConcept") { implicit fieldPrefix =>
@@ -21,6 +21,7 @@
             } {
                 @views.html.common.typeLabelWithWatchButton(item, watched.contains(item.id))
             } {
+                @views.html.common.exportItem(conf.exportProxies(item.isA, item.id))
                 @views.html.common.latestAction(item, controllers.portal.routes.Portal.itemHistory(item.id, modal = true))
             }
         }

--- a/modules/portal/app/views/country/itemDetails.scala.html
+++ b/modules/portal/app/views/country/itemDetails.scala.html
@@ -1,4 +1,4 @@
-@(item: Country, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: SessionPrefs, conf: AppConfig, messages: Messages, md: MarkdownRenderer)
+@(item: Country, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: cookies.SessionPrefs, conf: config.AppConfig, messages: Messages, md: MarkdownRenderer)
 
 @import CountryF._
 @import views.html.common.textField
@@ -54,6 +54,7 @@
                     }
                 </ul>
             }
+            @views.html.common.exportItem(conf.exportProxies(item.isA, item.id))
             @views.html.common.latestAction(item, controllers.portal.routes.Portal.itemHistory(item.id, modal = true))
         }
     }

--- a/modules/portal/app/views/documentaryUnit/itemDetails.scala.html
+++ b/modules/portal/app/views/documentaryUnit/itemDetails.scala.html
@@ -1,4 +1,4 @@
-@(item: DocumentaryUnit, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String], dlid: Option[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: SessionPrefs, conf: AppConfig, messages: Messages, md: MarkdownRenderer)
+@(item: DocumentaryUnit, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String], dlid: Option[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: cookies.SessionPrefs, conf: config.AppConfig, messages: Messages, md: MarkdownRenderer)
 
 @views.html.common.itemDetails {
     @defining("documentaryUnit") { implicit fieldPrefix =>
@@ -17,7 +17,10 @@
                     @views.html.documentaryUnit.archivalContext(item)
                     @views.html.common.childItemSidebar(item, EntityType.DocumentaryUnit)
                     @views.html.common.exportItem(
-                        Map("ead" -> controllers.portal.routes.DocumentaryUnits.export(item.topLevel.id, asFile = true)))
+                        Seq(
+                            "ead" -> controllers.portal.routes.DocumentaryUnits.export(item.topLevel.id, asFile = true)
+                        ) ++ conf.exportProxies(item.isA, item.id)
+                    )
                     @views.html.common.latestAction(item, controllers.portal.routes.Portal.itemHistory(item.id, modal = true))
                 }
             }

--- a/modules/portal/app/views/historicalAgent/itemDetails.scala.html
+++ b/modules/portal/app/views/historicalAgent/itemDetails.scala.html
@@ -1,4 +1,4 @@
-@(item: HistoricalAgent, annotations: Seq[Annotation], result: services.search.SearchResult[(Model, services.search.SearchHit)], action: Call, watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: SessionPrefs, conf: AppConfig, messages: Messages, md: MarkdownRenderer)
+@(item: HistoricalAgent, annotations: Seq[Annotation], result: services.search.SearchResult[(Model, services.search.SearchHit)], action: Call, watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: cookies.SessionPrefs, conf: config.AppConfig, messages: Messages, md: MarkdownRenderer)
 
 @views.html.common.itemDetails {
     @defining("historicalAgent") { implicit fieldPrefix =>
@@ -10,7 +10,11 @@
             } {
                 @views.html.common.typeLabelWithWatchButton(item, watched.contains(item.id))
             } {
-                @views.html.common.exportItem(Map("eac" -> controllers.portal.routes.HistoricalAgents.export(item.id, asFile = true)))
+                @views.html.common.exportItem(
+                    Seq(
+                        "eac" -> controllers.portal.routes.HistoricalAgents.export(item.id, asFile = true)
+                    ) ++ conf.exportProxies(item.isA, item.id)
+                )
                 @views.html.common.latestAction(item, controllers.portal.routes.Portal.itemHistory(item.id, modal = true))
             }
         }

--- a/modules/portal/app/views/repository/itemDetails.scala.html
+++ b/modules/portal/app/views/repository/itemDetails.scala.html
@@ -1,4 +1,4 @@
-@(item: Repository, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String])(implicit userOpt: Option[UserProfile], req: RequestHeader, prefs: SessionPrefs, conf: AppConfig, messages: Messages, md: MarkdownRenderer)
+@(item: Repository, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String])(implicit userOpt: Option[UserProfile], req: RequestHeader, prefs: cookies.SessionPrefs, conf: config.AppConfig, messages: Messages, md: MarkdownRenderer)
 
 @views.html.common.itemDetails {
     @defining("repository") { implicit fieldPrefix =>
@@ -16,7 +16,10 @@
                 @views.html.common.sidepanelToc {
                     @views.html.common.childItemSidebar(item, EntityType.DocumentaryUnit)
                     @views.html.common.exportItem(
-                        Map("eag" -> controllers.portal.routes.Repositories.export(item.id, asFile = true)))
+                        Seq(
+                            "eag" -> controllers.portal.routes.Repositories.export(item.id, asFile = true)
+                        ) ++ conf.exportProxies(item.isA, item.id)
+                    )
                     @views.html.common.latestAction(item, controllers.portal.routes.Portal.itemHistory(item.id, modal = true))
                 }
             }

--- a/modules/portal/app/views/vocabulary/itemDetails.scala.html
+++ b/modules/portal/app/views/vocabulary/itemDetails.scala.html
@@ -1,4 +1,4 @@
-@(item: Vocabulary, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: SessionPrefs, conf: AppConfig, messages: Messages, md: MarkdownRenderer)
+@(item: Vocabulary, annotations: Seq[Annotation], links: Seq[Link], watched: Seq[String])(implicit userOpt: Option[UserProfile], request: RequestHeader, prefs: cookies.SessionPrefs, conf: config.AppConfig, messages: Messages, md: MarkdownRenderer)
 
 @views.html.common.itemDetails {
     @views.html.common.rightSidebar {
@@ -10,10 +10,10 @@
         @views.html.common.typeLabelWithWatchButton(item, watched.contains(item.id), views.html.vocabulary.introNotice())
         @views.html.common.childItemSidebar(item, EntityType.Concept)
         @views.html.common.exportItem(
-            Map(
+            Seq(
                 "ttl" -> controllers.portal.routes.Vocabularies.exportSkos(item.id, format = Some("TTL")),
                 "rdf_xml" -> controllers.portal.routes.Vocabularies.exportSkos(item.id, format = Some("RDF/XML")),
-            )
+            ) ++ conf.exportProxies(item.isA, item.id)
         )
         @views.html.common.latestAction(item, controllers.portal.routes.Portal.itemHistory(item.id, modal = true))
     }

--- a/test/integration/portal/PortalSpec.scala
+++ b/test/integration/portal/PortalSpec.scala
@@ -153,6 +153,16 @@ class PortalSpec extends IntegrationTestRunner {
       contentAsString(skos) must contain("<http://data.ehri-project.eu/vocabularies/cvoc1>")
     }
 
+    "show export proxy URLs when configured" in new ITestApp(
+      Map("ehri.exportProxies.Repository" -> Seq(Map("name" -> "BLAH TTL", "url" -> "http://blah.example.com/r1/export-foo")))
+    ) {
+      val show = FakeRequest(controllers.portal.routes.Repositories.browse("r1"))
+        .withUser(privilegedUser).call()
+      status(show) must equalTo(OK)
+      contentAsString(show) must contain("BLAH TTL")
+      contentAsString(show) must contain("http://blah.example.com/r1/export-foo")
+    }
+
     "view item history" in new ITestApp {
       val history = FakeRequest(portalRoutes.itemHistory("c4")).call()
       status(history) must equalTo(OK)


### PR DESCRIPTION
Add configuration that enables adding export proxy URLs down the sidebar on portal items. These are just a label and an URL for which the corresponding URL has been set up to export an item via an external service, e.g. via a proxy server.