### PR TITLE
When batch-copying import configs, also copy properties files

### DIFF
--- a/modules/admin/app/assets/css/datasets.scss
+++ b/modules/admin/app/assets/css/datasets.scss
@@ -1025,11 +1025,12 @@ $active-table-row: #e7f1ff;
 }
 
 .ingest-options-properties-container {
-  height: 6rem;
+  height: 8rem;
   display: flex;
   flex-direction: column;
   overflow-y: auto;
   width: 100%;
+  font-size: $font-size-sm;
   background-color: $gray-100;
 
   .panel-placeholder {
@@ -1049,6 +1050,12 @@ $active-table-row: #e7f1ff;
   left: 0;
   right: 0;
   cursor: pointer;
+}
+
+.ingest-options-properties th {
+  position: sticky;
+  top: 0;
+  background-color: $gray-200;
 }
 
 .ingest-options-properties tr {

--- a/modules/admin/app/assets/js/datasets/api.ts
+++ b/modules/admin/app/assets/js/datasets/api.ts
@@ -4,7 +4,7 @@ import {apiCall} from "./common";
 import {
   Cleanup,
   CleanupSummary,
-  ConvertConfig,
+  ConvertConfig, CopyResult,
   Coreference,
   DataTransformation,
   DataTransformationInfo,
@@ -82,6 +82,10 @@ export class DatasetManagerApi {
 
   fileUrls(ds: string, stage: string, paths: string[]): Promise<object> {
     return apiCall(this.service.ImportFiles.fileUrls(this.repoId, ds, stage), paths);
+  }
+
+  copyFile(ds: string, stage: string, key: string, toDs: string, toName?: string, versionId?: string): Promise<CopyResult> {
+    return apiCall(this.service.ImportFiles.copyFile(this.repoId, ds, stage, key, toDs, toName, versionId));
   }
 
   uploadHandle(ds: string, stage: string, fileSpec: FileToUpload): Promise<{presignedUrl: string}> {

--- a/modules/admin/app/assets/js/datasets/types.ts
+++ b/modules/admin/app/assets/js/datasets/types.ts
@@ -142,6 +142,11 @@ export interface FileInfo {
   versions: FileList,
 }
 
+export interface CopyResult {
+  message: string,
+  url: string
+}
+
 export interface XmlValidationError {
   line: number,
   pos: number,

--- a/modules/admin/app/controllers/datasets/ImportDatasets.scala
+++ b/modules/admin/app/controllers/datasets/ImportDatasets.scala
@@ -54,6 +54,7 @@ case class ImportDatasets @Inject()(
         controllers.datasets.routes.javascript.ImportFiles.deleteFiles,
         controllers.datasets.routes.javascript.ImportFiles.uploadHandle,
         controllers.datasets.routes.javascript.ImportFiles.fileUrls,
+        controllers.datasets.routes.javascript.ImportFiles.copyFile,
         controllers.datasets.routes.javascript.HarvestConfigs.harvest,
         controllers.datasets.routes.javascript.HarvestConfigs.get,
         controllers.datasets.routes.javascript.HarvestConfigs.save,

--- a/modules/admin/conf/datasets.routes
+++ b/modules/admin/conf/datasets.routes
@@ -27,6 +27,7 @@ DELETE      /api/:id/files/delete/:ds/:stage              @controllers.datasets.
 POST        /api/:id/files/upload/:ds/:stage              @controllers.datasets.ImportFiles.uploadHandle(id: String, ds: String, stage: models.FileStage.Value)
 POST        /api/:id/files/validate/:ds/:stage            @controllers.datasets.ImportFiles.validateFiles(id: String, ds: String, stage: models.FileStage.Value)
 POST        /api/:id/files/urls/:ds/:stage                @controllers.datasets.ImportFiles.fileUrls(id: String, ds: String, stage: models.FileStage.Value)
+POST        /api/:id/files/copy/:ds/:stage                @controllers.datasets.ImportFiles.copyFile(id: String, ds: String, stage: models.FileStage.Value, fileName: String, toDs: String, toName: Option[String] ?= None, versionId: Option[String] ?= None)
 
 GET         /api/:id/transformations                      @controllers.datasets.DataTransformations.list(id: String)
 POST        /api/:id/transformations                      @controllers.datasets.DataTransformations.create(id: String, generic: Boolean ?= false)

--- a/modules/portal/app/services/storage/FileStorage.scala
+++ b/modules/portal/app/services/storage/FileStorage.scala
@@ -168,4 +168,13 @@ trait FileStorage {
     * @return an optional pair of metadata and a byte source
     */
   def fromUri(uri: URI): Future[Option[(FileMeta, Source[ByteString, _])]]
+
+  /**
+    * Copy a file from one location to another.
+    *
+    * @param path   the path of the file to copy
+    * @param toPath the path to copy the file to
+    * @return the URI of the copied file
+    */
+  def copyFile(path: String, toPath: String): Future[URI]
 }

--- a/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
+++ b/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
@@ -220,12 +220,22 @@ case class S3CompatibleFileStorage(
     else Future.successful(Option.empty)
   }
 
+  override def copyFile(path: String, toPath: String): Future[URI] = {
+    val request = CopyObjectRequest.builder()
+      .copySource(s"$name/$path")
+      .destinationBucket(name)
+      .destinationKey(toPath)
+      .build()
+    client.copyObject(request)
+    Future.successful(uri(toPath))
+  }
+
   private def infoToMeta(path: String, meta: ObjectMetadata): FileMeta = FileMeta(
     name,
     path,
     java.time.Instant.ofEpochMilli(meta.lastModified.clicks),
     meta.getContentLength,
-    meta.eTag,
+    meta.eTag, // NB: the eTag does NOT have quotes!
     meta.contentType,
     meta.versionId
   )

--- a/test/services/storage/MockFileStorage.scala
+++ b/test/services/storage/MockFileStorage.scala
@@ -144,4 +144,9 @@ case class MockFileStorage(name: String, db: collection.mutable.Map[String, Seq[
   override def setVersioned(enabled: Boolean) = Future.successful(())
 
   override def isVersioned = Future.successful(true)
+
+  override def copyFile(path: String, toPath: String): Future[URI] = {
+    val bytes = getF(path).collect { case Version(_, _, bytes) => bytes }
+    bytes.map(b => putBytes(toPath, Source.single(b), None, meta = Map.empty)).getOrElse(Future.failed(new Exception("File not found")))
+  }
 }


### PR DESCRIPTION
This went down a bit of a rabbit hole and ended up involving a lot of changes to achieve idempotent copying. Might want to rework the storage API to not always use multi-part upload, since this results in eTags that are different from non-multipart uploads.