### PR TITLE
Require POST to confirm email addresses

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,8 +82,8 @@ val coreDependencies = backendDependencies ++ Seq(
   "org.jsoup" % "jsoup" % "1.11.3",
 
   // Mailer...
-  "com.typesafe.play" %% "play-mailer" % "7.0.1",
-  "com.typesafe.play" %% "play-mailer-guice" % "7.0.1",
+  "com.typesafe.play" %% "play-mailer" % "8.0.1",
+  "com.typesafe.play" %% "play-mailer-guice" % "8.0.1",
 
   // Time formatting library
   "org.ocpsoft.prettytime" % "prettytime" % "3.2.7.Final",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -439,6 +439,7 @@ ehri {
 # Ensure indexer does not idle timeout
 akka.http.host-connection-pool.client.idle-timeout = 5 minutes
 
+
 # system-specific overrides and extensions
 include "search.conf"
 include "form-config.conf"

--- a/conf/logback-play-dev.xml
+++ b/conf/logback-play-dev.xml
@@ -69,7 +69,10 @@
   <!-- <logger name="eu.ehri.project.core.impl" level="TRACE" /> -->
 
   <!-- Uncomment to see misc controller logging -->
-  <logger name="controllers" level="INFO" />
+    <logger name="controllers" level="INFO" />
+
+  <!-- Uncomment to see mailer debug, when play.mailer.debug=yes in configuration -->
+  <!--  <logger name="play.mailer" level="DEBUG" />-->
   
   <!--<logger name="akka.stream" level="TRACE" />-->
 

--- a/modules/portal/app/forms/AccountForms.scala
+++ b/modules/portal/app/forms/AccountForms.scala
@@ -44,6 +44,8 @@ case class AccountForms @Inject() (config: Configuration, conf: AppConfig, oAuth
 
   val forgotPasswordForm: Form[String] = Form(Forms.single("email" -> email))
 
+  val confirmEmailForm: Form[String] = Form(Forms.single("token" -> nonEmptyText))
+
   val changeEmailForm: Form[(String, String)] = Form(
     tuple(
       "email" -> email,

--- a/modules/portal/app/views/account/changeEmailForm.scala.html
+++ b/modules/portal/app/views/account/changeEmailForm.scala.html
@@ -14,7 +14,7 @@
     </div>
 
     <div class="form-field">
-        <input type="submit" class="login-button btn btn-warning" value="@Messages("login.email.change.submit")" />
+        <input type="submit" class="btn btn-warning" value="@Messages("login.email.change.submit")" />
         <a class="btn btn-cancel" href="@controllers.portal.users.routes.UserProfiles.updateProfile()">@Messages("cancel")</a>
     </div>
 }

--- a/modules/portal/app/views/account/confirmEmail.scala.html
+++ b/modules/portal/app/views/account/confirmEmail.scala.html
@@ -1,0 +1,19 @@
+@(form: Form[String], recaptchaKey: String, action: Call)(implicit userOpt: Option[UserProfile], request: RequestHeader, conf: AppConfig, flash: Flash, messages: Messages,prefs: SessionPrefs)
+
+@implicitField = @{ views.html.helper.FieldConstructor(views.html.helpers.fieldTemplateSignUp.f) }
+
+@views.html.layout.loginLayout(Messages("signup.validation")) {
+    @views.html.common.itemHeader(Messages("signup.validation"))
+    <p>@Messages("signup.validation.message")</p>
+    @helper.form(action = action, 'class -> "form signup-form login-form") {
+        @formHelpers.csrfToken()
+        @formHelpers.globalErrors(form)
+        @common.recaptcha(recaptchaKey)
+        @formHelpers.hiddenInput(form("token"))
+
+        <div class="form-field">
+            <input type="submit" class="login-button btn btn-lg btn-post" value="@Messages("signup.validation.message.submit")" />
+        </div>
+    }
+}
+

--- a/modules/portal/conf/account.routes
+++ b/modules/portal/conf/account.routes
@@ -11,6 +11,7 @@ GET         /sso/$client<[a-z0-9]+>         @controllers.portal.account.Accounts
 
 GET         /signup                         @controllers.portal.account.Accounts.signup()
 POST        /signup                         @controllers.portal.account.Accounts.signupPost()
+POST        /confirmEmail                   @controllers.portal.account.Accounts.confirmEmailPost()
 GET         /confirmEmail/:token            @controllers.portal.account.Accounts.confirmEmail(token: String)
 GET         /change-email                   @controllers.portal.account.Accounts.changeEmail()
 POST        /change-email                   @controllers.portal.account.Accounts.changeEmailPost()

--- a/modules/portal/conf/messages
+++ b/modules/portal/conf/messages
@@ -329,10 +329,15 @@ signup.badPasswords=The password and confirmation did not match. Please try agai
 signup.agreeTerms=You must agree to the terms.
 signup.confirmation=Thanks for signing up! We''ve sent you an email which you can use to confirm \
   your email address.
-signup.validation.badToken=Confirmation URL is invalid or has expired.
+signup.validation=Validate your account
+signup.validation.badToken=Confirmation URL is invalid, has already been used, or has expired. \
+  Note: confirmation links can only be used once.
 signup.validation.confirmation=Your account has been validated.
 signup.disabled=Signup is disabled on this site. If you are using a staging instance sign up on the production \
   site and wait for periodic account synchronisation to occur.
+signup.validation.message=Click the button below to confirm your email address.
+signup.validation.message.submit=Confirm Email
+signup.validation.alreadyValidated=Your email address has already been validated.
 
 #
 # Mail stuff

--- a/test/helpers/TestConfiguration.scala
+++ b/test/helpers/TestConfiguration.scala
@@ -9,7 +9,6 @@ import auth.handler.{AuthHandler, AuthIdContainer}
 import auth.oauth2.MockOAuth2Service
 import config.ServiceConfig
 import cookies.SessionPreferences
-import lifecycle.{ItemLifecycle, NoopItemLifecycle}
 import models.{Account, CypherQuery, Feedback}
 import org.jsoup.Jsoup
 import org.specs2.execute.{AsResult, Result}

--- a/test/services/accounts/MockAccountManager.scala
+++ b/test/services/accounts/MockAccountManager.scala
@@ -22,7 +22,6 @@ case class MockAccountManager @Inject()(executionContext: ExecutionContext) exte
   }
 
   override def oAuth2: OAuth2AssociationManager = new OAuth2AssociationManager {
-    protected implicit def executionContext: ExecutionContext = self.executionContext
 
     def addAssociation(id: String, providerId: String, provider: String): Future[Option[OAuth2Association]] =
       immediate {
@@ -44,7 +43,6 @@ case class MockAccountManager @Inject()(executionContext: ExecutionContext) exte
   }
 
   override def openId: OpenIdAssociationManager = new OpenIdAssociationManager {
-    protected implicit def executionContext: ExecutionContext = self.executionContext
 
     def addAssociation(id: String, assoc: String): Future[Option[OpenIDAssociation]] =
       immediate {


### PR DESCRIPTION
This is because some mail hosts follow links to check for malware and this makes the user's attempt to verify fail, confusing them.

Also improve some language strings.