### PR TITLE
Set an extended timeout to endpoints that might stream a lot of data

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -215,6 +215,9 @@ ehri {
 
         # How long to cache backend data for...
         cacheExpiration = 5 minutes
+
+        # Extended timeout for streaming data from the backend...
+        streamingTimeout = 10 minutes
     }
 
     # THIS ENSURES SECURED ROUTES ARE SECURED. MAKE SURE IT'S EITHER

--- a/modules/api/app/controllers/api/graphql/GraphQL.scala
+++ b/modules/api/app/controllers/api/graphql/GraphQL.scala
@@ -10,6 +10,7 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents, RawBuffer}
 import services.data.Constants
 
 import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.Duration
 
 
 @Singleton
@@ -45,6 +46,7 @@ case class GraphQL @Inject()(
     val serviceConfig = ServiceConfig("ehridata", config)
     ws.url(s"${serviceConfig.baseUrl}/graphql")
       .withMethod(HttpVerbs.POST)
+      .withRequestTimeout(config.get[Duration]("ehri.backend.streamingTimeout"))
       .addHttpHeaders(serviceConfig.authHeaders: _*)
       .addHttpHeaders(streamHeader.map(Constants.STREAM_HEADER_NAME -> _).toSeq: _*)
       .addHttpHeaders(request.userOpt.map(u => Constants.AUTH_HEADER_NAME -> u.id).toSeq: _*)

--- a/modules/backend/src/main/scala/services/data/DataServiceBuilder.scala
+++ b/modules/backend/src/main/scala/services/data/DataServiceBuilder.scala
@@ -7,6 +7,7 @@ import play.api.libs.ws.WSResponse
 import play.api.mvc.Headers
 import utils._
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -66,9 +67,10 @@ trait DataService {
     * @param urlPart the URL backend path
     * @param headers the required headers
     * @param params  additional parameters
+    * @param timeout an optional timeout for the request
     * @return a web response
     */
-  def stream(urlPart: String, headers: Headers = Headers(), params: Map[String, Seq[String]] = Map.empty): Future[WSResponse]
+  def stream(urlPart: String, headers: Headers = Headers(), params: Map[String, Seq[String]] = Map.empty, timeout: Option[Duration] = None): Future[WSResponse]
 
   /**
     * Create a new user profile.

--- a/modules/backend/src/main/scala/services/data/WsDataService.scala
+++ b/modules/backend/src/main/scala/services/data/WsDataService.scala
@@ -48,9 +48,11 @@ case class WsDataService(eventHandler: EventHandler, config: Configuration, cach
     userCall(enc(baseUrl, urlPart) + (if (params.nonEmpty) "?" + utils.http.joinQueryString(params) else ""))
       .withHeaders(headers.headers: _*).get()
 
-  override def stream(urlPart: String, headers: Headers = Headers(), params: Map[String,Seq[String]] = Map.empty): Future[WSResponse] =
-    userCall(enc(baseUrl, urlPart) + (if(params.nonEmpty) "?" + utils.http.joinQueryString(params) else ""))
-      .withHeaders(headers.headers: _*).withMethod(HttpVerbs.GET).stream()
+  override def stream(urlPart: String, headers: Headers = Headers(), params: Map[String,Seq[String]] = Map.empty, timeout: Option[Duration] = None): Future[WSResponse] = {
+    val request = userCall(enc(baseUrl, urlPart) + (if (params.nonEmpty) "?" + utils.http.joinQueryString(params) else ""))
+    val timeoutRequest = timeout.fold(request)(t => request.withTimeout(t))
+    timeoutRequest.withHeaders(headers.headers: _*).withMethod(HttpVerbs.GET).stream()
+  }
 
   override def createNewUserProfile[T <: WithId : Readable](data: Map[String, String] = Map.empty, groups: Seq[String] = Seq.empty): Future[T] = {
     userCall(enc(baseUrl, "admin", "create-default-user-profile"))


### PR DESCRIPTION
e.g. GraphQL and EAD endpoints