### PR TITLE
Make it possible to import large datasets in batches

### DIFF
--- a/conf/evolutions/default/1.sql
+++ b/conf/evolutions/default/1.sql
@@ -237,6 +237,7 @@ CREATE TABLE import_config (
     properties_file   VARCHAR(1024) NULL,
     default_lang      CHAR(3) NULL,
     log_message       TEXT,
+    batch_size        INTEGER NULL,
     created           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     comments          TEXT NULL,
     PRIMARY KEY (repo_id, import_dataset_id),

--- a/etc/db_migrations/20230914_add_import_config_batch_size_column.sql
+++ b/etc/db_migrations/20230914_add_import_config_batch_size_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE import_config ADD COLUMN batch_size INTEGER NULL;

--- a/modules/admin/app/actors/cleanup/CleanupRunner.scala
+++ b/modules/admin/app/actors/cleanup/CleanupRunner.scala
@@ -1,7 +1,6 @@
 package actors.cleanup
 
 import actors.Ticker
-import actors.Ticker.Tick
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import play.api.Configuration
 import services.data.{DataService, EventForwarder}
@@ -10,16 +9,20 @@ import services.ingest.{Cleanup, ImportLogService, IngestService}
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 
 object CleanupRunner {
   case class Status(relinkCount: Int = 0, redirectCount: Int = 0, deleteCount: Int = 0)
 
   sealed trait CleanupState
+
   case class Relinked(cleanup: Cleanup, status: Status) extends CleanupState
+
   case class Redirected(cleanup: Cleanup, status: Status) extends CleanupState
+
   case class DeleteBatch(cleanup: Cleanup, todo: Seq[String], status: Status) extends CleanupState
+
   case class Done(secs: Duration) extends CleanupState
 
 

--- a/modules/admin/app/assets/js/datasets/components/_manager-dataset.vue
+++ b/modules/admin/app/assets/js/datasets/components/_manager-dataset.vue
@@ -77,6 +77,12 @@ export default {
   <div id="dataset-manager-container">
     <ul id="stage-tabs" class="nav nav-tabs">
       <li class="nav-item">
+          <a v-on:click.prevent="$emit('close-dataset')" href="#" class="nav-link" title="Close Dataset">
+              <i class="fa fa-chevron-left"></i>
+              <div class="sr-only">Close Dataset</div>
+          </a>
+      </li>
+      <li class="nav-item">
         <a v-if="dataset.src === 'oaipmh'" href="#tab-input" class="nav-link" v-bind:class="{active: tab === 'input'}"
            v-on:click.prevent="switchTab('input')">
           <i class="fa fw-fw fa-cloud-download"></i>

--- a/modules/admin/app/assets/js/datasets/components/_manager-snapshots.vue
+++ b/modules/admin/app/assets/js/datasets/components/_manager-snapshots.vue
@@ -82,10 +82,6 @@ export default {
 </script>
 <template>
   <div id="snapshot-manager">
-    <modal-snapshot-config v-if="showCreateDialog"
-                           v-on:create="takeSnapshot"
-                           v-on:close="showCreateDialog = false"/>
-
     <div class="actions-bar">
       <div class="filter-control">
         <label class="sr-only">Filter Snapshots</label>
@@ -106,6 +102,10 @@ export default {
         <i v-else class="fa fa-fw fa-circle-o-notch fa-spin"></i>
         Create Snapshot
       </button>
+
+      <modal-snapshot-config v-if="showCreateDialog"
+                             v-on:create="takeSnapshot"
+                             v-on:close="showCreateDialog = false"/>
     </div>
     <p class="admin-help-notice">
       Snapshots record the global and local item identifiers

--- a/modules/admin/app/assets/js/datasets/components/_modal-batch-ops.vue
+++ b/modules/admin/app/assets/js/datasets/components/_modal-batch-ops.vue
@@ -258,7 +258,9 @@ export default {
         let others: ImportDataset[] = this.datasets.filter(s => s.id !== this.copyFrom);
         this.inProgress = true;
         for (let set of others) {
-          await this.api.saveImportConfig(set.id, config)
+          let existing = await this.api.getImportConfig(set.id);
+          let newConfig = {...config, batchSize: existing?.batchSize} as ImportConfig;
+          await this.api.saveImportConfig(set.id, newConfig);
           this.println("Copied", set.name);
         }
         this.cleanup();
@@ -314,7 +316,7 @@ export default {
     <fieldset v-bind:disabled="inProgress" class="options-form">
       <div v-if="tab === 'copy'" class="form-group">
         <label class="form-label" for="from-dataset">
-          Source Dataset
+          Source dataset
           <span class="required-input">*</span>
         </label>
         <select v-model="copyFrom" class="form-control" id="from-dataset">
@@ -325,20 +327,20 @@ export default {
 
       <div v-if="tab === 'copy'" class="form-group">
         <label class="form-label" for="copy-type">
-          Copy Configuration
+          Copy configuration
           <span class="required-input">*</span>
         </label>
         <select v-model="copyType" class="form-control" id="copy-type">
           <option v-bind:value="null" disabled>(required)</option>
-          <option v-bind:value="'convert'">Convert Settings</option>
-          <option v-bind:value="'import'">Import Settings</option>
+          <option v-bind:value="'convert'">Convert settings</option>
+          <option v-bind:value="'import'">Import settings</option>
         </select>
       </div>
 
       <div v-if="tab === 'sync' || tab === 'all'" class="form-group form-check">
         <input class="form-check-input" id="opt-clean" type="checkbox" v-model="cleanupOrphans"/>
         <label class="form-check-label" for="opt-clean">
-          Cleanup Orphaned Files
+          Cleanup orphaned files during synchronisation
         </label>
       </div>
 

--- a/modules/admin/app/assets/js/datasets/components/_modal-cleanup-config.vue
+++ b/modules/admin/app/assets/js/datasets/components/_modal-cleanup-config.vue
@@ -44,9 +44,6 @@ export default {
     resize: function () {
       this.timestamp = (new Date()).getTime();
     },
-    formatNumber: function (num: Number): string {
-      return new Intl.NumberFormat()
-    }
   },
   computed: {
     isValid: function (): boolean {
@@ -72,7 +69,7 @@ export default {
       </div>
     </fieldset>
     <div class="log-container">
-      <panel-log-window v-bind:log="log" v-bind:resize="timestamp" v-bind:visible="visible"/>
+      <panel-log-window v-bind:log="log" v-bind:resize="timestamp" v-bind:visible="visible" v-bind:disabled="!cleanupRunning"/>
     </div>
     <template v-slot:footer>
       <button v-bind:disabled="!isValid || cleanupRunning" v-on:click="doCleanup()" type="button"

--- a/modules/admin/app/assets/js/datasets/components/_modal-ingest-config.vue
+++ b/modules/admin/app/assets/js/datasets/components/_modal-ingest-config.vue
@@ -26,6 +26,7 @@ export default {
       defaultLang: this.opts ? this.opts.defaultLang : null,
       properties: this.opts ? this.opts.properties : null,
       logMessage: this.opts ? this.opts.logMessage : "",
+      batchSize: this.opts ? this.opts.batchSize : null,
       loading: false,
       commit: false,
       error: null,
@@ -42,6 +43,7 @@ export default {
             defaultLang: this.defaultLang,
             properties: this.properties,
             logMessage: this.logMessage,
+            batchSize: this.batchSize || null,
           })
           .then(data => this.$emit("saved-config", data, this.commit))
           .catch(error => this.$emit("error", "Error saving import config", error));
@@ -157,12 +159,19 @@ export default {
         <label class="form-label" for="opt-log-message">Log Message</label>
         <input v-model="logMessage" class="form-control form-control-sm" id="opt-log-message" placeholder="(required)"/>
       </div>
+
+      <hr class="form-group" />
+
       <div class="form-group form-check">
         <input tabindex="-1" v-model="commit" class="form-check-input" id="opt-commit-check" type="checkbox"/>
         <label class="form-check-label" for="opt-commit-check">
           Commit ingest: make changes to database
         </label>
       </div>
+        <div class="form-group">
+            <label class="form-check-label" for="opt-batch-size">Import Batch Size</label>
+            <input v-model.number.trim="batchSize" class="form-control form-control-sm" id="opt-batch-size" type="number" min="50"/>
+        </div>
       <div v-if="error" class="alert alert-danger">
         {{ error }}
       </div>

--- a/modules/admin/app/assets/js/datasets/types.ts
+++ b/modules/admin/app/assets/js/datasets/types.ts
@@ -47,6 +47,7 @@ export interface ImportConfig {
   properties?: string,
   defaultLang?: string,
   logMessage: string,
+  batchSize: number,
   comments?: string,
 }
 

--- a/modules/admin/app/controllers/admin/Ingest.scala
+++ b/modules/admin/app/controllers/admin/Ingest.scala
@@ -74,9 +74,9 @@ case class Ingest @Inject()(
                 .map(_.ref)
 
             val task = ingestTask.copy(properties = FileProperties(props), data = FilePayload(Some(data.ref)))
-            val ingest = IngestData(task, dataType, contentType, AuthenticatedUser(request.user.id), instance)
+            val ingestData = IngestData(task, dataType, contentType, AuthenticatedUser(request.user.id), instance)
 
-            mat.system.actorOf(Props(DataImporterManager(IngestJob(jobId, ingest), ingestApi)), jobId)
+            mat.system.actorOf(Props(DataImporterManager(IngestJob(jobId, List(ingestData)), ingestApi)), jobId)
             logger.info(s"Submitted ingest job: $jobId")
 
             immediate {

--- a/modules/admin/app/models/ImportConfig.scala
+++ b/modules/admin/app/models/ImportConfig.scala
@@ -9,6 +9,7 @@ case class ImportConfig(
   properties: Option[String] = None,
   defaultLang: Option[String] = None,
   logMessage: String,
+  batchSize: Option[Int] = None,
   comments: Option[String] = None,
 )
 

--- a/modules/admin/app/services/ingest/IngestService.scala
+++ b/modules/admin/app/services/ingest/IngestService.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorRef
 import models.{ContentTypes, IngestParams, IngestResult}
 import play.api.mvc.QueryStringBindable
 import services.data.DataUser
-import services.ingest.IngestService.IngestJob
+import services.ingest.IngestService.IngestData
 
 import java.net.URI
 import scala.concurrent.Future
@@ -27,21 +27,21 @@ object IngestService {
     contentType: String,
     user: DataUser,
     instance: String,
+    batch: Option[Int] = None,
   )
 
   // A job with a given ID tag
-  case class IngestJob(id: String, data: IngestData)
-
+  case class IngestJob(jobId: String, data: List[IngestData], batchSize: Option[Int] = None)
 }
 
 trait IngestService {
   /**
     * Import data into the backend.
     *
-    * @param job the job parameters
+    * @param data the job data parameters
     * @return an ingest result object
     */
-  def importData(job: IngestJob): Future[IngestResult]
+  def importData(data: IngestData): Future[IngestResult]
 
   /**
     * Import coreference data into the backend
@@ -76,11 +76,12 @@ trait IngestService {
   /**
     * Save a job and the result to file storage.
     *
-    * @param job the ingest job
+    * @param jobId the ingest job ID
+    * @param data the ingest data
     * @param res the ingest result
     * @return an URL to the stored file
     */
-  def storeManifestAndLog(job: IngestJob, res: IngestResult): Future[URI]
+  def storeManifestAndLog(jobId: String, data: IngestService.IngestData, res: IngestResult): Future[URI]
 
   /**
     * Remove IDs from the index.

--- a/modules/admin/app/services/ingest/SqlImportConfigService.scala
+++ b/modules/admin/app/services/ingest/SqlImportConfigService.scala
@@ -16,7 +16,7 @@ case class SqlImportConfigService @Inject()(db: Database, actorSystem: ActorSyst
 
   private implicit val parser: RowParser[ImportConfig] =
     Macro.parser[ImportConfig](
-      "allow_updates", "use_source_id", "tolerant", "properties_file", "default_lang", "log_message", "comments")
+      "allow_updates", "use_source_id", "tolerant", "properties_file", "default_lang", "log_message", "batch_size", "comments")
 
   override def get(id: String, ds: String): Future[Option[ImportConfig]] = Future {
     db.withConnection { implicit conn =>
@@ -34,7 +34,7 @@ case class SqlImportConfigService @Inject()(db: Database, actorSystem: ActorSyst
   override def save(id: String, ds: String, data: ImportConfig): Future[ImportConfig] = Future {
     db.withTransaction { implicit conn =>
       SQL"""INSERT INTO import_config
-        (repo_id, import_dataset_id, allow_updates, use_source_id, tolerant, properties_file, default_lang, log_message, comments)
+        (repo_id, import_dataset_id, allow_updates, use_source_id, tolerant, properties_file, default_lang, log_message, batch_size, comments)
         VALUES (
           $id,
           $ds,
@@ -44,6 +44,7 @@ case class SqlImportConfigService @Inject()(db: Database, actorSystem: ActorSyst
           ${data.properties},
           ${data.defaultLang},
           ${data.logMessage},
+          ${data.batchSize},
           ${data.comments}
       ) ON CONFLICT (repo_id, import_dataset_id) DO UPDATE
         SET
@@ -53,6 +54,7 @@ case class SqlImportConfigService @Inject()(db: Database, actorSystem: ActorSyst
           properties_file = ${data.properties},
           default_lang = ${data.defaultLang},
           log_message = ${data.logMessage},
+          batch_size = ${data.batchSize},
           comments = ${data.comments}
         RETURNING *
       """.executeInsert(parser.single)

--- a/test/actors/ingest/DataImporterManagerSpec.scala
+++ b/test/actors/ingest/DataImporterManagerSpec.scala
@@ -18,7 +18,7 @@ class DataImporterManagerSpec extends IntegrationTestRunner {
   private val datasetId = "default"
   private val keyVersion = "foo.ead?versionId=1"
   private val job: IngestJob = IngestJob(jobId,
-    IngestData(
+    List(IngestData(
       IngestParams(
         ContentTypes.Repository,
         scope = "r1",
@@ -30,7 +30,7 @@ class DataImporterManagerSpec extends IntegrationTestRunner {
       DataUser(userOpt.map(_.id)),
       hostInstance,
     )
-  )
+  ))
 
 
   "Data Import manager" should {

--- a/test/actors/ingest/DataImporterSpec.scala
+++ b/test/actors/ingest/DataImporterSpec.scala
@@ -1,0 +1,92 @@
+package actors.ingest
+
+import actors.ingest.DataImporter.{Done, Start, Message}
+import akka.actor.Props
+import helpers.IntegrationTestRunner
+import models._
+import services.data.DataUser
+import services.ingest.IngestService.{IngestData, IngestJob}
+import services.ingest._
+
+import scala.concurrent.Future
+
+class DataImporterSpec extends IntegrationTestRunner {
+
+  import mockdata.adminUserProfile
+
+  private implicit val userOpt: Option[UserProfile] = Some(adminUserProfile)
+  private val payload = Map(
+    "foo.ead?version=1" -> java.net.URI.create("http://example.com/foo.ead"),
+    "bar.ead?version=1" -> java.net.URI.create("http://example.com/bar.ead"))
+  private val jobId = "test-job-id"
+  private val ingestData = IngestData(
+    IngestParams(
+      ContentTypes.Repository,
+      scope = "r1",
+      log = "Testing...",
+      data = UrlMapPayload(payload)
+    ),
+    IngestService.IngestDataType.Ead,
+    "application/json",
+    DataUser(userOpt.map(_.id)),
+    hostInstance,
+  )
+  private val job: IngestJob = IngestJob(jobId, List(ingestData))
+
+
+  "Data Importer" should {
+    "send correct messages when importing files" in new ITestAppWithAkka {
+      val importLog = ImportLog()
+      val importApi = MockIngestService(importLog)
+      val importer = system.actorOf(Props(DataImporter(job, importApi, (_, _) => Future.successful(()))))
+
+      importer ! Start
+
+      expectMsg(Message(s"Initialising ingest for job: $jobId..."))
+      expectMsg(importLog)
+      expectMsg(Message("Data: created: 0, updated: 0, unchanged: 0, errors: 0"))
+      expectMsg(Message("Task was a dry run so not proceeding to reindex"))
+      expectMsg(Message("Uploading log..."))
+      expectMsg(Message("Log stored at http://example.com/log"))
+      expectMsgType[Done]
+    }
+
+    "send correct messages when batch importing files" in new ITestAppWithAkka {
+      val batchData = payload.toSeq.zipWithIndex.map { case ((k, v), i) =>
+        ingestData.copy(params = ingestData.params.copy(data = UrlMapPayload(Map(k -> v))), batch = Some(i + 1))
+      }.toList
+      val batchJob = job.copy(data = batchData, batchSize = Some(1))
+      val importLog = ImportLog()
+      val importApi = MockIngestService(importLog)
+      val importer = system.actorOf(Props(DataImporter(batchJob, importApi, (_, _) => Future.successful(()))))
+
+      importer ! Start
+
+      expectMsg(Message(s"Initialising ingest for job: $jobId..."))
+      expectMsg(Message("Splitting job into 2 batches of 1"))
+      expectMsg(Message("Starting batch 1"))
+      expectMsg(importLog)
+      expectMsg(Message("Data: created: 0, updated: 0, unchanged: 0, errors: 0"))
+      expectMsg(Message("Task was a dry run so not proceeding to reindex"))
+      expectMsg(Message("Uploading log..."))
+      expectMsg(Message("Log stored at http://example.com/log"))
+      expectMsg(Message("Starting batch 2"))
+      expectMsg(importLog)
+      expectMsg(Message("Data: created: 0, updated: 0, unchanged: 0, errors: 0"))
+      expectMsg(Message("Task was a dry run so not proceeding to reindex"))
+      expectMsg(Message("Uploading log..."))
+      expectMsg(Message("Log stored at http://example.com/log"))
+      expectMsgType[Done]
+    }
+
+    "send correct messages when imports throw an error" in new ITestAppWithAkka {
+      val importApi = MockIngestService(ErrorLog("identifier", "Missing field"))
+      val importer = system.actorOf(Props(DataImporter(job, importApi, (_, _) => Future.successful(()))))
+
+      importer ! Start
+
+      expectMsg(Message(s"Initialising ingest for job: $jobId..."))
+      expectMsg(ErrorLog("identifier", "Missing field"))
+    }
+  }
+}

--- a/test/services/ingest/MockIngestService.scala
+++ b/test/services/ingest/MockIngestService.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Future
   * plus side has no dependencies.
   */
 case class MockIngestService(res: IngestResult) extends IngestService {
-  override def importData(job: IngestService.IngestJob) =
+  override def importData(data: IngestService.IngestData) =
     Future.successful(res)
 
   override def remapMovedUnits(movedIds: Seq[(String, String)]) =
@@ -23,7 +23,7 @@ case class MockIngestService(res: IngestResult) extends IngestService {
   override def reindex(ids: Seq[String], chan: ActorRef) =
     Future.successful(())
 
-  override def storeManifestAndLog(job: IngestService.IngestJob, res: IngestResult) =
+  override def storeManifestAndLog(jobId: String, data: IngestService.IngestData, res: IngestResult) =
     Future.successful(java.net.URI.create("http://example.com/log"))
 
   override def clearIndex(ids: Seq[String], chan: ActorRef) =


### PR DESCRIPTION
This is basically only for the USHMM `collections` dataset, which exhausts memory on the backend when imported.