### PR TITLE
Add a samesite attribute to the auth cookie.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -174,8 +174,14 @@ recaptcha.key.private = 6LcEhOcSAAAAAOTZqZYDeLdXv0911i-yUuMKEPrr
 # Don't show recaptcha
 recaptcha.skip = true
 
+# Auth session cookie name (legacy)
+auth.session.cookieName = "PLAY2AUTH_SESS_ID"
 # How long the session takes to timeout
 auth.session.timeout = 7 days
+# Samesite attribute on the auth cookie. This has to be 'lax' otherwise
+# OAuth2 redirect sign-ins will not work.
+auth.session.cookieSameSite = "lax"
+
 
 # Storage configuration
 storage {

--- a/test/integration/portal/PortalSpec.scala
+++ b/test/integration/portal/PortalSpec.scala
@@ -27,7 +27,7 @@ class PortalSpec extends IntegrationTestRunner {
 
     "show index page in other languages" in new ITestApp {
       val doc = FakeRequest(portalRoutes.index())
-        .withCookies(Cookie("PLAY_LANG", "fr", sameSite = Some(Cookie.SameSite.Lax)))
+        .withCookies(Cookie("PLAY_LANG", "fr"))
         .call()
       contentAsString(doc) must contain("Bienvenue sur")
     }


### PR DESCRIPTION
This needs to be lax for the time being, since cross-domain cookies are needed for functional OAuth2 logins.