### PR TITLE
Hack the Search API error handler to figure out moved units

### DIFF
--- a/modules/api/conf/messages
+++ b/modules/api/conf/messages
@@ -1,3 +1,5 @@
+api.error.301=Moved Permanently
+api.error.302=Found
 api.error.400=Bad Request
 api.error.401=Not Authenticated
 api.error.403=Forbidden


### PR DESCRIPTION
This requires an unseemly substitution of the API URL prefix with the /unit one, so it won't work for types of item yet. That will have to wait for a better solution.