### PR TITLE
Disable quoting on TSV parsing, to avoid mangling Excel format files

### DIFF
--- a/modules/admin/app/assets/js/datasets/common.spec.ts
+++ b/modules/admin/app/assets/js/datasets/common.spec.ts
@@ -10,8 +10,26 @@ test("encodeTsv", () => {
   expect(tsv).toBe("header1\theader2\na\tb\nc\td");
 });
 
+test("encodeTsv with quotes", () => {
+  let data = [["header1", "header2"], ["a", "\"b\""], ["c", "d with \"quotes\""]];
+  let tsv = encodeTsv(data, 2);
+  expect(tsv).toBe("header1\theader2\na\t\"b\"\nc\td with \"quotes\"");
+});
+
+test("encodeTsv with tabs", () => {
+  let data = [["header1", "header2"], ["a", "b"], ["c", "d\te"]];
+  let tsv = encodeTsv(data, 2);
+  expect(tsv).toBe("header1\theader2\na\tb\nc\td\te");
+});
+
 test("decodeTsv", () => {
   let tsv = "header1\theader2\na\tb\nc\td\n";
   let data = decodeTsv(tsv, 2);
   expect(data).toStrictEqual([["header1", "header2"], ["a", "b"], ["c", "d"]])
+});
+
+test("decodeTsv with quotes", () => {
+  let tsv = "header1\theader2\na\t\"b\"\nc\td with \"quotes\"\n";
+  let data = decodeTsv(tsv, 2);
+  expect(data).toStrictEqual([["header1", "header2"], ["a", "\"b\""], ["c", "d with \"quotes\""]]);
 });

--- a/modules/admin/app/assets/js/datasets/common.ts
+++ b/modules/admin/app/assets/js/datasets/common.ts
@@ -50,6 +50,8 @@ function apiCall<T>(endpoint: {url: string, method: any}, data?: object): Promis
 
 let tsvOpts = {
   delimiter: "\t",
+  quoteChar: '',
+  escapeChar: '',
   header: false,
   skipEmptyLines: true
 };


### PR DESCRIPTION
This is a bit dangerous for encoding, since values cannot contain tabs (FIXME) but previously it would completely break mapping conversions.

Ultimately we should use a safer format (like JSON) with fewer ambiguities, but until then use Excel-style nothing-is-quoted style.