### PR TITLE
Don't disable the batch process button when there's only 1 dataset

### DIFF
--- a/modules/admin/app/assets/js/datasets/components/_manager-dataset-list.vue
+++ b/modules/admin/app/assets/js/datasets/components/_manager-dataset-list.vue
@@ -220,7 +220,7 @@ export default {
                   <i class="fa fa-file-code-o"></i>
                   Import/export Datasets
                 </button>
-                <button v-on:click.prevent="showOptions = false; showBatchForm = true" class="dropdown-item" v-bind:disabled="datasets.length <= 1">
+                <button v-on:click.prevent="showOptions = false; showBatchForm = true" class="dropdown-item">
                   <i class="fa fa-warning"></i>
                   Batch Operations
                 </button>


### PR DESCRIPTION
It's still useful to be able to batch a single dataset, because you can combine harvesting, conversion and import in one click.