### PR TITLE
Clean up serializer/deserializer naming and prevent OOI issues

### DIFF
--- a/modules/admin/app/client/json/ClientWriteable.scala
+++ b/modules/admin/app/client/json/ClientWriteable.scala
@@ -3,5 +3,5 @@ package client.json
 import play.api.libs.json.Writes
 
 trait ClientWriteable[T] {
-  def clientFormat: Writes[T]
+  def _clientFormat: Writes[T]
 }

--- a/modules/admin/app/client/json/package.scala
+++ b/modules/admin/app/client/json/package.scala
@@ -10,38 +10,38 @@ import utils.EnumUtils
 package object json {
 
   implicit object datePeriodJson extends ClientWriteable[DatePeriodF] {
-    lazy val clientFormat: Format[DatePeriodF] = Json.format[DatePeriodF]
+    lazy val _clientFormat: Format[DatePeriodF] = Json.format[DatePeriodF]
   }
 
   implicit object addressJson extends ClientWriteable[AddressF] {
-    lazy val clientFormat: Writes[AddressF] = Json.writes[AddressF]
+    lazy val _clientFormat: Writes[AddressF] = Json.writes[AddressF]
   }
 
   implicit object anyModelJson extends ClientWriteable[Model] {
     private val logger = Logger(getClass)
-    private val clientFormatRegistry: PartialFunction[EntityType.Value, Format[Model]] = {
-      case EntityType.Repository => repositoryJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.Country => countryJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.DocumentaryUnit => documentaryUnitJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.Vocabulary => vocabularyJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.Concept => conceptJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.HistoricalAgent => historicalAgentJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.AuthoritativeSet => authoritativeSetJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.SystemEvent => systemEventJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.Group => groupJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.UserProfile => userProfileJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.Link => linkJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.Annotation => annotationJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.PermissionGrant => permissionGrantJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.ContentType => contentTypeJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.AccessPoint => accessPointJson.clientFormat.asInstanceOf[Format[Model]]
-      case EntityType.VirtualUnit => virtualUnitJson.clientFormat.asInstanceOf[Format[Model]]
+    private val _clientFormatRegistry: PartialFunction[EntityType.Value, Format[Model]] = {
+      case EntityType.Repository => repositoryJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.Country => countryJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.DocumentaryUnit => documentaryUnitJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.Vocabulary => vocabularyJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.Concept => conceptJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.HistoricalAgent => historicalAgentJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.AuthoritativeSet => authoritativeSetJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.SystemEvent => systemEventJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.Group => groupJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.UserProfile => userProfileJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.Link => linkJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.Annotation => annotationJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.PermissionGrant => permissionGrantJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.ContentType => contentTypeJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.AccessPoint => accessPointJson._clientFormat.asInstanceOf[Format[Model]]
+      case EntityType.VirtualUnit => virtualUnitJson._clientFormat.asInstanceOf[Format[Model]]
     }
 
     def typeOf(json: JsValue): EntityType.Value = (json \ Entity.ISA).as(EnumUtils.enumReads(EntityType))
 
     implicit val clientReadAny: Reads[Model] = Reads { json =>
-      clientFormatRegistry
+      _clientFormatRegistry
         .lift(typeOf(json))
         .map(json.validate(_))
         .getOrElse(
@@ -50,7 +50,7 @@ package object json {
     }
 
     implicit val clientWriteAny: Writes[Model] = Writes { model =>
-      clientFormatRegistry
+      _clientFormatRegistry
         .lift(model.isA)
         .map(Json.toJson(model)(_))
         .getOrElse {
@@ -60,252 +60,252 @@ package object json {
         }
     }
 
-    implicit val clientFormat: Format[Model] = Format(clientReadAny, clientWriteAny)
+    implicit val _clientFormat: Format[Model] = Format(clientReadAny, clientWriteAny)
   }
 
   implicit object contentTypeJson extends ClientWriteable[DataContentType] {
-    val clientFormat: Format[DataContentType] = Json.format[DataContentType]
+    val _clientFormat: Format[DataContentType] = Json.format[DataContentType]
   }
 
   implicit object permissionGrantJson extends ClientWriteable[PermissionGrant] {
     private implicit val permissionGrantFormat: OFormat[models.PermissionGrantF] = Json.format[PermissionGrantF]
-    implicit val clientFormat: Format[PermissionGrant] = (
+    implicit val _clientFormat: Format[PermissionGrant] = (
       JsPath.format(permissionGrantFormat) and
-      (__ \ "accessor").lazyFormatNullable[Accessor](accessorJson.clientFormat) and
-      (__ \ "targets").formatSeqOrEmpty(anyModelJson.clientFormat) and
-      (__ \ "scope").lazyFormatNullable[Model](anyModelJson.clientFormat) and
-      (__ \ "grantedBy").lazyFormatNullable[UserProfile](userProfileJson.clientFormat) and
+      (__ \ "accessor").lazyFormatNullable[Accessor](accessorJson._clientFormat) and
+      (__ \ "targets").formatSeqOrEmpty(anyModelJson._clientFormat) and
+      (__ \ "scope").lazyFormatNullable[Model](anyModelJson._clientFormat) and
+      (__ \ "grantedBy").lazyFormatNullable[UserProfile](userProfileJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(PermissionGrant.apply, unlift(PermissionGrant.unapply))
   }
 
   implicit object accessPointJson extends ClientWriteable[AccessPoint] {
-    val clientFormat: Format[AccessPoint] = Json.format[AccessPoint]
+    val _clientFormat: Format[AccessPoint] = Json.format[AccessPoint]
   }
 
   implicit object linkJson extends ClientWriteable[Link] {
     private implicit val linkFormat: OFormat[models.LinkF] = Json.format[LinkF]
-    val clientFormat: Format[Link] = (
+    val _clientFormat: Format[Link] = (
       JsPath.format[LinkF](linkFormat) and
-      (__ \ "targets").formatSeqOrEmpty(anyModelJson.clientFormat) and
-      (__ \ "source").lazyFormatNullable(anyModelJson.clientFormat) and
-      (__ \ "user").lazyFormatNullable(accessorJson.clientFormat) and
-      (__ \ "accessPoints").formatSeqOrEmpty(accessPointJson.clientFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "promotedBy").formatSeqOrEmpty(userProfileJson.clientFormat) and
-      (__ \ "demotedBy").formatSeqOrEmpty(userProfileJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+      (__ \ "targets").formatSeqOrEmpty(anyModelJson._clientFormat) and
+      (__ \ "source").lazyFormatNullable(anyModelJson._clientFormat) and
+      (__ \ "user").lazyFormatNullable(accessorJson._clientFormat) and
+      (__ \ "accessPoints").formatSeqOrEmpty(accessPointJson._clientFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "promotedBy").formatSeqOrEmpty(userProfileJson._clientFormat) and
+      (__ \ "demotedBy").formatSeqOrEmpty(userProfileJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(Link.apply, unlift(Link.unapply))
   }
 
   implicit object countryJson extends ClientWriteable[Country] {
 
-    private val fFormat = Json.format[CountryF]
-    val clientFormat: Format[Country] = (
-      JsPath.format[CountryF](fFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    private val _formFormat = Json.format[CountryF]
+    val _clientFormat: Format[Country] = (
+      JsPath.format[CountryF](_formFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(Country.apply, unlift(Country.unapply))
   }
 
   implicit object versionJson extends ClientWriteable[Version] {
-    private implicit val fFormat: OFormat[models.VersionF] = Json.format[VersionF]
-    implicit val clientFormat: Format[Version] = (
-      JsPath.format[VersionF](fFormat) and
-      (__ \ "event").lazyFormatNullable(systemEventJson.clientFormat) and
+    private implicit val _formFormat: OFormat[models.VersionF] = Json.format[VersionF]
+    implicit val _clientFormat: Format[Version] = (
+      JsPath.format[VersionF](_formFormat) and
+      (__ \ "event").lazyFormatNullable(systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(Version.apply, unlift(Version.unapply))
   }
 
   implicit object accessorJson extends ClientWriteable[Accessor] {
-    implicit val reads: Reads[Accessor] = Reads(
-      _.validate[Accessor](anyModelJson.clientFormat.asInstanceOf[Format[Accessor]]))
+    implicit val _reads: Reads[Accessor] = Reads(
+      _.validate[Accessor](anyModelJson._clientFormat.asInstanceOf[Format[Accessor]]))
 
-    implicit val writes: Writes[Accessor] = Writes(
-      Json.toJson(_)(anyModelJson.clientFormat.asInstanceOf[Format[Accessor]]))
+    implicit val _writes: Writes[Accessor] = Writes(
+      Json.toJson(_)(anyModelJson._clientFormat.asInstanceOf[Format[Accessor]]))
 
-    implicit val clientFormat: Format[Accessor] = Format(reads, writes)
+    implicit val _clientFormat: Format[Accessor] = Format(_reads, _writes)
   }
 
   implicit object systemEventJson extends ClientWriteable[SystemEvent] {
-    private implicit val fFormat: OFormat[models.SystemEventF] = Json.format[SystemEventF]
+    private implicit val _formFormat: OFormat[models.SystemEventF] = Json.format[SystemEventF]
 
-    implicit val clientFormat: Format[SystemEvent] = (
-      JsPath.format[SystemEventF](fFormat) and
-      (__ \ "scope").lazyFormatNullable[Model](anyModelJson.clientFormat) and
-      (__ \ "firstSubject").lazyFormatNullable[Model](anyModelJson.clientFormat) and
-      (__ \ "user").lazyFormatNullable[Accessor](accessorJson.clientFormat) and
-      (__ \ "version").lazyFormatNullable(versionJson.clientFormat) and
+    implicit val _clientFormat: Format[SystemEvent] = (
+      JsPath.format[SystemEventF](_formFormat) and
+      (__ \ "scope").lazyFormatNullable[Model](anyModelJson._clientFormat) and
+      (__ \ "firstSubject").lazyFormatNullable[Model](anyModelJson._clientFormat) and
+      (__ \ "user").lazyFormatNullable[Accessor](accessorJson._clientFormat) and
+      (__ \ "version").lazyFormatNullable(versionJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(SystemEvent.apply, unlift(SystemEvent.unapply))
   }
 
   implicit object groupJson extends ClientWriteable[Group] {
-    private lazy val fFormat = Json.format[GroupF]
-    lazy val clientFormat: Format[Group] = (
-      JsPath.format[GroupF](fFormat) and
-      (__ \ "groups").lazyNullableSeqFormat(clientFormat) and
-      (__ \ "accessibleTo").lazyNullableSeqFormat(accessorJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    private lazy val _formFormat = Json.format[GroupF]
+    lazy val _clientFormat: Format[Group] = (
+      JsPath.format[GroupF](_formFormat) and
+      (__ \ "groups").lazyNullableSeqFormat(_clientFormat) and
+      (__ \ "accessibleTo").lazyNullableSeqFormat(accessorJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(Group.apply, unlift(Group.unapply))
   }
 
   implicit object userProfileJson extends ClientWriteable[UserProfile] {
-    private lazy val fFormat = Json.format[UserProfileF]
-    val clientFormat: Format[UserProfile] = (
-      JsPath.format[UserProfileF](fFormat) and
-      (__ \ "groups").formatSeqOrEmpty(groupJson.clientFormat) and
-      (__ \ "accessibleTo").lazyNullableSeqFormat(accessorJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    private lazy val _formFormat = Json.format[UserProfileF]
+    val _clientFormat: Format[UserProfile] = (
+      JsPath.format[UserProfileF](_formFormat) and
+      (__ \ "groups").formatSeqOrEmpty(groupJson._clientFormat) and
+      (__ \ "accessibleTo").lazyNullableSeqFormat(accessorJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(UserProfile.quickApply, unlift(UserProfile.quickUnapply))
   }
 
   implicit object annotationJson extends ClientWriteable[Annotation] {
-    private val fFormat = Json.format[AnnotationF]
-    val clientFormat: Format[Annotation] = (
-      JsPath.format[AnnotationF](fFormat) and
-      (__ \ "annotations").lazyNullableSeqFormat(clientFormat) and
-      (__ \ "user").lazyFormatNullable[UserProfile](userProfileJson.clientFormat) and
-      (__ \ "source").lazyFormatNullable[Model](anyModelJson.clientFormat) and
-      (__ \ "target").lazyFormatNullable[Model](anyModelJson.clientFormat) and
+    private val _formFormat = Json.format[AnnotationF]
+    val _clientFormat: Format[Annotation] = (
+      JsPath.format[AnnotationF](_formFormat) and
+      (__ \ "annotations").lazyNullableSeqFormat(_clientFormat) and
+      (__ \ "user").lazyFormatNullable[UserProfile](userProfileJson._clientFormat) and
+      (__ \ "source").lazyFormatNullable[Model](anyModelJson._clientFormat) and
+      (__ \ "target").lazyFormatNullable[Model](anyModelJson._clientFormat) and
       (__ \ "targetPart").lazyFormatNullable[Entity](Entity.entityFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "promotedBy").formatSeqOrEmpty(userProfileJson.clientFormat) and
-      (__ \ "demotedBy").formatSeqOrEmpty(userProfileJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "promotedBy").formatSeqOrEmpty(userProfileJson._clientFormat) and
+      (__ \ "demotedBy").formatSeqOrEmpty(userProfileJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(Annotation.apply, unlift(Annotation.unapply))
   }
 
   implicit object documentaryUnitDescriptionJson extends ClientWriteable[DocumentaryUnitDescriptionF] {
-    private implicit val accessPointFormat: Format[models.AccessPoint] = accessPointJson.clientFormat
-    private implicit val datePeriodFormat: Format[models.DatePeriodF] = datePeriodJson.clientFormat
+    private implicit val accessPointFormat: Format[models.AccessPoint] = accessPointJson._clientFormat
+    private implicit val datePeriodFormat: Format[models.DatePeriodF] = datePeriodJson._clientFormat
     private implicit val isadGIdentityFormat: OFormat[models.IsadGIdentity] = Json.format[IsadGIdentity]
     private implicit val isadGContextFormat: OFormat[models.IsadGContext] = Json.format[IsadGContext]
     private implicit val isadGContentFormat: OFormat[models.IsadGContent] = Json.format[IsadGContent]
     private implicit val isadGConditionsFormat: OFormat[models.IsadGConditions] = Json.format[IsadGConditions]
     private implicit val isadGMaterialsFormat: OFormat[models.IsadGMaterials] = Json.format[IsadGMaterials]
     private implicit val isadGControlFormat: OFormat[models.IsadGControl] = Json.format[IsadGControl]
-    val clientFormat: Format[DocumentaryUnitDescriptionF] = Json.format[DocumentaryUnitDescriptionF]
+    val _clientFormat: Format[DocumentaryUnitDescriptionF] = Json.format[DocumentaryUnitDescriptionF]
   }
 
   implicit object historicalAgentDescriptionJson extends ClientWriteable[HistoricalAgentDescriptionF] {
-    private implicit val accessPointFormat: Format[models.AccessPoint] = accessPointJson.clientFormat
-    private implicit val datePeriodFormat: Format[models.DatePeriodF] = datePeriodJson.clientFormat
+    private implicit val accessPointFormat: Format[models.AccessPoint] = accessPointJson._clientFormat
+    private implicit val datePeriodFormat: Format[models.DatePeriodF] = datePeriodJson._clientFormat
     private implicit val isaarDetailsFormat: OFormat[models.IsaarDetail] = Json.format[IsaarDetail]
     private implicit val isaarControlFormat: OFormat[models.IsaarControl] = Json.format[IsaarControl]
-    val clientFormat: Format[HistoricalAgentDescriptionF] = Json.format[HistoricalAgentDescriptionF]
+    val _clientFormat: Format[HistoricalAgentDescriptionF] = Json.format[HistoricalAgentDescriptionF]
   }
 
   implicit object repositoryDescriptionJson extends ClientWriteable[RepositoryDescriptionF] {
-    private implicit val addressFormat: Writes[models.AddressF] = addressJson.clientFormat
-    private implicit val accessPointFormat: Format[models.AccessPoint] = accessPointJson.clientFormat
+    private implicit val addressFormat: Writes[models.AddressF] = addressJson._clientFormat
+    private implicit val accessPointFormat: Format[models.AccessPoint] = accessPointJson._clientFormat
     private implicit val isdiahDetailsFormat: OFormat[models.IsdiahDetails] = Json.format[IsdiahDetails]
     private implicit val isdiahAccessFormat: OFormat[models.IsdiahAccess] = Json.format[IsdiahAccess]
     private implicit val isdiahServicesFormat: OFormat[models.IsdiahServices] = Json.format[IsdiahServices]
     private implicit val isdiahControlFormat: OFormat[models.IsdiahControl] = Json.format[IsdiahControl]
-    val clientFormat: Format[RepositoryDescriptionF] = Json.format[RepositoryDescriptionF]
+    val _clientFormat: Format[RepositoryDescriptionF] = Json.format[RepositoryDescriptionF]
   }
 
   implicit object conceptDescriptionJson extends ClientWriteable[ConceptDescriptionF] {
-    private implicit val accessPointFormat: Format[models.AccessPoint] = accessPointJson.clientFormat
-    lazy val clientFormat: Format[ConceptDescriptionF] = Json.format[ConceptDescriptionF]
+    private implicit val accessPointFormat: Format[models.AccessPoint] = accessPointJson._clientFormat
+    lazy val _clientFormat: Format[ConceptDescriptionF] = Json.format[ConceptDescriptionF]
   }
 
   implicit object historicalAgentJson extends ClientWriteable[HistoricalAgent] {
-    private implicit val haDescFmt: Format[models.HistoricalAgentDescriptionF] = historicalAgentDescriptionJson.clientFormat
-    private val fFormat = Json.format[HistoricalAgentF]
+    private implicit val haDescFmt: Format[models.HistoricalAgentDescriptionF] = historicalAgentDescriptionJson._clientFormat
+    private val _formFormat = Json.format[HistoricalAgentF]
 
-    val clientFormat: Format[HistoricalAgent] = (
-      JsPath.format(fFormat) and
-      (__ \ "set").formatNullable[AuthoritativeSet](authoritativeSetJson.clientFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    val _clientFormat: Format[HistoricalAgent] = (
+      JsPath.format(_formFormat) and
+      (__ \ "set").formatNullable[AuthoritativeSet](authoritativeSetJson._clientFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(HistoricalAgent.apply, unlift(HistoricalAgent.unapply))
   }
 
   implicit object repositoryJson extends ClientWriteable[Repository] {
-    private implicit val repoDescFmt: Format[models.RepositoryDescriptionF] = repositoryDescriptionJson.clientFormat
-    private val fFormat = Json.format[RepositoryF]
+    private implicit val repoDescFmt: Format[models.RepositoryDescriptionF] = repositoryDescriptionJson._clientFormat
+    private val _formFormat = Json.format[RepositoryF]
 
-    val clientFormat: Format[Repository] = (
-      JsPath.format(fFormat) and
-      (__ \ "country").formatNullable[Country](countryJson.clientFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    val _clientFormat: Format[Repository] = (
+      JsPath.format(_formFormat) and
+      (__ \ "country").formatNullable[Country](countryJson._clientFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(Repository.apply, unlift(Repository.unapply))
   }
 
   implicit object documentaryUnitJson extends ClientWriteable[DocumentaryUnit] {
-    private implicit val docDescFmt: Format[models.DocumentaryUnitDescriptionF] = documentaryUnitDescriptionJson.clientFormat
-    private val fFormat = Json.format[DocumentaryUnitF]
-    lazy val clientFormat: Format[DocumentaryUnit] = (
-      JsPath.format(fFormat) and
-      (__ \ "holder").formatNullable[Repository](repositoryJson.clientFormat) and
-      (__ \ "parent").lazyFormatNullable[DocumentaryUnit](clientFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    private implicit val docDescFmt: Format[models.DocumentaryUnitDescriptionF] = documentaryUnitDescriptionJson._clientFormat
+    private val _formFormat = Json.format[DocumentaryUnitF]
+    lazy val _clientFormat: Format[DocumentaryUnit] = (
+      JsPath.format(_formFormat) and
+      (__ \ "holder").formatNullable[Repository](repositoryJson._clientFormat) and
+      (__ \ "parent").lazyFormatNullable[DocumentaryUnit](_clientFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(DocumentaryUnit.apply, unlift(DocumentaryUnit.unapply))
   }
 
   implicit object virtualUnitJson extends ClientWriteable[VirtualUnit] {
-    private implicit val vuDescFmt: Format[models.DocumentaryUnitDescriptionF] = documentaryUnitDescriptionJson.clientFormat
-    private val fFormat = Json.format[VirtualUnitF]
+    private implicit val _vuClientFormat: Format[models.DocumentaryUnitDescriptionF] = documentaryUnitDescriptionJson._clientFormat
+    private val _formFormat = Json.format[VirtualUnitF]
 
-    lazy val clientFormat: Format[VirtualUnit] = (
-      JsPath.format[VirtualUnitF](fFormat) and
-      (__ \ "descriptions").formatSeqOrEmpty(documentaryUnitJson.clientFormat) and
-      (__ \ "author").formatNullable[Accessor](accessorJson.clientFormat) and
-      (__ \ "parent").lazyFormatNullable[VirtualUnit](clientFormat) and
-      (__ \ "holder").formatNullable[Repository](repositoryJson.clientFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    lazy val _clientFormat: Format[VirtualUnit] = (
+      JsPath.format[VirtualUnitF](_formFormat) and
+      (__ \ "descriptions").formatSeqOrEmpty(documentaryUnitJson._clientFormat) and
+      (__ \ "author").formatNullable[Accessor](accessorJson._clientFormat) and
+      (__ \ "parent").lazyFormatNullable[VirtualUnit](_clientFormat) and
+      (__ \ "holder").formatNullable[Repository](repositoryJson._clientFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(VirtualUnit.apply, unlift(VirtualUnit.unapply))
   }
 
   implicit object authoritativeSetJson extends ClientWriteable[AuthoritativeSet] {
-    private val fFormat = Json.format[AuthoritativeSetF]
-    val clientFormat: Format[AuthoritativeSet] = (
-      JsPath.format[AuthoritativeSetF](fFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "promotedBy").formatSeqOrEmpty(userProfileJson.clientFormat) and
-      (__ \ "demotedBy").formatSeqOrEmpty(userProfileJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    private val _formFormat = Json.format[AuthoritativeSetF]
+    val _clientFormat: Format[AuthoritativeSet] = (
+      JsPath.format[AuthoritativeSetF](_formFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "promotedBy").formatSeqOrEmpty(userProfileJson._clientFormat) and
+      (__ \ "demotedBy").formatSeqOrEmpty(userProfileJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(AuthoritativeSet.apply, unlift(AuthoritativeSet.unapply))
   }
 
   implicit object vocabularyJson extends ClientWriteable[Vocabulary] {
-    private val fFormat = Json.format[VocabularyF]
-    val clientFormat: Format[Vocabulary] = (
-      JsPath.format[VocabularyF](fFormat) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "promotedBy").formatSeqOrEmpty(userProfileJson.clientFormat) and
-      (__ \ "demotedBy").formatSeqOrEmpty(userProfileJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    private val _formFormat = Json.format[VocabularyF]
+    val _clientFormat: Format[Vocabulary] = (
+      JsPath.format[VocabularyF](_formFormat) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "promotedBy").formatSeqOrEmpty(userProfileJson._clientFormat) and
+      (__ \ "demotedBy").formatSeqOrEmpty(userProfileJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(Vocabulary.apply, unlift(Vocabulary.unapply))
   }
 
   implicit object conceptJson extends ClientWriteable[Concept] {
 
-    private implicit val fdFormat: Format[models.ConceptDescriptionF] = conceptDescriptionJson.clientFormat
-    implicit val fFormat: Format[ConceptF] = Json.format[ConceptF]
-    val clientFormat: Format[Concept] = (
-      JsPath.format[ConceptF](fFormat) and
-      (__ \ "vocabulary").formatNullable[Vocabulary](vocabularyJson.clientFormat) and
-      (__ \ "parent").lazyFormatNullable[Concept](clientFormat) and
-      (__ \ "broaderTerms").lazyFormat[Seq[Concept]](Format(Reads.seq(clientFormat), Writes.seq(clientFormat))) and
-      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson.clientFormat) and
-      (__ \ "event").formatNullable[SystemEvent](systemEventJson.clientFormat) and
+    private implicit val fdFormat: Format[models.ConceptDescriptionF] = conceptDescriptionJson._clientFormat
+    implicit val _formFormat: Format[ConceptF] = Json.format[ConceptF]
+    val _clientFormat: Format[Concept] = (
+      JsPath.format[ConceptF](_formFormat) and
+      (__ \ "vocabulary").formatNullable[Vocabulary](vocabularyJson._clientFormat) and
+      (__ \ "parent").lazyFormatNullable[Concept](_clientFormat) and
+      (__ \ "broaderTerms").lazyFormat[Seq[Concept]](Format(Reads.seq(_clientFormat), Writes.seq(_clientFormat))) and
+      (__ \ "accessibleTo").formatSeqOrEmpty(accessorJson._clientFormat) and
+      (__ \ "event").formatNullable[SystemEvent](systemEventJson._clientFormat) and
       (__ \ "meta").format[JsObject]
     )(Concept.apply, unlift(Concept.unapply))
   }

--- a/modules/admin/app/controllers/admin/AdminSearch.scala
+++ b/modules/admin/app/controllers/admin/AdminSearch.scala
@@ -66,7 +66,7 @@ case class AdminSearch @Inject()(
       render {
         case Accepts.Json() => Ok(Json.obj(
             "numPages" -> result.page.numPages,
-            "page" -> Json.toJson(result.page.items.map(_._1))(Writes.seq(client.json.anyModelJson.clientFormat)),
+            "page" -> Json.toJson(result.page.items.map(_._1))(Writes.seq(client.json.anyModelJson._clientFormat)),
             "facets" -> result.facetClasses
           ))
         case _ => Ok(views.html.admin.search.search(result, controllers.admin.routes.AdminSearch.search()))

--- a/modules/admin/app/controllers/admin/Metrics.scala
+++ b/modules/admin/app/controllers/admin/Metrics.scala
@@ -41,7 +41,7 @@ case class Metrics @Inject()(
   private def jsonResponse[T](result: SearchResult[(T, SearchHit)])(implicit request: Request[AnyContent], w: ClientWriteable[T]): Result = {
     render {
       case Accepts.Json() | Accepts.JavaScript() => Ok(Json.obj(
-        "page" -> Json.toJson(result.mapItems(_._1).page)(pageWrites(w.clientFormat)),
+        "page" -> Json.toJson(result.mapItems(_._1).page)(pageWrites(w._clientFormat)),
         "params" -> result.params,
         "appliedFacets" -> result.facets,
         "facetClasses" -> result.facetClasses

--- a/modules/admin/app/models/IngestResult.scala
+++ b/modules/admin/app/models/IngestResult.scala
@@ -11,19 +11,19 @@ sealed trait IngestResult
 
 object IngestResult {
 
-  implicit val reads: Reads[IngestResult] = Reads { json =>
+  implicit val _reads: Reads[IngestResult] = Reads { json =>
     json.validate[ImportValidationError]
       .map(e => ErrorLog(s"Validation error at ${e.context}", e.toString))
       .orElse(json.validate[ErrorLog])
       .orElse(json.validate[ImportLog])
       .orElse(json.validate[SyncLog])
   }
-  implicit val writes: Writes[IngestResult] = Writes {
-    case i: ImportLog => Json.toJson(i)(ImportLog.format)
-    case i: SyncLog => Json.toJson(i)(SyncLog.format)
-    case i: ErrorLog => Json.toJson(i)(ErrorLog.format)
+  implicit val _writes: Writes[IngestResult] = Writes {
+    case i: ImportLog => Json.toJson(i)(ImportLog._format)
+    case i: SyncLog => Json.toJson(i)(SyncLog._format)
+    case i: ErrorLog => Json.toJson(i)(ErrorLog._format)
   }
-  implicit val format: Format[IngestResult] = Format(reads, writes)
+  implicit val _format: Format[IngestResult] = Format(_reads, _writes)
 }
 
 case class ImportValidationError(context: String, errorSet: ErrorSet) extends RuntimeException(errorSet.toString) {
@@ -56,7 +56,7 @@ case class ImportLog(
 
 object ImportLog {
   implicit val config: Aux[Json.MacroOptions] = JsonConfiguration(SnakeCase)
-  implicit val format: Format[ImportLog] = Json.format[ImportLog]
+  implicit val _format: Format[ImportLog] = Json.format[ImportLog]
 }
 
 // The result of an EAD synchronisation, which incorporates an import
@@ -68,14 +68,14 @@ case class SyncLog(
 ) extends IngestResult
 
 object SyncLog {
-  implicit val format: Format[SyncLog] = Json.format[SyncLog]
+  implicit val _format: Format[SyncLog] = Json.format[SyncLog]
 }
 
 // An import error we can understand, e.g. not a crash!
 case class ErrorLog(error: String, details: String) extends IngestResult
 
 object ErrorLog {
-  implicit val format: Format[ErrorLog] = Json.format[ErrorLog]
+  implicit val _format: Format[ErrorLog] = Json.format[ErrorLog]
 }
 
 

--- a/modules/api/app/models/api/v1/JsonApiV1.scala
+++ b/modules/api/app/models/api/v1/JsonApiV1.scala
@@ -37,7 +37,7 @@ object JsonApiV1 {
   )
 
   object DocumentaryUnitDescriptionAttrs {
-    implicit val writes: Writes[DocumentaryUnitDescriptionAttrs] = Json.writes[DocumentaryUnitDescriptionAttrs]
+    implicit val _writes: Writes[DocumentaryUnitDescriptionAttrs] = Json.writes[DocumentaryUnitDescriptionAttrs]
 
     def apply(d: DocumentaryUnitDescriptionF)(implicit messages: Messages): DocumentaryUnitDescriptionAttrs =
       new DocumentaryUnitDescriptionAttrs(
@@ -66,7 +66,7 @@ object JsonApiV1 {
   )
 
   object DocumentaryUnitAttrs {
-    implicit val writes: Writes[DocumentaryUnitAttrs] = Json.writes[DocumentaryUnitAttrs]
+    implicit val _writes: Writes[DocumentaryUnitAttrs] = Json.writes[DocumentaryUnitAttrs]
 
     def apply(d: DocumentaryUnit)(implicit messages: Messages): DocumentaryUnitAttrs =
       new DocumentaryUnitAttrs(
@@ -92,7 +92,7 @@ object JsonApiV1 {
   )
 
   object AddressAttrs {
-    implicit val writes: Writes[AddressAttrs] = Json.writes[AddressAttrs]
+    implicit val _writes: Writes[AddressAttrs] = Json.writes[AddressAttrs]
 
     def apply(a: AddressF)(implicit messages: Messages): AddressAttrs = new AddressAttrs(
       a.name,
@@ -133,7 +133,7 @@ object JsonApiV1 {
   )
 
   object RepositoryAttrs {
-    implicit val writes: Writes[RepositoryAttrs] = Json.writes[RepositoryAttrs]
+    implicit val _writes: Writes[RepositoryAttrs] = Json.writes[RepositoryAttrs]
 
     def apply(r: Repository)(implicit messages: Messages): RepositoryAttrs = {
       r.data.primaryDescription.map { d =>
@@ -172,7 +172,7 @@ object JsonApiV1 {
   )
 
   object DocumentaryUnitLinks {
-    implicit val writes: Writes[DocumentaryUnitLinks] = Json.writes[DocumentaryUnitLinks]
+    implicit val _writes: Writes[DocumentaryUnitLinks] = Json.writes[DocumentaryUnitLinks]
   }
 
   case class DocumentaryUnitRelations(
@@ -184,7 +184,7 @@ object JsonApiV1 {
     // Not using default writes here because missing (Optional)
     // relations should be expressed using null
     // http://jsonapi.org/format/#document-resource-object-related-resource-links
-    implicit val writes: Writes[DocumentaryUnitRelations] = Writes[DocumentaryUnitRelations] { r =>
+    implicit val _writes: Writes[DocumentaryUnitRelations] = Writes[DocumentaryUnitRelations] { r =>
       Json.obj(
         "holder" -> r.holder,
         "parent" -> r.parent
@@ -206,7 +206,7 @@ object JsonApiV1 {
   )
 
   object HistoricalAgentAttrs {
-    implicit val writes: Writes[HistoricalAgentAttrs] = Json.writes[HistoricalAgentAttrs]
+    implicit val _writes: Writes[HistoricalAgentAttrs] = Json.writes[HistoricalAgentAttrs]
 
     def apply(a: HistoricalAgent)(implicit messages: Messages): HistoricalAgentAttrs = {
       a.data.primaryDescription.map { d =>
@@ -234,7 +234,7 @@ object JsonApiV1 {
   )
 
   object HistoricalAgentLinks {
-    implicit val writes: Writes[HistoricalAgentLinks] = Json.writes[HistoricalAgentLinks]
+    implicit val _writes: Writes[HistoricalAgentLinks] = Json.writes[HistoricalAgentLinks]
   }
 
   case class RepositoryLinks(
@@ -244,7 +244,7 @@ object JsonApiV1 {
   )
 
   object RepositoryLinks {
-    implicit val writes: Writes[RepositoryLinks] = Json.writes[RepositoryLinks]
+    implicit val _writes: Writes[RepositoryLinks] = Json.writes[RepositoryLinks]
   }
 
   case class RepositoryRelations(
@@ -252,7 +252,7 @@ object JsonApiV1 {
   )
 
   object RepositoryRelations {
-    implicit val writes: Writes[RepositoryRelations] = Json.writes[RepositoryRelations]
+    implicit val _writes: Writes[RepositoryRelations] = Json.writes[RepositoryRelations]
   }
 
   case class CountryAttrs(
@@ -266,7 +266,7 @@ object JsonApiV1 {
   )
 
   object CountryAttrs {
-    implicit val writes: Writes[CountryAttrs] = Json.writes[CountryAttrs]
+    implicit val _writes: Writes[CountryAttrs] = Json.writes[CountryAttrs]
 
     def apply(c: Country)(implicit requestHeader: RequestHeader, messages: Messages): CountryAttrs =
       new CountryAttrs(
@@ -286,7 +286,7 @@ object JsonApiV1 {
   )
 
   object CountryLinks {
-    implicit val writes: Writes[CountryLinks] = Json.writes[CountryLinks]
+    implicit val _writes: Writes[CountryLinks] = Json.writes[CountryLinks]
   }
 
   case class ConceptDescriptionAttrs(
@@ -302,7 +302,7 @@ object JsonApiV1 {
   )
 
   object ConceptDescriptionAttrs {
-    implicit val writes: Writes[ConceptDescriptionAttrs] = Json.writes[ConceptDescriptionAttrs]
+    implicit val _writes: Writes[ConceptDescriptionAttrs] = Json.writes[ConceptDescriptionAttrs]
 
     def apply(d: ConceptDescriptionF)(implicit messages: Messages): ConceptDescriptionAttrs = new ConceptDescriptionAttrs(
       languageCode = d.languageCode,
@@ -326,7 +326,7 @@ object JsonApiV1 {
   )
 
   object ConceptAttrs {
-    implicit val writes: Writes[ConceptAttrs] = Json.writes[ConceptAttrs]
+    implicit val _writes: Writes[ConceptAttrs] = Json.writes[ConceptAttrs]
 
     def apply(c: Concept)(implicit requestHeader: RequestHeader, messages: Messages): ConceptAttrs =
       new ConceptAttrs(
@@ -347,7 +347,7 @@ object JsonApiV1 {
   )
 
   object ConceptLinks {
-    implicit val writes: Writes[ConceptLinks] = Json.writes[ConceptLinks]
+    implicit val _writes: Writes[ConceptLinks] = Json.writes[ConceptLinks]
   }
 
   case class JsonApiResponse(
@@ -380,7 +380,7 @@ object JsonApiV1 {
   )
 
   object ResourceIdentifier {
-    implicit val writes: Writes[ResourceIdentifier] = Json.writes[ResourceIdentifier]
+    implicit val _writes: Writes[ResourceIdentifier] = Json.writes[ResourceIdentifier]
 
     def apply(m: Model) = new ResourceIdentifier(m.id, m.isA.toString)
   }
@@ -393,7 +393,7 @@ object JsonApiV1 {
   )
 
   object PaginationLinks {
-    implicit val writes: Writes[PaginationLinks] = Json.writes[PaginationLinks]
+    implicit val _writes: Writes[PaginationLinks] = Json.writes[PaginationLinks]
   }
 
   case class JsonApiError(
@@ -406,7 +406,7 @@ object JsonApiV1 {
   )
 
   object JsonApiError {
-    implicit val writes: Writes[JsonApiError] = Json.writes[JsonApiError]
+    implicit val _writes: Writes[JsonApiError] = Json.writes[JsonApiError]
   }
 
   case class GeoPoint(
@@ -415,7 +415,7 @@ object JsonApiV1 {
   )
 
   object GeoPoint {
-    implicit val writes: Writes[GeoPoint] = Writes { p =>
+    implicit val _writes: Writes[GeoPoint] = Writes { p =>
       Json.obj(
         "type" -> "Point",
         "coordinates" -> Json.arr(p.latitude, p.longitude)

--- a/modules/backend/src/main/scala/models/GlobalPermissionSet.scala
+++ b/modules/backend/src/main/scala/models/GlobalPermissionSet.scala
@@ -20,7 +20,7 @@ object GlobalPermissionSet {
    * value in each, converting them to a tuple for internal use.
    *
    */
-  implicit val restReads: Reads[GlobalPermissionSet] = Reads.seq(Reads.map(Reads.map(Reads.seq[String]))).map { pd =>
+  implicit val _reads: Reads[GlobalPermissionSet] = Reads.seq(Reads.map(Reads.map(Reads.seq[String]))).map { pd =>
     pd.flatMap { pmap =>
       pmap.headOption.map { case (user, perms) =>
         (user, perms.flatMap {
@@ -45,6 +45,5 @@ case class GlobalPermissionSet(data: GlobalPermissionSet.PermData) extends Permi
    * Check if this permission set has the given permission.
    */
   def has(sub: ContentTypes.Value, permission: PermissionType.Value): Boolean =
-    data.flatMap(_._2.get(sub)).filter(plist => plist.exists(p =>
-      PermissionType.in(p, permission))).nonEmpty
+    data.flatMap(_._2.get(sub)).exists(plist => plist.exists(p => PermissionType.in(p, permission)))
 }

--- a/modules/backend/src/main/scala/models/ItemPermissionSet.scala
+++ b/modules/backend/src/main/scala/models/ItemPermissionSet.scala
@@ -14,7 +14,7 @@ object ItemPermissionSet {
    * a less stringly typed version: all the entity types and permissions
    * should all correspond to Enum values in ContentType and PermissionType.
    */
-  implicit def restReads(contentType: ContentTypes.Value): Reads[ItemPermissionSet] = Reads.seq(Reads.map(Reads.seq[String])).map { pd =>
+  implicit def _reads(contentType: ContentTypes.Value): Reads[ItemPermissionSet] = Reads.seq(Reads.map(Reads.seq[String])).map { pd =>
     // Raw data is a Seq[Map[String, Seq[String]]]
     import scala.util.control.Exception._
     pd.flatMap { userPermMap =>

--- a/modules/backend/src/main/scala/models/Readable.scala
+++ b/modules/backend/src/main/scala/models/Readable.scala
@@ -9,7 +9,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("No member of type class Readable found for type ${T}")
 trait Readable[T] {
-  val restReads: Reads[T]
+  def _reads: Reads[T]
 }
 
 object Readable {

--- a/modules/backend/src/main/scala/models/Writable.scala
+++ b/modules/backend/src/main/scala/models/Writable.scala
@@ -10,7 +10,7 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("No member of type class Writable found for type ${T}")
 trait Writable[T] {
-  val restFormat: Format[T]
+  def _format: Format[T]
 }
 
 object Writable {

--- a/modules/backend/src/main/scala/services/cypher/WsCypherService.scala
+++ b/modules/backend/src/main/scala/services/cypher/WsCypherService.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 private case class WsCypherResultData(row: List[JsValue], meta: Seq[JsValue])
 
 private object WsCypherResultData {
-  implicit val reads: Reads[WsCypherResultData] = (
+  implicit val _reads: Reads[WsCypherResultData] = (
     (__ \ "row").read[List[JsValue]] and
     (__ \ "meta").read[Seq[JsValue]]
   )(WsCypherResultData.apply _)
@@ -31,7 +31,7 @@ private case class WsCypherResult(columns: Seq[String], data: Seq[WsCypherResult
 }
 
 private object WsCypherResult {
-  implicit val reads: Reads[WsCypherResult] = (
+  implicit val _reads: Reads[WsCypherResult] = (
     (__ \ "columns").read[Seq[String]] and
     (__ \ "data").read[Seq[WsCypherResultData]]
   )(WsCypherResult.apply _)

--- a/modules/backend/src/main/scala/services/data/BatchResult.scala
+++ b/modules/backend/src/main/scala/services/data/BatchResult.scala
@@ -5,5 +5,5 @@ import play.api.libs.json.{Format, Json}
 case class BatchResult(created: Int, updated: Int, unchanged: Int, errors: Map[String, String])
 
 object BatchResult {
-  implicit val format: Format[BatchResult] = Json.format[BatchResult]
+  implicit val _format: Format[BatchResult] = Json.format[BatchResult]
 }

--- a/modules/backend/src/test/scala/models/PermissionSetSpec.scala
+++ b/modules/backend/src/test/scala/models/PermissionSetSpec.scala
@@ -40,7 +40,7 @@ class PermissionSetSpec extends Specification {
         )
       )
 
-      val permSet = Json.toJson(data).as(ItemPermissionSet.restReads(ContentTypes.DocumentaryUnit))
+      val permSet = Json.toJson(data).as(ItemPermissionSet._reads(ContentTypes.DocumentaryUnit))
       permSet.has(PermissionType.Create) must beTrue
       permSet.has(PermissionType.Update) must beTrue
       permSet.has(PermissionType.Annotate) must beFalse

--- a/modules/core/src/main/scala/controllers/generic/Annotate.scala
+++ b/modules/core/src/main/scala/controllers/generic/Annotate.scala
@@ -21,14 +21,14 @@ trait Annotate[MT] extends Read[MT] {
     * @return
     */
   def createAnnotationJsonPost(id: String): Action[JsValue] = Action.async(parsers.json) { request =>
-    request.body.validate[AnnotationF](AnnotationF.Converter.clientFormat).fold(
+    request.body.validate[AnnotationF](AnnotationF.Converter._clientFormat).fold(
       errors => immediate(BadRequest(JsError.toJson(errors))),
       ap => {
         // NB: No checking of permissions here - we're going to depend
         // on the server for that
         OptionalUserAction.async { implicit request =>
           userDataApi.createAnnotation[Annotation, AnnotationF](id, ap).map { ann =>
-            Created(Json.toJson(ann.data)(AnnotationF.Converter.clientFormat))
+            Created(Json.toJson(ann.data)(AnnotationF.Converter._clientFormat))
           }
         }(request.map(js => AnyContentAsEmpty))
       }

--- a/modules/core/src/main/scala/models/AccessPoint.scala
+++ b/modules/core/src/main/scala/models/AccessPoint.scala
@@ -26,14 +26,14 @@ object AccessPointF {
     val PlaceAccess = Value("place")
     val GenreAccess = Value("genre")
 
-    implicit val format: Format[AccessPointType.Value] = EnumUtils.enumFormat(this)
+    implicit val _format: Format[AccessPointType.Value] = EnumUtils.enumFormat(this)
 
     def exceptCreator: ValueSet = values.filterNot(_ == CreatorAccess)
   }
 
   import Entity.{TYPE => ETYPE,_}
 
-  implicit val accessPointFormat: Format[AccessPointF] = (
+  implicit lazy val _format: Format[AccessPointF] = (
     (__ \ ETYPE).formatIfEquals(EntityType.AccessPoint) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ TYPE).formatWithDefault(AccessPointType.SubjectAccess) and
@@ -42,7 +42,7 @@ object AccessPointF {
   )(AccessPointF.apply, unlift(AccessPointF.unapply))
 
   implicit object Converter extends Writable[AccessPointF] {
-    lazy val restFormat: Format[AccessPointF] = accessPointFormat
+    lazy val _format: Format[AccessPointF] = AccessPointF._format
   }
 }
 
@@ -82,13 +82,13 @@ object AccessPoint {
   import AccessPointF.{TYPE => ETYPE, _}
   import EnumUtils.enumMapping
 
-  implicit val metaReads: Reads[AccessPoint] = (
+  implicit lazy val _reads: Reads[AccessPoint] = (
     __.read[AccessPointF] and
       (__ \ META).readWithDefault(Json.obj())
     )(AccessPoint.apply _)
 
   implicit object Converter extends Readable[AccessPoint] {
-    val restReads: Reads[AccessPoint] = metaReads
+    val _reads: Reads[AccessPoint] = AccessPoint._reads
   }
 
 

--- a/modules/core/src/main/scala/models/Accessor.scala
+++ b/modules/core/src/main/scala/models/Accessor.scala
@@ -5,11 +5,12 @@ import play.api.libs.json._
 
 object Accessor {
   final val ADMIN_GROUP_NAME = "admin"
-  final val BELONGS_REL = "belongsTo"
+
+  implicit lazy val _reads: Reads[Accessor] = Reads[Accessor](
+    _.validate[Accessor](Model.Converter._reads.asInstanceOf[Reads[Accessor]]))
 
   implicit object Converter extends Readable[Accessor] {
-    implicit val restReads: Reads[Accessor] = Reads[Accessor](
-      _.validate[Accessor](Model.Converter.restReads.asInstanceOf[Reads[Accessor]]))
+    implicit val _reads: Reads[Accessor] = Accessor._reads
   }
 
   /**
@@ -17,7 +18,7 @@ object Accessor {
    * the entity type.
    */
   def resourceFor(t: EntityType.Value): ContentType[Accessor] = new ContentType[Accessor] {
-    val restReads: Reads[Accessor] = Converter.restReads
+    val _reads: Reads[Accessor] = Accessor._reads
     def entityType: EntityType.Value = t
     def contentType: ContentTypes.Value = ContentTypes.withName(t.toString)
   }

--- a/modules/core/src/main/scala/models/Address.scala
+++ b/modules/core/src/main/scala/models/Address.scala
@@ -13,7 +13,7 @@ object AddressF {
   import Isdiah._
   import play.api.libs.functional.syntax._
 
-  implicit val addressFormat: Format[AddressF] = (
+  implicit lazy val _format: Format[AddressF] = (
     (__ \ TYPE).formatIfEquals(EntityType.Address) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ ADDRESS_NAME).formatNullable[String] and
@@ -30,7 +30,7 @@ object AddressF {
   )(AddressF.apply, unlift(AddressF.unapply))
 
   implicit object Converter extends Writable[AddressF] {
-    val restFormat: Format[AddressF] = addressFormat
+    val _format: Format[AddressF] = AddressF._format
   }
 }
 

--- a/modules/core/src/main/scala/models/AdminUserData.scala
+++ b/modules/core/src/main/scala/models/AdminUserData.scala
@@ -16,7 +16,7 @@ object AdminUserData {
     verified = user.account.exists(_.verified)
   )
 
-  implicit val format: Format[AdminUserData] = Json.format[AdminUserData]
+  implicit val _format: Format[AdminUserData] = Json.format[AdminUserData]
 
   val form = Form(
     mapping(

--- a/modules/core/src/main/scala/models/AuthoritativeSet.scala
+++ b/modules/core/src/main/scala/models/AuthoritativeSet.scala
@@ -21,7 +21,7 @@ object AuthoritativeSetF {
 
   import Entity._
 
-  implicit val authoritativeSetFormat: Format[AuthoritativeSetF] = (
+  implicit lazy val _format: Format[AuthoritativeSetF] = (
     (__ \ TYPE).formatIfEquals(EntityType.AuthoritativeSet) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ IDENTIFIER).format[String] and
@@ -31,7 +31,7 @@ object AuthoritativeSetF {
   )(AuthoritativeSetF.apply, unlift(AuthoritativeSetF.unapply))
 
   implicit object Converter extends Writable[AuthoritativeSetF] {
-    lazy val restFormat: Format[AuthoritativeSetF] = authoritativeSetFormat
+    lazy val _format: Format[AuthoritativeSetF] = AuthoritativeSetF._format
   }
 }
 
@@ -50,10 +50,7 @@ object AuthoritativeSet {
   import Entity._
   import eu.ehri.project.definitions.Ontology._
 
-  private implicit val systemEventReads: Reads[models.SystemEvent] = SystemEvent.SystemEventResource.restReads
-  private implicit val accessorReads: Reads[models.Accessor] = Accessor.Converter.restReads
-
-  implicit val metaReads: Reads[AuthoritativeSet] = (
+  implicit lazy val _reads: Reads[AuthoritativeSet] = (
     __.read[AuthoritativeSetF] and
     (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).readSeqOrEmpty[Accessor] and
     (__ \ RELATIONSHIPS \ PROMOTED_BY).readSeqOrEmpty[UserProfile] and
@@ -65,10 +62,10 @@ object AuthoritativeSet {
   implicit object AuthoritativeSetResource extends ContentType[AuthoritativeSet]  {
     val entityType = EntityType.AuthoritativeSet
     val contentType = ContentTypes.AuthoritativeSet
-    val restReads: Reads[AuthoritativeSet] = metaReads
+    val _reads: Reads[AuthoritativeSet] = AuthoritativeSet._reads
   }
 
-  val form = Form(
+  val form: Form[AuthoritativeSetF] = Form(
     mapping(
       ISA -> ignored(EntityType.AuthoritativeSet),
       ID -> optional(nonEmptyText),

--- a/modules/core/src/main/scala/models/ConceptDescription.scala
+++ b/modules/core/src/main/scala/models/ConceptDescription.scala
@@ -16,7 +16,7 @@ object ConceptDescriptionF {
   import Entity._
   import models.ConceptF._
 
-  implicit val conceptDescriptionFormat: Format[ConceptDescriptionF] = (
+  implicit lazy val _format: Format[ConceptDescriptionF] = (
     (__ \ TYPE).formatIfEquals(EntityType.ConceptDescription) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ LANG_CODE).format[String] and
@@ -37,7 +37,7 @@ object ConceptDescriptionF {
   )(ConceptDescriptionF.apply, unlift(ConceptDescriptionF.unapply))
 
   implicit object Converter extends Writable[ConceptDescriptionF] {
-    lazy val restFormat: Format[ConceptDescriptionF] = conceptDescriptionFormat
+    lazy val _format: Format[ConceptDescriptionF] = ConceptDescriptionF._format
   }
 }
 

--- a/modules/core/src/main/scala/models/Country.scala
+++ b/modules/core/src/main/scala/models/Country.scala
@@ -23,7 +23,7 @@ object CountryF {
 
   import Entity._
 
-  lazy implicit val countryFormat: Format[CountryF] = (
+  implicit lazy val _format: Format[CountryF] = (
     (__ \ TYPE).formatIfEquals(EntityType.Country) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ IDENTIFIER).format[String] and
@@ -35,7 +35,7 @@ object CountryF {
   )(CountryF.apply, unlift(CountryF.unapply))
 
   implicit object Converter extends Writable[CountryF] {
-    lazy val restFormat: Format[CountryF] = countryFormat
+    lazy val _format: Format[CountryF] = CountryF._format
   }
 }
 
@@ -45,9 +45,9 @@ case class CountryF(
   identifier: String,
   abs: Option[String],
   history: Option[String],
-  situation: Option[String],                   
+  situation: Option[String],
   summary: Option[String],
-  extensive: Option[String]                   
+  extensive: Option[String]
 ) extends ModelData with Persistable {
 
   def displayText: Option[String] = abs orElse situation
@@ -59,10 +59,10 @@ object Country {
   import Entity._
   import eu.ehri.project.definitions.Ontology._
 
-  implicit val metaReads: Reads[Country] = (
-    __.read[CountryF](countryFormat) and
+  implicit lazy val _reads: Reads[Country] = (
+    __.read[CountryF](_format) and
     // Latest event
-    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).readSeqOrEmpty(Accessor.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).readSeqOrEmpty(Accessor._reads) and
     (__ \ RELATIONSHIPS \ ENTITY_HAS_LIFECYCLE_EVENT).readHeadNullable[SystemEvent] and
     (__ \ META).readWithDefault(Json.obj())
   )(Country.apply _)
@@ -70,7 +70,7 @@ object Country {
   implicit object CountryResource extends ContentType[Country]  {
     val entityType = EntityType.Country
     val contentType = ContentTypes.Country
-    val restReads: Reads[Country] = metaReads
+    val _reads: Reads[Country] = Country._reads
   }
 
   val form: Form[CountryF] = Form(

--- a/modules/core/src/main/scala/models/DataContentType.scala
+++ b/modules/core/src/main/scala/models/DataContentType.scala
@@ -10,7 +10,7 @@ case class DataContentTypeF(
 ) extends ModelData
 
 object DataContentTypeF {
-  implicit val format: Format[DataContentTypeF] = (
+  implicit val _format: Format[DataContentTypeF] = (
     (__ \ Entity.ID).formatNullable[String] and
     (__ \ Entity.TYPE).formatIfEquals(EntityType.ContentType)
   )(DataContentTypeF.apply, unlift(DataContentTypeF.unapply))
@@ -30,11 +30,11 @@ case class DataContentType(
 
 object DataContentType {
   import Entity._
-  implicit val format: Format[DataContentType] = (
+  implicit val _format: Format[DataContentType] = (
     __.format[DataContentTypeF] and
       (__ \ META).formatWithDefault(Json.obj())
     )(DataContentType.apply, unlift(DataContentType.unapply))
   implicit object Converter extends Readable[DataContentType] {
-    val restReads: Format[DataContentType] = format
+    val _reads: Format[DataContentType] = DataContentType._format
   }
 }

--- a/modules/core/src/main/scala/models/DatePeriod.scala
+++ b/modules/core/src/main/scala/models/DatePeriod.scala
@@ -23,7 +23,7 @@ object DatePeriodF {
     val Creation = Value("creation")
     val Existence = Value("existence")
 
-    implicit val format: Format[DatePeriodType.Value] = EnumUtils.enumFormat(this)
+    implicit val _format: Format[DatePeriodType.Value] = EnumUtils.enumFormat(this)
   }
 
   object DatePeriodPrecision extends Enumeration {
@@ -34,12 +34,12 @@ object DatePeriodF {
     val Week = Value("week")
     val Day = Value("day")
 
-    implicit val format: Format[DatePeriodPrecision.Value] = utils.EnumUtils.enumFormat(this)
+    implicit val _format: Format[DatePeriodPrecision.Value] = utils.EnumUtils.enumFormat(this)
   }
 
   import Entity.{TYPE => ETYPE, _}
 
-  implicit val datePeriodFormat: Format[DatePeriodF] = (
+  implicit lazy val datePeriodFormat: Format[DatePeriodF] = (
     (__ \ ETYPE).formatIfEquals(EntityType.DatePeriod) and
       (__ \ ID).formatNullable[String] and
       (__ \ DATA \ TYPE).formatNullable[DatePeriodType.Value] and
@@ -50,7 +50,7 @@ object DatePeriodF {
     ) (DatePeriodF.apply, unlift(DatePeriodF.unapply))
 
   implicit object Converter extends Writable[DatePeriodF] {
-    lazy val restFormat: Format[DatePeriodF] = datePeriodFormat
+    lazy val _format: Format[DatePeriodF] = datePeriodFormat
   }
 }
 

--- a/modules/core/src/main/scala/models/Description.scala
+++ b/modules/core/src/main/scala/models/Description.scala
@@ -40,7 +40,7 @@ object Description {
     val Import: Type = Value("IMPORT")
     val Manual: Type = Value("MANUAL")
 
-    implicit val format: Format[CreationProcess.Value] = utils.EnumUtils.enumFormat(this)
+    implicit val _format: Format[CreationProcess.Value] = utils.EnumUtils.enumFormat(this)
   }
 
   /**

--- a/modules/core/src/main/scala/models/DocumentaryUnitDescription.scala
+++ b/modules/core/src/main/scala/models/DocumentaryUnitDescription.scala
@@ -67,7 +67,7 @@ object DocumentaryUnitDescriptionF {
   import Ontology._
   import models.IsadG._
 
-  implicit val documentaryUnitDescriptionFormat: Format[DocumentaryUnitDescriptionF] = (
+  implicit lazy val documentaryUnitDescriptionFormat: Format[DocumentaryUnitDescriptionF] = (
     (__ \ TYPE).formatIfEquals(EntityType.DocumentaryUnitDescription) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ LANG_CODE).format[String] and
@@ -125,7 +125,7 @@ object DocumentaryUnitDescriptionF {
   )(DocumentaryUnitDescriptionF.apply, unlift(DocumentaryUnitDescriptionF.unapply))
 
   implicit object Converter extends Writable[DocumentaryUnitDescriptionF] {
-    val restFormat: Format[DocumentaryUnitDescriptionF] = documentaryUnitDescriptionFormat
+    val _format: Format[DocumentaryUnitDescriptionF] = documentaryUnitDescriptionFormat
   }
 }
 

--- a/modules/core/src/main/scala/models/Entity.scala
+++ b/modules/core/src/main/scala/models/Entity.scala
@@ -18,7 +18,7 @@ object Entity {
   /**
    * Reads a generic entity.
    */
-  implicit val entityReads: Reads[Entity] = (
+  implicit lazy val entityReads: Reads[Entity] = (
     (__ \ ID).read[String] and
     (__ \ TYPE).read[EntityType.Type](EnumUtils.enumReads(EntityType)) and
     (__ \ DATA).lazyRead(Reads.map[JsValue]) and

--- a/modules/core/src/main/scala/models/FieldMetadataSet.scala
+++ b/modules/core/src/main/scala/models/FieldMetadataSet.scala
@@ -36,7 +36,7 @@ case class FieldMetadataSet(fieldMetadata: ListMap[String, FieldMetadata]) {
         e.relationships.values.toSeq.flatten.flatMap { r => flattenEntity(r) }
     }
 
-    val json = Json.toJson(data)(implicitly[Writable[T]].restFormat)
+    val json = Json.toJson(data)(implicitly[Writable[T]]._format)
     json.validate[Entity] match {
       case JsSuccess(entity, _) =>
         val fms = fieldMetadata.values.filter(_.entityType == entity.isA).toSeq

--- a/modules/core/src/main/scala/models/Group.scala
+++ b/modules/core/src/main/scala/models/Group.scala
@@ -18,7 +18,7 @@ object GroupF {
 
   import Entity._
 
-  implicit val groupFormat: Format[GroupF] = (
+  implicit lazy val groupFormat: Format[GroupF] = (
     (__ \ TYPE).formatIfEquals(EntityType.Group) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ IDENTIFIER).format[String] and
@@ -27,7 +27,7 @@ object GroupF {
   )(GroupF.apply, unlift(GroupF.unapply))
 
   implicit object Converter extends Writable[GroupF] {
-    lazy val restFormat: Format[GroupF] = groupFormat
+    lazy val _format: Format[GroupF] = groupFormat
   }
 }
 
@@ -44,12 +44,12 @@ object Group {
   import Entity._
   import Ontology._
 
-  private lazy implicit val systemEventReads: Reads[SystemEvent] = SystemEvent.SystemEventResource.restReads
+  private lazy implicit val systemEventReads: Reads[SystemEvent] = SystemEvent.SystemEventResource._reads
 
-  implicit val metaReads: Reads[Group] = (
+  implicit lazy val _reads: Reads[Group] = (
     __.read[GroupF] and
-    (__ \ RELATIONSHIPS \ ACCESSOR_BELONGS_TO_GROUP).lazyReadSeqOrEmpty(metaReads) and
-    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ ACCESSOR_BELONGS_TO_GROUP).lazyReadSeqOrEmpty(Group._reads) and
+    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor._reads) and
     (__ \ RELATIONSHIPS \ ENTITY_HAS_LIFECYCLE_EVENT).readHeadNullable[SystemEvent] and
     (__ \ META).readWithDefault(Json.obj())
   )(Group.apply _)
@@ -57,7 +57,7 @@ object Group {
   implicit object GroupResource extends ContentType[Group]  {
     val entityType = EntityType.Group
     val contentType = ContentTypes.Group
-    val restReads: Reads[Group] = metaReads
+    val _reads: Reads[Group] = Group._reads
   }
 
   val form: Form[GroupF] = Form(

--- a/modules/core/src/main/scala/models/HistoricalAgent.scala
+++ b/modules/core/src/main/scala/models/HistoricalAgent.scala
@@ -22,7 +22,7 @@ object HistoricalAgentF {
   import Entity._
   import Ontology._
 
-  implicit val historicalAgentFormat: Format[HistoricalAgentF] = (
+  implicit lazy val historicalAgentFormat: Format[HistoricalAgentF] = (
     (__ \ TYPE).formatIfEquals(EntityType.HistoricalAgent) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ IDENTIFIER).format[String] and
@@ -31,7 +31,7 @@ object HistoricalAgentF {
   )(HistoricalAgentF.apply, unlift(HistoricalAgentF.unapply))
 
   implicit object Converter extends Writable[HistoricalAgentF] {
-    lazy val restFormat: Format[HistoricalAgentF] = historicalAgentFormat
+    lazy val _format: Format[HistoricalAgentF] = historicalAgentFormat
   }
 }
 
@@ -59,13 +59,13 @@ object HistoricalAgent {
   import Ontology._
   import utils.EnumUtils.enumMapping
 
-  private implicit val systemEventReads: Reads[models.SystemEvent] = SystemEvent.SystemEventResource.restReads
-  private implicit val authoritativeSetReads: Reads[models.AuthoritativeSet] = AuthoritativeSet.AuthoritativeSetResource.restReads
+  private implicit val systemEventReads: Reads[models.SystemEvent] = SystemEvent.SystemEventResource._reads
+  private implicit val authoritativeSetReads: Reads[models.AuthoritativeSet] = AuthoritativeSet.AuthoritativeSetResource._reads
 
-  implicit val metaReads: Reads[HistoricalAgent] = (
+  implicit lazy val _reads: Reads[HistoricalAgent] = (
     __.read[HistoricalAgentF] and
     (__ \ RELATIONSHIPS \ ITEM_IN_AUTHORITATIVE_SET).readHeadNullable[AuthoritativeSet] and
-    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).readSeqOrEmpty(Accessor.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).readSeqOrEmpty(Accessor._reads) and
     (__ \ RELATIONSHIPS \ ENTITY_HAS_LIFECYCLE_EVENT).readHeadNullable[SystemEvent] and
     (__ \ META).readWithDefault(Json.obj())
   )(HistoricalAgent.apply _)
@@ -73,7 +73,7 @@ object HistoricalAgent {
   implicit object HistoricalAgentResource extends ContentType[HistoricalAgent]  {
     val entityType = EntityType.HistoricalAgent
     val contentType = ContentTypes.HistoricalAgent
-    val restReads: Reads[HistoricalAgent] = metaReads
+    val _reads: Reads[HistoricalAgent] = HistoricalAgent._reads
   }
 
   val form = Form(

--- a/modules/core/src/main/scala/models/HistoricalAgentDescription.scala
+++ b/modules/core/src/main/scala/models/HistoricalAgentDescription.scala
@@ -40,7 +40,7 @@ object HistoricalAgentDescriptionF {
   import Isaar._
   import eu.ehri.project.definitions.Ontology._
 
-  implicit val historicalAgentDescriptionFormat: Format[HistoricalAgentDescriptionF] = (
+  implicit lazy val historicalAgentDescriptionFormat: Format[HistoricalAgentDescriptionF] = (
     (__ \ TYPE).formatIfEquals(EntityType.HistoricalAgentDescription) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ LANG_CODE).format[String] and
@@ -75,7 +75,7 @@ object HistoricalAgentDescriptionF {
   )(HistoricalAgentDescriptionF.apply, unlift(HistoricalAgentDescriptionF.unapply))
 
   implicit object Converter extends Writable[HistoricalAgentDescriptionF]  {
-    val restFormat: Format[HistoricalAgentDescriptionF] = historicalAgentDescriptionFormat
+    val _format: Format[HistoricalAgentDescriptionF] = historicalAgentDescriptionFormat
   }
 }
 

--- a/modules/core/src/main/scala/models/Isaar.scala
+++ b/modules/core/src/main/scala/models/Isaar.scala
@@ -15,7 +15,7 @@ case object Isaar {
     val Family = Value("family")
     val CorporateBody = Value("corporateBody")
 
-    implicit val format: Format[Isaar.HistoricalAgentType.Value] = EnumUtils.enumFormat(this)
+    implicit val _format: Format[Isaar.HistoricalAgentType.Value] = EnumUtils.enumFormat(this)
   }
 
   val IDENTIFIER = "identifier"

--- a/modules/core/src/main/scala/models/Link.scala
+++ b/modules/core/src/main/scala/models/Link.scala
@@ -1,12 +1,11 @@
 package models
 
-import play.api.libs.json._
-import models.json._
 import eu.ehri.project.definitions.Ontology
+import models.json._
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.Messages
-import play.api.libs.json.JsObject
+import play.api.libs.json._
 import utils.EnumUtils
 
 
@@ -51,7 +50,7 @@ object LinkF {
   import Ontology._
   import play.api.libs.functional.syntax._
 
-  implicit val linkFormat: Format[LinkF] = (
+  implicit lazy val linkFormat: Format[LinkF] = (
     (__ \ TYPE).formatIfEquals(EntityType.Link) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ LINK_TYPE).formatWithDefault(LinkType.Associative) and
@@ -62,7 +61,7 @@ object LinkF {
   )(LinkF.apply, unlift(LinkF.unapply))
 
   implicit object Converter extends Writable[LinkF] {
-    lazy val restFormat: Format[LinkF] = linkFormat
+    lazy val _format: Format[LinkF] = linkFormat
   }
 }
 
@@ -80,21 +79,17 @@ case class LinkF(
 
 object Link {
   import Entity._
+  import EnumUtils.enumMapping
   import Ontology._
   import play.api.libs.functional.syntax._
-  import EnumUtils.enumMapping
 
-  private implicit val userProfileMetaReads: Reads[models.UserProfile] = models.UserProfile.UserProfileResource.restReads
-  private implicit val accessPointReads: Reads[models.AccessPoint] = models.AccessPoint.Converter.restReads
-  private implicit val systemEventReads: Reads[models.SystemEvent] = SystemEvent.SystemEventResource.restReads
-
-  implicit val metaReads: Reads[Link] = (
+  implicit lazy val _reads: Reads[Link] = (
     __.read[LinkF] and
-    (__ \ RELATIONSHIPS \ LINK_HAS_TARGET).lazyReadSeqOrEmpty(Model.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ LINK_HAS_SOURCE).lazyReadHeadNullable(Model.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ LINK_HAS_LINKER).readHeadNullable(Accessor.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ LINK_HAS_TARGET).lazyReadSeqOrEmpty(Model.Converter._reads) and
+    (__ \ RELATIONSHIPS \ LINK_HAS_SOURCE).lazyReadHeadNullable(Model.Converter._reads) and
+    (__ \ RELATIONSHIPS \ LINK_HAS_LINKER).readHeadNullable(Accessor._reads) and
     (__ \ RELATIONSHIPS \ LINK_HAS_BODY).readSeqOrEmpty[AccessPoint] and
-    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor._reads) and
     (__ \ RELATIONSHIPS \ PROMOTED_BY).readSeqOrEmpty[UserProfile] and
     (__ \ RELATIONSHIPS \ DEMOTED_BY).readSeqOrEmpty[UserProfile] and
     (__ \ RELATIONSHIPS \ ENTITY_HAS_LIFECYCLE_EVENT).readHeadNullable[SystemEvent] and
@@ -104,7 +99,7 @@ object Link {
   implicit object LinkResource extends ContentType[Link]  {
     val entityType = EntityType.Link
     val contentType = ContentTypes.Link
-    val restReads: Reads[Link] = metaReads
+    val _reads: Reads[Link] = Link._reads
   }
 
   import LinkF._

--- a/modules/core/src/main/scala/models/MaintenanceEvent.scala
+++ b/modules/core/src/main/scala/models/MaintenanceEvent.scala
@@ -35,7 +35,7 @@ object MaintenanceEventF {
 
   import Entity._
 
-  implicit val maintenanceEventFormat: Format[MaintenanceEventF] = (
+  implicit lazy val maintenanceEventFormat: Format[MaintenanceEventF] = (
     (__ \ TYPE).formatIfEquals(EntityType.MaintenanceEvent) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ DATE).formatHeadOrSingleNullable[String] and
@@ -60,13 +60,13 @@ object MaintenanceEvent {
 
   import Entity.META
 
-  implicit val metaReads: Reads[MaintenanceEvent] = (
+  implicit lazy val _reads: Reads[MaintenanceEvent] = (
     __.read[MaintenanceEventF] and
     (__ \ META).readWithDefault(Json.obj())
   )(MaintenanceEvent.apply _)
 
   implicit object Converter extends Readable[MaintenanceEvent] {
-    val restReads: Reads[MaintenanceEvent] = metaReads
+    val _reads: Reads[MaintenanceEvent] = MaintenanceEvent._reads
   }
 }
 

--- a/modules/core/src/main/scala/models/Model.scala
+++ b/modules/core/src/main/scala/models/Model.scala
@@ -38,26 +38,26 @@ trait Model extends WithId {
 object Model {
 
   val readMap: PartialFunction[EntityType.Value, Reads[Model]] = {
-    case EntityType.Repository => Repository.RepositoryResource.restReads.widen[Model]
-    case EntityType.Country => Country.CountryResource.restReads.widen[Model]
-    case EntityType.DocumentaryUnit => DocumentaryUnit.DocumentaryUnitResource.restReads.widen[Model]
-    case EntityType.Vocabulary => Vocabulary.VocabularyResource.restReads.widen[Model]
-    case EntityType.Concept => Concept.ConceptResource.restReads.widen[Model]
-    case EntityType.HistoricalAgent => HistoricalAgent.HistoricalAgentResource.restReads.widen[Model]
-    case EntityType.AuthoritativeSet => AuthoritativeSet.AuthoritativeSetResource.restReads.widen[Model]
-    case EntityType.SystemEvent => SystemEvent.SystemEventResource.restReads.widen[Model]
-    case EntityType.Group => Group.GroupResource.restReads.widen[Model]
-    case EntityType.UserProfile => UserProfile.UserProfileResource.restReads.widen[Model]
-    case EntityType.Link => Link.LinkResource.restReads.widen[Model]
-    case EntityType.Annotation => Annotation.AnnotationResource.restReads.widen[Model]
-    case EntityType.PermissionGrant => PermissionGrant.PermissionGrantResource.restReads.widen[Model]
-    case EntityType.ContentType => DataContentType.Converter.restReads.widen[Model]
-    case EntityType.AccessPoint => AccessPoint.Converter.restReads.widen[Model]
-    case EntityType.VirtualUnit => VirtualUnit.VirtualUnitResource.restReads.widen[Model]
+    case EntityType.Repository => Repository.RepositoryResource._reads.widen[Model]
+    case EntityType.Country => Country.CountryResource._reads.widen[Model]
+    case EntityType.DocumentaryUnit => DocumentaryUnit.DocumentaryUnitResource._reads.widen[Model]
+    case EntityType.Vocabulary => Vocabulary.VocabularyResource._reads.widen[Model]
+    case EntityType.Concept => Concept.ConceptResource._reads.widen[Model]
+    case EntityType.HistoricalAgent => HistoricalAgent.HistoricalAgentResource._reads.widen[Model]
+    case EntityType.AuthoritativeSet => AuthoritativeSet.AuthoritativeSetResource._reads.widen[Model]
+    case EntityType.SystemEvent => SystemEvent.SystemEventResource._reads.widen[Model]
+    case EntityType.Group => Group.GroupResource._reads.widen[Model]
+    case EntityType.UserProfile => UserProfile.UserProfileResource._reads.widen[Model]
+    case EntityType.Link => Link.LinkResource._reads.widen[Model]
+    case EntityType.Annotation => Annotation.AnnotationResource._reads.widen[Model]
+    case EntityType.PermissionGrant => PermissionGrant.PermissionGrantResource._reads.widen[Model]
+    case EntityType.ContentType => DataContentType.Converter._reads.widen[Model]
+    case EntityType.AccessPoint => AccessPoint.Converter._reads.widen[Model]
+    case EntityType.VirtualUnit => VirtualUnit.VirtualUnitResource._reads.widen[Model]
   }
 
   implicit object Converter extends Readable[Model] {
-    implicit val restReads: Reads[Model] = Reads[Model] { json =>
+    implicit val _reads: Reads[Model] = Reads[Model] { json =>
       // Sniff the type...
       val et = (json \ Entity.TYPE).as(EnumUtils.enumReads(EntityType))
       readMap.lift(et).map { reads =>
@@ -76,6 +76,6 @@ object Model {
     */
   def resourceFor(t: EntityType.Value): Resource[Model] = new Resource[Model] {
     def entityType: EntityType.Value = t
-    val restReads: Reads[Model] = Converter.restReads
+    val _reads: Reads[Model] = Converter._reads
   }
 }

--- a/modules/core/src/main/scala/models/PermissionGrant.scala
+++ b/modules/core/src/main/scala/models/PermissionGrant.scala
@@ -26,7 +26,7 @@ object PermissionGrantF {
   )(PermissionGrantF.apply _)
 
   implicit object Converter extends Readable[PermissionGrantF] {
-    val restReads: Reads[PermissionGrantF] = permissionGrantReads
+    val _reads: Reads[PermissionGrantF] = permissionGrantReads
   }
 }
 
@@ -43,17 +43,17 @@ object PermissionGrant {
   import eu.ehri.project.definitions.Ontology._
   import play.api.libs.functional.syntax._
 
-  implicit val metaReads: Reads[PermissionGrant] = (
+  implicit lazy val _reads: Reads[PermissionGrant] = (
     __.read(permissionGrantReads) and
-    (__ \ RELATIONSHIPS \ PERMISSION_GRANT_HAS_SUBJECT).lazyReadHeadNullable(Accessor.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ PERMISSION_GRANT_HAS_TARGET).lazyReadSeqOrEmpty(Model.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ PERMISSION_GRANT_HAS_SCOPE).lazyReadHeadNullable(Model.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ PERMISSION_GRANT_HAS_GRANTEE).readHeadNullable[UserProfile](UserProfile.UserProfileResource.restReads) and
+    (__ \ RELATIONSHIPS \ PERMISSION_GRANT_HAS_SUBJECT).lazyReadHeadNullable(Accessor._reads) and
+    (__ \ RELATIONSHIPS \ PERMISSION_GRANT_HAS_TARGET).lazyReadSeqOrEmpty(Model.Converter._reads) and
+    (__ \ RELATIONSHIPS \ PERMISSION_GRANT_HAS_SCOPE).lazyReadHeadNullable(Model.Converter._reads) and
+    (__ \ RELATIONSHIPS \ PERMISSION_GRANT_HAS_GRANTEE).readHeadNullable[UserProfile](UserProfile.UserProfileResource._reads) and
     (__ \ META).readWithDefault(Json.obj())
   )(PermissionGrant.apply _)
 
   implicit object PermissionGrantResource extends Resource[PermissionGrant]  {
-    implicit val restReads: Reads[PermissionGrant] = metaReads
+    implicit val _reads: Reads[PermissionGrant] = PermissionGrant._reads
     val entityType = EntityType.PermissionGrant
   }
 }

--- a/modules/core/src/main/scala/models/Repository.scala
+++ b/modules/core/src/main/scala/models/Repository.scala
@@ -28,7 +28,7 @@ object RepositoryF {
   import Entity._
   import Ontology._
 
-  implicit val repositoryFormat: Format[RepositoryF] = (
+  implicit lazy val repositoryFormat: Format[RepositoryF] = (
     (__ \ TYPE).formatIfEquals(EntityType.Repository) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ IDENTIFIER).format[String] and
@@ -42,7 +42,7 @@ object RepositoryF {
   )(RepositoryF.apply, unlift(RepositoryF.unapply))
 
   implicit object Converter extends Writable[RepositoryF] {
-    val restFormat: Format[RepositoryF] = repositoryFormat
+    val _format: Format[RepositoryF] = repositoryFormat
   }
 }
 
@@ -111,10 +111,10 @@ object Repository {
   import Ontology._
   import utils.EnumUtils.enumMapping
 
-  implicit lazy val metaReads: Reads[Repository] = (
+  implicit lazy val _reads: Reads[Repository] = (
     __.read[RepositoryF](repositoryFormat) and
     (__ \ RELATIONSHIPS \ REPOSITORY_HAS_COUNTRY).readHeadNullable[Country] and
-    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor._reads) and
     (__ \ RELATIONSHIPS \ ENTITY_HAS_LIFECYCLE_EVENT).readHeadNullable[SystemEvent] and
     (__ \ META).readWithDefault(Json.obj())
   )(Repository.apply _)
@@ -122,7 +122,7 @@ object Repository {
   implicit object RepositoryResource extends ContentType[Repository]  {
     val entityType = EntityType.Repository
     val contentType = ContentTypes.Repository
-    val restReads: Reads[Repository] = metaReads
+    val _reads: Reads[Repository] = Repository._reads
   }
 
   /**

--- a/modules/core/src/main/scala/models/RepositoryDescription.scala
+++ b/modules/core/src/main/scala/models/RepositoryDescription.scala
@@ -48,7 +48,7 @@ object RepositoryDescriptionF {
   import Isdiah._
   import eu.ehri.project.definitions.Ontology._
 
-  implicit val repositoryDescriptionFormat: Format[RepositoryDescriptionF] = (
+  implicit lazy val repositoryDescriptionFormat: Format[RepositoryDescriptionF] = (
     (__ \ TYPE).formatIfEquals(EntityType.RepositoryDescription) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ LANG_CODE).format[String] and
@@ -92,7 +92,7 @@ object RepositoryDescriptionF {
   )(RepositoryDescriptionF.apply, unlift(RepositoryDescriptionF.unapply))
 
   implicit object Converter extends Writable[RepositoryDescriptionF] {
-    val restFormat: Format[RepositoryDescriptionF] = repositoryDescriptionFormat
+    val _format: Format[RepositoryDescriptionF] = repositoryDescriptionFormat
   }
 }
 

--- a/modules/core/src/main/scala/models/SystemEvent.scala
+++ b/modules/core/src/main/scala/models/SystemEvent.scala
@@ -18,7 +18,7 @@ object SystemEventF {
   import SystemEventF.{EVENT_TYPE => EVENT_PROP}
   import Entity._
 
-  implicit val systemEventFormat: Format[SystemEventF] = (
+  implicit lazy val systemEventFormat: Format[SystemEventF] = (
     (__ \ TYPE).formatIfEquals(EntityType.SystemEvent) and
     (__ \ ID).formatNullable[String] and
     // NB: Default Joda DateTime format is less flexible then
@@ -32,7 +32,7 @@ object SystemEventF {
   )(SystemEventF.apply, unlift(SystemEventF.unapply))
 
   implicit object Converter extends Readable[SystemEventF] {
-    val restReads: Format[SystemEventF] = systemEventFormat
+    val _reads: Format[SystemEventF] = systemEventFormat
   }
 }
 
@@ -52,19 +52,19 @@ object SystemEvent {
   import Entity._
   import eu.ehri.project.definitions.Ontology._
 
-  implicit val metaReads: Reads[SystemEvent] = (
+  implicit lazy val _reads: Reads[SystemEvent] = (
     __.read[SystemEventF] and
-    (__ \ RELATIONSHIPS \ EVENT_HAS_SCOPE).lazyReadHeadNullable(Model.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ EVENT_HAS_FIRST_SUBJECT).lazyReadHeadNullable(Model.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ EVENT_HAS_ACTIONER).lazyReadHeadNullable(Accessor.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ VERSION_HAS_EVENT).readHeadNullable(Version.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ EVENT_HAS_SCOPE).lazyReadHeadNullable(Model.Converter._reads) and
+    (__ \ RELATIONSHIPS \ EVENT_HAS_FIRST_SUBJECT).lazyReadHeadNullable(Model.Converter._reads) and
+    (__ \ RELATIONSHIPS \ EVENT_HAS_ACTIONER).lazyReadHeadNullable(Accessor._reads) and
+    (__ \ RELATIONSHIPS \ VERSION_HAS_EVENT).readHeadNullable(Version.Converter._reads) and
     (__ \ META).readWithDefault(Json.obj())
   )(SystemEvent.apply _)
 
   implicit object SystemEventResource extends ContentType[SystemEvent]  {
     val entityType = EntityType.SystemEvent
     val contentType = ContentTypes.SystemEvent
-    val restReads: Reads[SystemEvent] = metaReads
+    val _reads: Reads[SystemEvent] = SystemEvent._reads
   }
 }
 

--- a/modules/core/src/main/scala/models/Version.scala
+++ b/modules/core/src/main/scala/models/Version.scala
@@ -18,7 +18,7 @@ case class VersionF(
   def entity: Option[Model] = try {
     for {
       data <- itemData
-      item <- Json.parse(data).validate(Model.Converter.restReads).asOpt
+      item <- Json.parse(data).validate(Model.Converter._reads).asOpt
     } yield item
   } catch {
     case _: JsonParseException => None
@@ -29,7 +29,7 @@ object VersionF {
   import Entity._
   import eu.ehri.project.definitions.Ontology._
 
-  implicit val reads: Reads[VersionF] = (
+  implicit val _reads: Reads[VersionF] = (
     (__ \ TYPE).readIfEquals(EntityType.Version) and
     (__ \ ID).readNullable[String] and
     (__ \ DATA \ VERSION_ENTITY_CLASS).read[EntityType.Value] and
@@ -38,7 +38,7 @@ object VersionF {
   )(VersionF.apply _)
 
   implicit object Converter extends Readable[VersionF] {
-    val restReads: Reads[VersionF] = reads
+    val _reads: Reads[VersionF] = VersionF._reads
   }
 }
 
@@ -55,13 +55,13 @@ object Version {
   import Entity._
   import eu.ehri.project.definitions.Ontology._
 
-  implicit val metaReads: Reads[Version] = (
+  implicit lazy val _reads: Reads[Version] = (
     __.read[VersionF] and
     (__ \ RELATIONSHIPS \ VERSION_HAS_EVENT).readHeadNullable[SystemEvent] and
     (__ \ META).readWithDefault(Json.obj())
   )(Version.apply _)
 
   implicit object Converter extends Readable[Version] {
-    val restReads: Reads[Version] = metaReads
+    val _reads: Reads[Version] = Version._reads
   }
 }

--- a/modules/core/src/main/scala/models/VirtualUnit.scala
+++ b/modules/core/src/main/scala/models/VirtualUnit.scala
@@ -18,7 +18,7 @@ object VirtualUnitF {
   import Entity._
   import Ontology._
 
-  implicit val virtualUnitFormat: Format[VirtualUnitF] = (
+  implicit lazy val virtualUnitFormat: Format[VirtualUnitF] = (
     (__ \ TYPE).formatIfEquals(EntityType.VirtualUnit) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ IDENTIFIER).format[String] and
@@ -26,7 +26,7 @@ object VirtualUnitF {
   )(VirtualUnitF.apply, unlift(VirtualUnitF.unapply))
 
   implicit object Converter extends Writable[VirtualUnitF] {
-    val restFormat: Format[VirtualUnitF] = virtualUnitFormat
+    val _format: Format[VirtualUnitF] = virtualUnitFormat
   }
 }
 
@@ -52,13 +52,13 @@ object VirtualUnit {
   import models.VirtualUnitF._
   import Ontology._
 
-  implicit val metaReads: Reads[VirtualUnit] = (
+  implicit lazy val _reads: Reads[VirtualUnit] = (
     __.read[VirtualUnitF](virtualUnitFormat) and
-    (__ \ RELATIONSHIPS \ VC_INCLUDES_UNIT).readSeqOrEmpty(DocumentaryUnit.DocumentaryUnitResource.restReads) and
-    (__ \ RELATIONSHIPS \ VC_HAS_AUTHOR).readHeadNullable(Accessor.Converter.restReads) and
-    (__ \ RELATIONSHIPS \ VC_IS_PART_OF).lazyReadHeadNullable(metaReads) and
+    (__ \ RELATIONSHIPS \ VC_INCLUDES_UNIT).readSeqOrEmpty(DocumentaryUnit.DocumentaryUnitResource._reads) and
+    (__ \ RELATIONSHIPS \ VC_HAS_AUTHOR).readHeadNullable(Accessor._reads) and
+    (__ \ RELATIONSHIPS \ VC_IS_PART_OF).lazyReadHeadNullable(VirtualUnit._reads) and
     (__ \ RELATIONSHIPS \ DOC_IS_CHILD_OF).readHeadNullable[Repository] and
-    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor._reads) and
     (__ \ RELATIONSHIPS \ ENTITY_HAS_LIFECYCLE_EVENT).readHeadNullable[SystemEvent] and
     (__ \ META).readWithDefault(Json.obj())
   )(VirtualUnit.apply _)
@@ -67,7 +67,7 @@ object VirtualUnit {
   implicit object VirtualUnitResource extends ContentType[VirtualUnit]  {
     val entityType = EntityType.VirtualUnit
     val contentType = ContentTypes.VirtualUnit
-    implicit val restReads: Reads[VirtualUnit] = metaReads
+    implicit val _reads: Reads[VirtualUnit] = VirtualUnit._reads
 
     /**
      * When displaying doc units we need the

--- a/modules/core/src/main/scala/models/Vocabulary.scala
+++ b/modules/core/src/main/scala/models/Vocabulary.scala
@@ -23,7 +23,7 @@ object VocabularyF {
 
   import Entity._
 
-  implicit val vocabularyFormat: Format[VocabularyF] = (
+  implicit lazy val vocabularyFormat: Format[VocabularyF] = (
     (__ \ TYPE).formatIfEquals(EntityType.Vocabulary) and
     (__ \ ID).formatNullable[String] and
     (__ \ DATA \ IDENTIFIER).format[String] and
@@ -33,7 +33,7 @@ object VocabularyF {
   )(VocabularyF.apply, unlift(VocabularyF.unapply))
 
   implicit object Converter extends Writable[VocabularyF] {
-    lazy val restFormat: Format[VocabularyF] = vocabularyFormat
+    lazy val _format: Format[VocabularyF] = vocabularyFormat
   }
 }
 
@@ -53,11 +53,11 @@ object Vocabulary {
   import Ontology._
   import VocabularyF._
 
-  private implicit val systemEventReads: Reads[models.SystemEvent] = SystemEvent.SystemEventResource.restReads
+  private implicit val systemEventReads: Reads[models.SystemEvent] = SystemEvent.SystemEventResource._reads
 
-  implicit val metaReads: Reads[Vocabulary] = (
+  implicit lazy val _reads: Reads[Vocabulary] = (
     __.read[VocabularyF] and
-    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor.Converter.restReads) and
+    (__ \ RELATIONSHIPS \ IS_ACCESSIBLE_TO).lazyReadSeqOrEmpty(Accessor._reads) and
     (__ \ RELATIONSHIPS \ PROMOTED_BY).readSeqOrEmpty[UserProfile] and
     (__ \ RELATIONSHIPS \ DEMOTED_BY).readSeqOrEmpty[UserProfile] and
     (__ \ RELATIONSHIPS \ ENTITY_HAS_LIFECYCLE_EVENT).readHeadNullable[SystemEvent] and
@@ -67,7 +67,7 @@ object Vocabulary {
   implicit object VocabularyResource extends ContentType[Vocabulary]  {
     val entityType = EntityType.Vocabulary
     val contentType = ContentTypes.Vocabulary
-    val restReads: Reads[Vocabulary] = metaReads
+    val _reads: Reads[Vocabulary] = Vocabulary._reads
   }
 
   val form = Form(

--- a/modules/core/src/main/scala/services/search/SearchParams.scala
+++ b/modules/core/src/main/scala/services/search/SearchParams.scala
@@ -82,7 +82,7 @@ object BoundingBox {
     }
   }
 
-  implicit val writes: Writes[BoundingBox] = Json.writes[BoundingBox]
+  implicit val _writes: Writes[BoundingBox] = Json.writes[BoundingBox]
 
   implicit def bboxQueryBinder(implicit stringBinder: QueryStringBindable[String]): QueryStringBindable[BoundingBox] =
     new QueryStringBindable[BoundingBox] {
@@ -118,7 +118,7 @@ object LatLng {
     }
   }
 
-  implicit val writes: Writes[LatLng] = Json.writes[LatLng]
+  implicit val _writes: Writes[LatLng] = Json.writes[LatLng]
 
   implicit def latLngQueryBinder(implicit stringBinder: QueryStringBindable[String]): QueryStringBindable[LatLng] =
     new QueryStringBindable[LatLng] {
@@ -163,7 +163,7 @@ object SearchParams {
 
   def empty: SearchParams = SearchParams()
 
-  implicit val writes: Writes[SearchParams] = Json.writes[SearchParams]
+  implicit val _writes: Writes[SearchParams] = Json.writes[SearchParams]
 
   implicit def _queryBinder(
     implicit seqStrBinder: QueryStringBindable[Seq[String]]): QueryStringBindable[SearchParams] with NamespaceExtractor = new QueryStringBindable[SearchParams] with NamespaceExtractor {

--- a/modules/core/src/main/scala/services/search/package.scala
+++ b/modules/core/src/main/scala/services/search/package.scala
@@ -12,7 +12,7 @@ package object search {
     val Name = Value("name")
     val Count = Value("count")
 
-    implicit val format: Format[FacetQuerySort.Value] = EnumUtils.enumFormat(FacetQuerySort)
+    implicit val _format: Format[FacetQuerySort.Value] = EnumUtils.enumFormat(FacetQuerySort)
   }
 
   /**

--- a/modules/portal/app/controllers/portal/users/UserProfiles.scala
+++ b/modules/portal/app/controllers/portal/users/UserProfiles.scala
@@ -75,7 +75,7 @@ case class UserProfiles @Inject()(
       item.toStringLang,
       views.Helpers.linkTo(item).absoluteURL(conf.https)
     )
-    implicit val writes: OWrites[ExportWatchItem] = Json.writes[ExportWatchItem]
+    implicit val _writes: OWrites[ExportWatchItem] = Json.writes[ExportWatchItem]
   }
 
   def activity(params: SystemEventParams, range: RangeParams): Action[AnyContent] = WithUserAction.async { implicit request =>
@@ -150,7 +150,7 @@ case class UserProfiles @Inject()(
         .map(t => views.Helpers.linkTo(t).absoluteURL(conf.https) + "#" + annotation.id)
     )
     import play.api.libs.json._
-    implicit val writes: OWrites[ExportAnnotation] = Json.writes[ExportAnnotation]
+    implicit val _writes: OWrites[ExportAnnotation] = Json.writes[ExportAnnotation]
   }
 
   def annotations(format: DataFormat.Value = DataFormat.Html, params: SearchParams, paging: PageParams): Action[AnyContent] = WithUserAction.async { implicit request =>

--- a/modules/portal/app/cookies/SessionPrefs.scala
+++ b/modules/portal/app/cookies/SessionPrefs.scala
@@ -26,19 +26,19 @@ object SessionPrefs {
   import play.api.libs.functional.syntax._
   import play.api.libs.json._
 
-  implicit val reads: Reads[SessionPrefs] = (
+  implicit val _reads: Reads[SessionPrefs] = (
     (__ \ SHOW_USER_CONTENT).readNullable[Boolean].map(_.getOrElse(true)) and
     (__ \ DEFAULT_LANGUAGES).readSeqOrEmpty[String] and
     (__ \ RECENT_ITEMS).readSeqOrEmpty[String]
   )(SessionPrefs.apply _)
 
-  implicit val writes: Writes[SessionPrefs] = (
+  implicit val _writes: Writes[SessionPrefs] = (
     (__ \ SHOW_USER_CONTENT).write[Boolean] and
     (__ \ DEFAULT_LANGUAGES).writeSeqOrEmpty[String] and
     (__ \ RECENT_ITEMS).writeSeqOrEmpty[String]
   )(unlift(SessionPrefs.unapply))
 
-  implicit val fmt: Format[SessionPrefs] = Format(reads, writes)
+  implicit val fmt: Format[SessionPrefs] = Format(_reads, _writes)
 
   /**
    * Update the session preferences from form values in the

--- a/modules/portal/app/models/FeedbackContext.scala
+++ b/modules/portal/app/models/FeedbackContext.scala
@@ -17,5 +17,5 @@ object FeedbackContext {
     headers = request.headers.toSimpleMap
   )
 
-  implicit val format: Format[FeedbackContext] = Json.format[FeedbackContext]
+  implicit val _format: Format[FeedbackContext] = Json.format[FeedbackContext]
 }

--- a/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrServerError.scala
+++ b/modules/solr/src/main/scala/eu/ehri/project/search/solr/SolrServerError.scala
@@ -6,7 +6,7 @@ import play.api.libs.functional.syntax._
 case class SolrServerError(code: Int, msg: String) extends RuntimeException(msg)
 
 private object SolrServerError {
-  implicit val reads: Reads[SolrServerError] = (
+  implicit val _reads: Reads[SolrServerError] = (
     (__ \ "error"\ "code").read[Int] and
     (__ \ "error" \ "msg").read[String]
   )(SolrServerError.apply _)

--- a/test/integration/admin/ApiSpec.scala
+++ b/test/integration/admin/ApiSpec.scala
@@ -84,7 +84,7 @@ class ApiSpec extends IntegrationTestRunner {
   "Annotation JSON endpoints" should {
     "allow creating annotations" in new ITestApp {
       val json = Json.toJson(new AnnotationF(id = None, body = "Hello, world!"))(
-        AnnotationF.Converter.clientFormat)
+        AnnotationF.Converter._clientFormat)
       val cr = FakeRequest(controllers.annotation.routes.Annotations.createAnnotationJsonPost("c1"))
         .withUser(privilegedUser).withCsrf.callWith(json)
       status(cr) must equalTo(CREATED)

--- a/test/services/data/WsDataServiceSpec.scala
+++ b/test/services/data/WsDataServiceSpec.scala
@@ -41,7 +41,7 @@ class WsDataServiceSpec extends IntegrationTestRunner {
       def entityType: EntityType.Value = EntityType.DocumentaryUnit
       import play.api.libs.functional.syntax._
       import play.api.libs.json._
-      val restReads: Reads[TestResource] = (
+      val _reads: Reads[TestResource] = (
         (__ \ Entity.ID).read[String] and
           (__ \ Entity.DATA).read[JsObject]
         )(TestResource.apply _)
@@ -215,10 +215,10 @@ class WsDataServiceSpec extends IntegrationTestRunner {
         import play.api.libs.functional.syntax._
         import play.api.libs.json._
         val badDeserializer: ContentType[UserProfile] = new ContentType[UserProfile] {
-          val restReads: Reads[UserProfile] = (
+          val _reads: Reads[UserProfile] = (
             __.read[UserProfileF] and
-            __.lazyReadSeqOrEmpty(Group.GroupResource.restReads) and
-            __.lazyReadSeqOrEmpty(Accessor.Converter.restReads) and
+            __.lazyReadSeqOrEmpty(Group.GroupResource._reads) and
+            __.lazyReadSeqOrEmpty(Accessor.Converter._reads) and
             __.readHeadNullable[SystemEvent] and
             __.read[JsObject]
           )(UserProfile.quickApply _)


### PR DESCRIPTION
For some reason, after 10 or so years, some test code started throwing NPEs after an unrelated changeset due to order-of-initial- isation issues in the JSON format objects. Where these are not macro-generated they're now `lazy vals`. Also rename a ton of the other reads/writes/format objects for consistency, with a leading '_' to make it clear they're auxilliary, often macro-generated companion object implicits.