### PR TITLE
Added the possibility to add custom headers to the URLSet harvester

### DIFF
--- a/modules/admin/app/actors/harvesting/UrlSetHarvester.scala
+++ b/modules/admin/app/actors/harvesting/UrlSetHarvester.scala
@@ -91,8 +91,12 @@ case class UrlSetHarvester (client: WSClient, storage: FileStorage)(
     val name = item.name
     val path = job.data.prefix + name
 
-    val req = job.data.config.auth.fold(client.url(item.url)) { case BasicAuthConfig(username, password) =>
-      client.url(item.url).withAuth(username, password, WSAuthScheme.BASIC)
+    val withHeader = job.data.config.headerOpt.fold(client.url(item.url)) {
+      case headerValue: List[Tuple2[String, String]] => 
+        client.url(item.url).withHttpHeaders(headerValue:_*)
+    }
+    val req = job.data.config.auth.fold(withHeader) { case BasicAuthConfig(username, password) =>
+      withHeader.withAuth(username, password, WSAuthScheme.BASIC)
     }
 
     req.head().flatMap { headReq =>

--- a/modules/admin/app/assets/js/datasets/components/_form-http-header.vue
+++ b/modules/admin/app/assets/js/datasets/components/_form-http-header.vue
@@ -1,0 +1,54 @@
+<script>
+
+import _isObject from 'lodash/isObject';
+
+export default {
+  props: {
+    modelValue: Object,
+  },
+  data: function() {
+    return {
+      show: _isObject(this.modelValue),
+      header: this.modelValue ? this.modelValue.header : "",
+    }
+  },
+  methods: {
+    update: function() {
+      this.$emit("update:modelValue", this.headerOpt)
+    }
+  },
+  computed: {
+    headerOpt: function() {
+      return this.show ? {
+        header: this.header
+      } : null;
+    },
+  },
+  watch: {
+    show: function() {
+      this.update();
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="http-header-params">
+    <div class="form-group">
+      <div class="form-check">
+        <input type="checkbox" class="form-check-input" id="opt-header" v-model="show"/>
+        <label class="form-check-label" for="opt-header">
+          HTTP Header
+        </label>
+      </div>
+    </div>
+    <fieldset v-if="show">
+      <div class="form-group">
+        <label class="form-label" for="header-value">
+          Header
+        </label>
+        <input v-model="header" v-on:change="update" class="form-control" id="header-value" type="text" autocomplete="off"/>
+      </div>
+    </fieldset>
+  </div>
+</template>

--- a/modules/admin/app/assets/js/datasets/components/_modal-urlset-config.vue
+++ b/modules/admin/app/assets/js/datasets/components/_modal-urlset-config.vue
@@ -5,10 +5,11 @@ import ModalAlert from './_modal-alert';
 import {DatasetManagerApi} from '../api';
 import EditorUrlset from "./_editor-urlset.vue";
 import FormHttpBasicAuth from "./_form-http-basic-auth";
+import FormHttpHeader from "./_form-http-header";
 import {decodeTsv, encodeTsv} from "../common";
 
 export default {
-  components: {EditorUrlset, ModalAlert, ModalWindow, FormHttpBasicAuth},
+  components: {EditorUrlset, ModalAlert, ModalWindow, FormHttpBasicAuth, FormHttpHeader},
   props: {
     waiting: Boolean,
     datasetId: String,
@@ -21,6 +22,7 @@ export default {
       urlMap: this.opts ? this.opts.urlMap : null,
       filter: this.opts ? this.opts.filter : null,
       auth: this.opts ? this.opts.auth : null,
+      headerOpt: this.opts ? this.opts.headerOpt : null,
       tested: null,
       testing: false,
       cleaning: false,
@@ -35,7 +37,8 @@ export default {
     isValidConfig: function() {
       return this.urlMap !== null
           && this.urlMap.length > 0
-          && (!this.auth || (this.auth.username !== "" && this.auth.password !== ""));
+          && (!this.auth || (this.auth.username !== "" && this.auth.password !== ""))
+          && (!this.headerOpt || this.headerOpt.header.indexOf(":") > 0);
     },
     urlMapText: {
       get: function(): string {
@@ -54,8 +57,8 @@ export default {
       }
       this.$emit("saving");
       try {
-        let data = await this.api.saveHarvestConfig(this.datasetId, {urlMap: this.urlMap, auth: null});
-        this.$emit("saved-config", {...data, auth: this.auth});
+        let data = await this.api.saveHarvestConfig(this.datasetId, {urlMap: this.urlMap, auth: null, headerOpt: null});
+        this.$emit("saved-config", {...data, auth: this.auth, headerOpt: this.headerOpt});
       } catch (e) {
         this.$emit("error", "Error saving URL set config", e?.response?.data?.error);
       }
@@ -68,7 +71,7 @@ export default {
       this.testing = true;
       this.error = null;
       try {
-        await this.api.testHarvestConfig(this.datasetId, {urlMap: this.urlMap, auth: this.auth});
+        await this.api.testHarvestConfig(this.datasetId, {urlMap: this.urlMap, auth: this.auth, headerOpt: this.headerOpt});
         this.tested = true;
       } catch (e) {
         this.tested = false;
@@ -176,6 +179,7 @@ export default {
     </div>
     <div v-else class="options-form">
       <form-http-basic-auth v-model="auth"/>
+      <form-http-header v-model="headerOpt"/>
     </div>
     
     <div id="endpoint-errors">

--- a/modules/admin/app/models/UrlSetConfig.scala
+++ b/modules/admin/app/models/UrlSetConfig.scala
@@ -7,6 +7,7 @@ case class UrlNameMap(url: String, name: String)
 case class UrlSetConfig(
   urlMap: Seq[(String, String)],
   auth: Option[BasicAuthConfig] = None,
+  headerOpt: Option[List[Tuple2[String, String]]] = None,
 ) extends HarvestConfig {
   override def src: ImportDataset.Src.Value = ImportDataset.Src.UrlSet
 
@@ -24,6 +25,7 @@ case class UrlSetConfig(
 object UrlSetConfig {
   val URLS = "urlMap"
   val AUTH = "auth"
+  val HEADEROPT = "headerOpt"
 
   import play.api.libs.functional.syntax._
   import play.api.libs.json._
@@ -32,7 +34,8 @@ object UrlSetConfig {
     (__ \ URLS).read[Seq[(String, String)]](Reads.seq(Reads.Tuple2R[String, String](
       Reads.filter(JsonValidationError("errors.invalidUrl"))(forms.isValidUrl),
       Reads.pattern("^[\\w.-_]+$".r, "harvesting.error.invalidFileName")))) and
-    (__ \ AUTH).readNullable[BasicAuthConfig]
+    (__ \ AUTH).readNullable[BasicAuthConfig] and
+    (__ \ HEADEROPT \ "header").readNullable[String].map(_.map(_.split("(: ?)| ").grouped(2).map { case Array(k, v) => k -> v }.toList))
   ) (UrlSetConfig.apply _)
 
   implicit val _writes: Writes[UrlSetConfig] = Json.writes[UrlSetConfig]


### PR DESCRIPTION
Hello,

I have added this option to the URLSet harvester in order to be able to expand the existing functionality to other uses, mainly downloading files from an API that requires an API token (like the Wiener Library). However, it could also be used for content negotiation if necessary. I have tested it downloading the files from the Wiener Library API that will be integrated in production in the following days.

Best,
Herminio