### PR TITLE
Update to Play 3.0, switch Akka/Alpakka to Pekko/Pekko Connectors

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -2,6 +2,8 @@
 --ignore-dir=target
 --ignore-dir=miniodata
 --ignore-dir=DB
+--ignore-dir=.idea
+--ignore-file=match:application.log
 
 # Add a type for messages, messages.en etc files
 --type-set=messages:match:/messages(\.[a-z]{2})?/

--- a/app/guice/SearchModule.scala
+++ b/app/guice/SearchModule.scala
@@ -19,7 +19,7 @@ class SearchModule extends AbstractModule {
     bind(classOf[Index]).toProvider(classOf[SolrIndexProvider])
     bind(classOf[ResponseParser]).to(classOf[SolrJsonResponseParser])
     bind(classOf[QueryBuilder]).to(classOf[SolrQueryBuilder])
-    bind(classOf[SearchIndexMediator]).to(classOf[AkkaStreamsIndexMediator])
+    bind(classOf[SearchIndexMediator]).to(classOf[PekkoStreamsIndexMediator])
     bind(classOf[SearchEngine]).to(classOf[SolrSearchEngine])
     bind(classOf[SearchItemResolver]).to(classOf[GidSearchResolver])
   }

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import com.typesafe.sbt.packager.SettingsHelper._
 import com.typesafe.sbt.uglify.Import._
 import com.typesafe.sbt.web.SbtWeb.autoImport._
 import net.ground5hark.sbt.concat.Import._
-import play.core.PlayVersion.{akkaHttpVersion, akkaVersion}
+import play.core.PlayVersion.{pekkoHttpVersion, pekkoVersion}
 import play.sbt.PlayImport._
 import play.sbt.routes.RoutesKeys._
 import play.twirl.sbt.Import.TwirlKeys.templateImports
@@ -22,7 +22,7 @@ val appName = "docview"
 
 val backendVersion = "0.15.1"
 val dataConverterVersion = "1.1.15"
-val alpakkaVersion = "3.0.4"
+val pekkoConnectorsVersion = "1.0.2"
 
 // This prevents a library version incompatibility error between
 // scala-xml 1.3.0 and 2.2.0 (which are in fact binary compatible.)
@@ -39,10 +39,10 @@ val backendDependencies = Seq(
   "org.apache.commons" % "commons-text" % "1.4",
 
   // Push JSON parser used for stream parsing...
-  "com.lightbend.akka" %% "akka-stream-alpakka-json-streaming" % alpakkaVersion,
+  "org.apache.pekko" %% "pekko-connectors-json-streaming" % pekkoConnectorsVersion,
 
   // CSV parser/writer...
-  "com.lightbend.akka" %% "akka-stream-alpakka-csv" % alpakkaVersion,
+  "org.apache.pekko" %% "pekko-connectors-csv" % pekkoConnectorsVersion,
 
   // IRI helper...
   "org.apache.jena" % "jena-iri" % "3.9.0",
@@ -61,9 +61,9 @@ val coreDependencies = backendDependencies ++ Seq(
   // Force Scala XML version
   "org.scala-lang.modules" %% "scala-xml" % "2.2.0",
 
-  // Force Akka HTTP version
-  "com.typesafe.akka" %% "akka-http"   % akkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-xml"   % akkaHttpVersion,
+  // Force Pekko HTTP version
+  "org.apache.pekko" %% "pekko-http"   % pekkoHttpVersion,
+  "org.apache.pekko" %% "pekko-http-xml"   % pekkoHttpVersion,
 
   // Anorm DB lib
   "org.playframework.anorm" %% "anorm" % "2.7.0",
@@ -109,13 +109,13 @@ val portalDependencies = Seq(
   "eu.ehri-project" % "index-data-converter" % dataConverterVersion exclude("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"),
 
   // S3 Upload plugin
-  "com.lightbend.akka" %% "akka-stream-alpakka-s3" % alpakkaVersion,
+  "org.apache.pekko" %% "pekko-connectors-s3" % pekkoConnectorsVersion,
 
   // S3 sdk
-  "software.amazon.awssdk" % "s3" % "2.15.63",
+  "software.amazon.awssdk" % "s3" % "2.17.113",
 
   // AWS Location sdk
-  "software.amazon.awssdk" % "location" % "2.15.63",
+  "software.amazon.awssdk" % "location" % "2.17.113",
 )
 
 val adminDependencies = Seq(
@@ -123,15 +123,15 @@ val adminDependencies = Seq(
   "org.relaxng" % "jing" % "20181222",
 
   // XML parsing
-  "com.lightbend.akka" %% "akka-stream-alpakka-xml" % alpakkaVersion,
-  "com.lightbend.akka" %% "akka-stream-alpakka-text" % alpakkaVersion,
+  "org.apache.pekko" %% "pekko-connectors-xml" % pekkoConnectorsVersion,
+  "org.apache.pekko" %% "pekko-connectors-text" % pekkoConnectorsVersion,
 )
 
 val testDependencies = Seq(
   specs2 % Test,
 
   // Used for testing JSON stream parsing...
-  "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test
+  "org.apache.pekko" %% "pekko-stream-testkit" % pekkoVersion % Test
 )
 
 val additionalResolvers = Resolver.sonatypeOssRepos("releases") ++ Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -164,8 +164,8 @@ contexts {
   }
 }
 
-# Akka S3 defaults
-alpakka.s3.aws {
+# Pekko S3 defaults
+pekko.connectors.s3.aws {
     path-style-access: false
     credentials.provider: static
     region.provider: static
@@ -195,9 +195,9 @@ storage {
 
     # Classifier is basically the bucket name on AWS S3.
     # Config refers to a block of configuration matching
-    # the Alpakka reference.conf:
-    # https://github.com/akka/alpakka/blob/master/s3/src/main/resources/reference.conf
-    # Make sure this is defined, i.e. config = ${alpakka.s3}
+    # the Pekko connectors reference.conf:
+    # https://github.com/apache/pekko-connectors/blob/main/s3/src/main/resources/reference.conf
+    # Make sure this is defined, i.e. config = ${pekko.connectors.s3}
     portal {
         classifier = disk-a
         config = {}
@@ -444,9 +444,9 @@ ehri {
 }
 
 # Ensure indexer does not idle timeout
-akka.http.host-connection-pool.client.idle-timeout = 5 minutes
-akka.http.client.idle-timeout = 5 minutes
-akka.http.server.idle-timeout = 5 minutes
+pekko.http.host-connection-pool.client.idle-timeout = 5 minutes
+pekko.http.client.idle-timeout = 5 minutes
+pekko.http.server.idle-timeout = 5 minutes
 
 # Ensure websocket connections do not idle timeout
 play.server.websocket.periodic-keep-alive-max-idle = 10 seconds

--- a/conf/aws.conf.example
+++ b/conf/aws.conf.example
@@ -1,4 +1,4 @@
-akka.stream.alpakka.s3.aws {
+pekko.stream.connectors.s3.aws {
     # e.g. "eu-west-1"
     region.default-region=
 

--- a/conf/logback-play-dev.xml
+++ b/conf/logback-play-dev.xml
@@ -33,7 +33,7 @@
     <appender-ref ref="STDOUT" />
   </appender>
 
-  <logger name="akka" level="WARN" />
+  <logger name="pekko" level="WARN" />
   <logger name="play" level="INFO" />
   
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
@@ -76,7 +76,7 @@
   <!-- Uncomment to see mailer debug, when play.mailer.debug=yes in configuration -->
   <!--  <logger name="play.mailer" level="DEBUG" />-->
   
-  <!--<logger name="akka.stream" level="TRACE" />-->
+  <!--<logger name="pekko.stream" level="TRACE" />-->
 
   <!-- Uncomment to show LOTS of debug info about HTTP calls -->
   <!-- <logger name="play.shaded.ahc.org.asynchttpclient" level="DEBUG" />-->

--- a/modules/admin/app/actors/Ticker.scala
+++ b/modules/admin/app/actors/Ticker.scala
@@ -1,7 +1,7 @@
 package actors
 
 import actors.Ticker.Tick
-import akka.actor.{Actor, ActorRef, Cancellable}
+import org.apache.pekko.actor.{Actor, ActorRef, Cancellable}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.{DurationInt, FiniteDuration}

--- a/modules/admin/app/actors/cleanup/CleanupRunner.scala
+++ b/modules/admin/app/actors/cleanup/CleanupRunner.scala
@@ -1,7 +1,7 @@
 package actors.cleanup
 
 import actors.Ticker
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
 import play.api.Configuration
 import services.data.{DataService, EventForwarder}
 import services.ingest.{Cleanup, ImportLogService, IngestService}
@@ -45,7 +45,7 @@ case class CleanupRunner(
 )(implicit config: Configuration, ec: ExecutionContext) extends Actor with ActorLogging {
 
   import CleanupRunner._
-  import akka.pattern._
+  import org.apache.pekko.pattern._
 
   private val batchSize = config.get[Int]("ehri.admin.bulkOperations.maxDeletions")
 

--- a/modules/admin/app/actors/cleanup/CleanupRunnerManager.scala
+++ b/modules/admin/app/actors/cleanup/CleanupRunnerManager.scala
@@ -3,7 +3,7 @@ package actors.cleanup
 import actors.LongRunningJob.Cancel
 import actors.Ticker.Tick
 import actors.cleanup.CleanupRunner.CleanupJob
-import akka.actor.{Actor, ActorContext, ActorLogging, ActorRef, Terminated}
+import org.apache.pekko.actor.{Actor, ActorContext, ActorLogging, ActorRef, Terminated}
 import play.api.i18n.Messages
 import services.ingest.Cleanup
 import utils.WebsocketConstants

--- a/modules/admin/app/actors/datamodel/Auditor.scala
+++ b/modules/admin/app/actors/datamodel/Auditor.scala
@@ -2,8 +2,8 @@ package actors.datamodel
 
 import actors.LongRunningJob.Cancel
 import actors.datamodel.AuditorManager.{AuditTask, AuditorJob}
-import akka.actor.{Actor, ActorLogging, ActorRef}
-import akka.pattern._
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef}
+import org.apache.pekko.pattern._
 import models._
 import services.data.DataUser
 import services.search._

--- a/modules/admin/app/actors/datamodel/AuditorManager.scala
+++ b/modules/admin/app/actors/datamodel/AuditorManager.scala
@@ -3,8 +3,8 @@ package actors.datamodel
 import actors.LongRunningJob.Cancel
 import actors.datamodel.Auditor.{Cancelled, CheckBatch, Checked, Completed, RunAudit}
 import actors.datamodel.AuditorManager.{AuditorJob, ItemResult}
-import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
+import org.apache.pekko.actor.SupervisorStrategy.Stop
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
 import models._
 import play.api.Configuration
 import play.api.i18n.Messages

--- a/modules/admin/app/actors/harvesting/HarvesterManager.scala
+++ b/modules/admin/app/actors/harvesting/HarvesterManager.scala
@@ -2,9 +2,9 @@ package actors.harvesting
 
 import actors.LongRunningJob.Cancel
 import actors.harvesting.Harvester.HarvestJob
-import akka.actor.Status.Failure
-import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{Actor, ActorContext, ActorLogging, ActorRef, OneForOneStrategy, SupervisorStrategy, Terminated}
+import org.apache.pekko.actor.Status.Failure
+import org.apache.pekko.actor.SupervisorStrategy.Stop
+import org.apache.pekko.actor.{Actor, ActorContext, ActorLogging, ActorRef, OneForOneStrategy, SupervisorStrategy, Terminated}
 import models.UserProfile
 import play.api.i18n.Messages
 import services.harvesting.{HarvestEventHandle, HarvestEventService, OaiPmhError}
@@ -26,7 +26,7 @@ case class HarvesterManager(job: HarvestJob, init: ActorContext => ActorRef, eve
   import Harvester._
   import HarvesterManager._
   import OaiPmhHarvester._
-  import akka.pattern.pipe
+  import org.apache.pekko.pattern.pipe
 
   override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() {
     case e =>

--- a/modules/admin/app/actors/harvesting/OaiPmhHarvester.scala
+++ b/modules/admin/app/actors/harvesting/OaiPmhHarvester.scala
@@ -2,8 +2,8 @@ package actors.harvesting
 
 import actors.LongRunningJob.Cancel
 import actors.harvesting.Harvester.HarvestJob
-import akka.actor.Status.Failure
-import akka.actor.{Actor, ActorLogging, ActorRef}
+import org.apache.pekko.actor.Status.Failure
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef}
 import models.{OaiPmhConfig, UserProfile}
 import services.harvesting.{OaiPmhClient, OaiPmhError}
 import services.storage.FileStorage
@@ -55,7 +55,7 @@ case class OaiPmhHarvester (client: OaiPmhClient, storage: FileStorage)(
     implicit userOpt: Option[UserProfile], ec: ExecutionContext) extends Actor with ActorLogging {
   import Harvester._
   import OaiPmhHarvester._
-  import akka.pattern.pipe
+  import org.apache.pekko.pattern.pipe
 
   override def postStop(): Unit = {
     log.debug("Harvester shut down")

--- a/modules/admin/app/actors/harvesting/ResourceSyncHarvester.scala
+++ b/modules/admin/app/actors/harvesting/ResourceSyncHarvester.scala
@@ -2,9 +2,9 @@ package actors.harvesting
 
 import actors.LongRunningJob.Cancel
 import actors.harvesting.Harvester.HarvestJob
-import akka.actor.Status.Failure
-import akka.actor.{Actor, ActorLogging, ActorRef}
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.actor.Status.Failure
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef}
+import org.apache.pekko.http.scaladsl.model.Uri
 import models.{FileLink, ResourceSyncConfig, UserProfile}
 import services.harvesting.ResourceSyncClient
 import services.storage.FileStorage
@@ -44,7 +44,7 @@ case class ResourceSyncHarvester (client: ResourceSyncClient, storage: FileStora
     implicit userOpt: Option[UserProfile], ec: ExecutionContext) extends Actor with ActorLogging {
   import Harvester._
   import ResourceSyncHarvester._
-  import akka.pattern.pipe
+  import org.apache.pekko.pattern.pipe
 
   override def receive: Receive = {
     // Start the initial harvest

--- a/modules/admin/app/actors/harvesting/UrlSetHarvester.scala
+++ b/modules/admin/app/actors/harvesting/UrlSetHarvester.scala
@@ -2,10 +2,10 @@ package actors.harvesting
 
 import actors.LongRunningJob.Cancel
 import actors.harvesting.Harvester.HarvestJob
-import akka.actor.Status.Failure
-import akka.actor.{Actor, ActorLogging, ActorRef}
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.actor.Status.Failure
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef}
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import models.{BasicAuthConfig, UrlNameMap, UrlSetConfig, UserProfile}
 import play.api.http.HeaderNames
 import play.api.libs.ws.{WSAuthScheme, WSClient}
@@ -45,7 +45,7 @@ case class UrlSetHarvester (client: WSClient, storage: FileStorage)(
     implicit userOpt: Option[UserProfile], ec: ExecutionContext) extends Actor with ActorLogging {
   import Harvester._
   import UrlSetHarvester._
-  import akka.pattern.pipe
+  import org.apache.pekko.pattern.pipe
 
   override def receive: Receive = {
     // Start the initial harvest

--- a/modules/admin/app/actors/ingest/DataImporter.scala
+++ b/modules/admin/app/actors/ingest/DataImporter.scala
@@ -2,8 +2,8 @@ package actors.ingest
 
 import actors.Ticker
 import actors.ingest.DataImporter._
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import akka.pattern._
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Props}
+import org.apache.pekko.pattern._
 import models._
 import services.ingest.IngestService.{IngestData, IngestJob}
 import services.ingest._

--- a/modules/admin/app/actors/ingest/DataImporterManager.scala
+++ b/modules/admin/app/actors/ingest/DataImporterManager.scala
@@ -2,8 +2,8 @@ package actors.ingest
 
 import actors.Ticker.Tick
 import actors.ingest.DataImporter.{Done, Start, Message, UnexpectedError}
-import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
+import org.apache.pekko.actor.SupervisorStrategy.Stop
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
 import models.{ErrorLog, ImportLog}
 import services.ingest.IngestService.{IngestData, IngestJob}
 import services.ingest._

--- a/modules/admin/app/actors/transformation/XmlConverter.scala
+++ b/modules/admin/app/actors/transformation/XmlConverter.scala
@@ -3,8 +3,8 @@ package actors.transformation
 import actors.LongRunningJob.Cancel
 import actors.transformation.XmlConverter._
 import actors.transformation.XmlConverterManager.XmlConvertJob
-import akka.actor.{Actor, ActorLogging, ActorRef, Scheduler}
-import akka.stream.Materializer
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Scheduler}
+import org.apache.pekko.stream.Materializer
 import services.transformation.utils.getUtf8Transcoder
 import models.UserProfile
 import services.storage.{FileMeta, FileStorage}
@@ -43,7 +43,7 @@ case class XmlConverter (job: XmlConvertJob, transformer: XmlTransformer, storag
 
   private val transformDigest: String = services.transformation.utils.digest(job.data.transformers)
 
-  import akka.pattern.pipe
+  import org.apache.pekko.pattern.pipe
 
   override def receive: Receive = {
     // Start the initial harvest
@@ -94,7 +94,7 @@ case class XmlConverter (job: XmlConvertJob, transformer: XmlTransformer, storag
 
     // Fetching a file
     case Convert(file :: others, truncated, _, count, fresh) =>
-      import akka.pattern.retry
+      import org.apache.pekko.pattern.retry
       implicit val scheduler: Scheduler = context.system.scheduler
 
       context.become(running(msgTo, count, fresh, total, start))

--- a/modules/admin/app/actors/transformation/XmlConverterManager.scala
+++ b/modules/admin/app/actors/transformation/XmlConverterManager.scala
@@ -3,9 +3,9 @@ package actors.transformation
 import actors.LongRunningJob.Cancel
 import actors.transformation.XmlConverter._
 import actors.transformation.XmlConverterManager.XmlConvertJob
-import akka.actor.SupervisorStrategy.Stop
-import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
-import akka.stream.Materializer
+import org.apache.pekko.actor.SupervisorStrategy.Stop
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, SupervisorStrategy, Terminated}
+import org.apache.pekko.stream.Materializer
 import models.{TransformationType, UserProfile}
 import play.api.i18n.Messages
 import play.api.libs.json.JsObject

--- a/modules/admin/app/controllers/admin/Indexing.scala
+++ b/modules/admin/app/controllers/admin/Indexing.scala
@@ -1,6 +1,6 @@
 package controllers.admin
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
 import controllers.AppComponents
 import controllers.base.AdminController
 import models.EntityType

--- a/modules/admin/app/controllers/admin/Ingest.scala
+++ b/modules/admin/app/controllers/admin/Ingest.scala
@@ -1,8 +1,8 @@
 package controllers.admin
 
 import actors.ingest.DataImporterManager
-import akka.actor.Props
-import akka.stream.Materializer
+import org.apache.pekko.actor.Props
+import org.apache.pekko.stream.Materializer
 import controllers.AppComponents
 import controllers.base.AdminController
 import controllers.datasets.StorageHelpers

--- a/modules/admin/app/controllers/admin/Tasks.scala
+++ b/modules/admin/app/controllers/admin/Tasks.scala
@@ -1,8 +1,8 @@
 package controllers.admin
 
 import actors.LongRunningJob
-import akka.actor.{Actor, ActorLogging, ActorNotFound, ActorSystem, Props}
-import akka.stream.{Materializer, OverflowStrategy}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorNotFound, ActorSystem, Props}
+import org.apache.pekko.stream.{Materializer, OverflowStrategy}
 import controllers.AppComponents
 import controllers.base.AdminController
 import play.api.libs.json.{JsNull, JsValue, Json}

--- a/modules/admin/app/controllers/admin/Utils.scala
+++ b/modules/admin/app/controllers/admin/Utils.scala
@@ -1,9 +1,9 @@
 package controllers.admin
 
-import akka.actor.ActorRef
-import akka.stream.scaladsl.{BroadcastHub, Keep, Source}
-import akka.stream.{CompletionStrategy, Materializer, OverflowStrategy}
-import akka.{Done, NotUsed}
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.stream.scaladsl.{BroadcastHub, Keep, Source}
+import org.apache.pekko.stream.{CompletionStrategy, Materializer, OverflowStrategy}
+import org.apache.pekko.{Done, NotUsed}
 import controllers.AppComponents
 import controllers.base.AdminController
 import play.api.http.MimeTypes

--- a/modules/admin/app/controllers/countries/Countries.scala
+++ b/modules/admin/app/controllers/countries/Countries.scala
@@ -1,7 +1,7 @@
 package controllers.countries
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import akka.stream.Materializer
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import org.apache.pekko.stream.Materializer
 import controllers.AppComponents
 import controllers.base.AdminController
 import controllers.generic._

--- a/modules/admin/app/controllers/cypher/CypherQueries.scala
+++ b/modules/admin/app/controllers/cypher/CypherQueries.scala
@@ -1,9 +1,9 @@
 package controllers.cypher
 
 
-import akka.stream.alpakka.csv.scaladsl.CsvFormatting
-import akka.stream.scaladsl.{Keep, Source}
-import akka.util.ByteString
+import org.apache.pekko.stream.connectors.csv.scaladsl.CsvFormatting
+import org.apache.pekko.stream.scaladsl.{Keep, Source}
+import org.apache.pekko.util.ByteString
 import controllers.base.AdminController
 import controllers.{AppComponents, DataFormat}
 import models.CypherQuery

--- a/modules/admin/app/controllers/datamodel/EntityTypeMetadataApi.scala
+++ b/modules/admin/app/controllers/datamodel/EntityTypeMetadataApi.scala
@@ -2,8 +2,8 @@ package controllers.datamodel
 
 import actors.datamodel.AuditorManager
 import actors.datamodel.AuditorManager.{AuditTask, AuditorJob}
-import akka.actor.Props
-import akka.stream.Materializer
+import org.apache.pekko.actor.Props
+import org.apache.pekko.stream.Materializer
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import models._

--- a/modules/admin/app/controllers/datasets/ConvertConfigs.scala
+++ b/modules/admin/app/controllers/datasets/ConvertConfigs.scala
@@ -2,11 +2,11 @@ package controllers.datasets
 
 import actors.transformation.XmlConverterManager
 import actors.transformation.XmlConverterManager.{XmlConvertData, XmlConvertJob}
-import akka.NotUsed
-import akka.actor.Props
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Flow, Source}
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.Props
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Flow, Source}
+import org.apache.pekko.util.ByteString
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic.Update

--- a/modules/admin/app/controllers/datasets/CoreferenceTables.scala
+++ b/modules/admin/app/controllers/datasets/CoreferenceTables.scala
@@ -1,7 +1,7 @@
 package controllers.datasets
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Sink
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic._

--- a/modules/admin/app/controllers/datasets/DataTransformations.scala
+++ b/modules/admin/app/controllers/datasets/DataTransformations.scala
@@ -1,6 +1,6 @@
 package controllers.datasets
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic.Update

--- a/modules/admin/app/controllers/datasets/HarvestConfigs.scala
+++ b/modules/admin/app/controllers/datasets/HarvestConfigs.scala
@@ -5,10 +5,10 @@ import actors.harvesting.OaiPmhHarvester.{OaiPmhHarvestData, OaiPmhHarvestJob}
 import actors.harvesting.ResourceSyncHarvester.{ResourceSyncData, ResourceSyncJob}
 import actors.harvesting.UrlSetHarvester.{UrlSetHarvesterData, UrlSetHarvesterJob}
 import actors.harvesting.{HarvesterManager, OaiPmhHarvester, ResourceSyncHarvester, UrlSetHarvester}
-import akka.actor.{ActorContext, ActorRef, Props}
-import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
+import org.apache.pekko.actor.{ActorContext, ActorRef, Props}
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Sink
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic.Update

--- a/modules/admin/app/controllers/datasets/ImportConfigs.scala
+++ b/modules/admin/app/controllers/datasets/ImportConfigs.scala
@@ -1,9 +1,9 @@
 package controllers.datasets
 
 import actors.ingest
-import akka.actor.Props
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
+import org.apache.pekko.actor.Props
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic._

--- a/modules/admin/app/controllers/datasets/ImportDatasets.scala
+++ b/modules/admin/app/controllers/datasets/ImportDatasets.scala
@@ -1,6 +1,6 @@
 package controllers.datasets
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic._

--- a/modules/admin/app/controllers/datasets/ImportFiles.scala
+++ b/modules/admin/app/controllers/datasets/ImportFiles.scala
@@ -1,9 +1,9 @@
 package controllers.datasets
 
-import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.util.ByteString
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic._

--- a/modules/admin/app/controllers/datasets/ImportLogs.scala
+++ b/modules/admin/app/controllers/datasets/ImportLogs.scala
@@ -2,9 +2,9 @@ package controllers.datasets
 
 import actors.cleanup.CleanupRunner.CleanupJob
 import actors.cleanup.{CleanupRunner, CleanupRunnerManager}
-import akka.actor.{ActorContext, ActorRef, Props}
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
+import org.apache.pekko.actor.{ActorContext, ActorRef, Props}
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
 import controllers.AppComponents
 import controllers.base.{AdminController, ApiBodyParsers}
 import controllers.generic._

--- a/modules/admin/app/controllers/institutions/Repositories.scala
+++ b/modules/admin/app/controllers/institutions/Repositories.scala
@@ -1,6 +1,6 @@
 package controllers.institutions
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import controllers.AppComponents
 import controllers.base.{AdminController, ImageHelpers, ResolutionTooHigh, UnrecognizedType}
 import controllers.generic._

--- a/modules/admin/app/controllers/tools/Tools.scala
+++ b/modules/admin/app/controllers/tools/Tools.scala
@@ -1,12 +1,13 @@
 package controllers.tools
 
-import akka.stream.Materializer
-import akka.stream.alpakka.csv.scaladsl.CsvParsing
-import akka.stream.scaladsl.{FileIO, Flow, Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.csv.scaladsl.CsvParsing
+import org.apache.pekko.stream.scaladsl.{FileIO, Flow, Sink, Source}
+import org.apache.pekko.util.ByteString
 import controllers.base.AdminController
 import controllers.{AppComponents, Execution}
 import models.{BatchDeleteTask, ContentTypes}
+import org.apache.pekko.NotUsed
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.Messages
@@ -73,14 +74,14 @@ case class Tools @Inject()(
 
   }
 
-  private val errorsToBytes: Flow[XmlValidationError, ByteString, akka.NotUsed] = Flow[XmlValidationError]
+  private val errorsToBytes: Flow[XmlValidationError, ByteString, NotUsed] = Flow[XmlValidationError]
     .map(e => Json.toJson(e))
     .map(Json.prettyPrint)
     .map(ByteString.apply)
     .intersperse(ByteString("["), ByteString(","), ByteString("]"))
 
   private val eadValidatingBodyParser: BodyParser[Source[ByteString, _]] = BodyParser { req =>
-    val validateFlow: Flow[ByteString, ByteString, akka.NotUsed] = Flow[ByteString]
+    val validateFlow: Flow[ByteString, ByteString, NotUsed] = Flow[ByteString]
       .prefixAndTail(0)
       .mapAsync(1) { case (_, src) => eadValidator.validateEad(src) }
       .flatMapConcat(errs => Source.apply(errs.toList))

--- a/modules/admin/app/models/UrlSetConfig.scala
+++ b/modules/admin/app/models/UrlSetConfig.scala
@@ -1,6 +1,6 @@
 package models
 
-import akka.http.scaladsl.model.HttpMethods
+import org.apache.pekko.http.scaladsl.model.HttpMethods
 
 
 case class UrlNameMap(url: String, name: String)

--- a/modules/admin/app/services/datasets/ImportDatasetService.scala
+++ b/modules/admin/app/services/datasets/ImportDatasetService.scala
@@ -1,6 +1,6 @@
 package services.datasets
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.google.inject.ImplementedBy
 import models.{ImportDataset, ImportDatasetInfo}
 import play.api.http.{MimeTypes, Writeable}

--- a/modules/admin/app/services/datasets/SqlImportDatasetService.scala
+++ b/modules/admin/app/services/datasets/SqlImportDatasetService.scala
@@ -1,6 +1,6 @@
 package services.datasets
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.{Macro, RowParser, _}
 import models.{ImportDataset, ImportDatasetInfo}
 import play.api.db.Database

--- a/modules/admin/app/services/harvesting/OaiPmhClient.scala
+++ b/modules/admin/app/services/harvesting/OaiPmhClient.scala
@@ -2,8 +2,8 @@ package services.harvesting
 
 import java.time.Instant
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import models.{OaiPmhConfig, OaiPmhIdentity}
 import org.w3c.dom.Element
 import play.api.i18n.Messages

--- a/modules/admin/app/services/harvesting/OaiPmhRecordParser.scala
+++ b/modules/admin/app/services/harvesting/OaiPmhRecordParser.scala
@@ -1,9 +1,9 @@
 package services.harvesting
 
-import akka.stream.alpakka.xml.{Characters, EndElement, ParseEvent, StartElement}
-import akka.stream.scaladsl.Flow
-import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler}
-import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import org.apache.pekko.stream.connectors.xml.{Characters, EndElement, ParseEvent, StartElement}
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler}
+import org.apache.pekko.stream.{Attributes, FlowShape, Inlet, Outlet}
 
 import scala.concurrent.{Future, Promise}
 

--- a/modules/admin/app/services/harvesting/OaiPmhTokenParser.scala
+++ b/modules/admin/app/services/harvesting/OaiPmhTokenParser.scala
@@ -1,9 +1,9 @@
 package services.harvesting
 
-import akka.stream.alpakka.xml.{Characters, EndDocument, ParseEvent, StartElement}
-import akka.stream.scaladsl.Flow
-import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler}
-import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import org.apache.pekko.stream.connectors.xml.{Characters, EndDocument, ParseEvent, StartElement}
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler}
+import org.apache.pekko.stream.{Attributes, FlowShape, Inlet, Outlet}
 
 import scala.concurrent.{Future, Promise}
 

--- a/modules/admin/app/services/harvesting/ResourceSyncClient.scala
+++ b/modules/admin/app/services/harvesting/ResourceSyncClient.scala
@@ -1,7 +1,7 @@
 package services.harvesting
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import models.{FileLink, ResourceSyncConfig}
 import play.api.i18n.Messages
 

--- a/modules/admin/app/services/harvesting/SqlHarvestEventService.scala
+++ b/modules/admin/app/services/harvesting/SqlHarvestEventService.scala
@@ -2,7 +2,7 @@ package services.harvesting
 
 import java.io.{PrintWriter, StringWriter}
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.{Macro, RowParser, _}
 import javax.inject.Inject
 import models.{HarvestEvent, UserProfile}

--- a/modules/admin/app/services/harvesting/SqlOaiPmhConfigService.scala
+++ b/modules/admin/app/services/harvesting/SqlOaiPmhConfigService.scala
@@ -1,6 +1,6 @@
 package services.harvesting
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.{RowParser, SqlParser, _}
 import models.OaiPmhConfig
 import play.api.db.Database

--- a/modules/admin/app/services/harvesting/SqlResourceSyncConfigService.scala
+++ b/modules/admin/app/services/harvesting/SqlResourceSyncConfigService.scala
@@ -1,6 +1,6 @@
 package services.harvesting
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.{RowParser, _}
 import models.ResourceSyncConfig
 import play.api.db.Database

--- a/modules/admin/app/services/harvesting/SqlUrlSetConfigService.scala
+++ b/modules/admin/app/services/harvesting/SqlUrlSetConfigService.scala
@@ -1,6 +1,6 @@
 package services.harvesting
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.postgresql._
 import anorm.{RowParser, _}
 import models.UrlSetConfig

--- a/modules/admin/app/services/harvesting/WSOaiPmhClient.scala
+++ b/modules/admin/app/services/harvesting/WSOaiPmhClient.scala
@@ -1,11 +1,11 @@
 package services.harvesting
 
-import akka.NotUsed
-import akka.stream.Materializer
-import akka.stream.alpakka.xml.ParseEvent
-import akka.stream.alpakka.xml.scaladsl.{XmlParsing, XmlWriting}
-import akka.stream.scaladsl.{Flow, Keep, Source}
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.xml.ParseEvent
+import org.apache.pekko.stream.connectors.xml.scaladsl.{XmlParsing, XmlWriting}
+import org.apache.pekko.stream.scaladsl.{Flow, Keep, Source}
+import org.apache.pekko.util.ByteString
 import models.OaiPmhIdentity.Granularity
 import models.{OaiPmhConfig, OaiPmhIdentity}
 import org.w3c.dom.Element

--- a/modules/admin/app/services/harvesting/WSResourceSyncClient.scala
+++ b/modules/admin/app/services/harvesting/WSResourceSyncClient.scala
@@ -1,10 +1,10 @@
 package services.harvesting
 
 import java.util.regex.Pattern
-import akka.NotUsed
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.util.ByteString
 
 import javax.inject.Inject
 import models._

--- a/modules/admin/app/services/ingest/EadValidator.scala
+++ b/modules/admin/app/services/ingest/EadValidator.scala
@@ -2,9 +2,9 @@ package services.ingest
 
 import java.nio.file.Path
 
-import akka.http.scaladsl.model.Uri
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 
 import scala.concurrent.Future
 

--- a/modules/admin/app/services/ingest/ImportLogService.scala
+++ b/modules/admin/app/services/ingest/ImportLogService.scala
@@ -1,6 +1,6 @@
 package services.ingest
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import com.google.inject.ImplementedBy
 import models.ImportLog
 import play.api.libs.json.{Json, Writes}

--- a/modules/admin/app/services/ingest/IngestService.scala
+++ b/modules/admin/app/services/ingest/IngestService.scala
@@ -1,6 +1,6 @@
 package services.ingest
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import models.{ContentTypes, IngestParams, IngestResult}
 import play.api.mvc.QueryStringBindable
 import services.data.DataUser

--- a/modules/admin/app/services/ingest/RelaxNGEadValidator.scala
+++ b/modules/admin/app/services/ingest/RelaxNGEadValidator.scala
@@ -3,10 +3,10 @@ package services.ingest
 import java.io.InputStreamReader
 import java.nio.file.Path
 
-import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 import com.google.common.io.Resources
 import com.thaiopensource.util.PropertyMapBuilder
 import com.thaiopensource.validate.prop.rng.RngProperty

--- a/modules/admin/app/services/ingest/SqlCoreferenceService.scala
+++ b/modules/admin/app/services/ingest/SqlCoreferenceService.scala
@@ -1,6 +1,6 @@
 package services.ingest
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.SqlParser._
 import anorm._
 import play.api.db.Database

--- a/modules/admin/app/services/ingest/SqlImportConfigService.scala
+++ b/modules/admin/app/services/ingest/SqlImportConfigService.scala
@@ -1,6 +1,6 @@
 package services.ingest
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.{Macro, RowParser, _}
 import models.ImportConfig
 import play.api.db.Database

--- a/modules/admin/app/services/ingest/SqlImportLogService.scala
+++ b/modules/admin/app/services/ingest/SqlImportLogService.scala
@@ -1,8 +1,8 @@
 package services.ingest
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import anorm.SqlParser._
 import anorm._
 import models.ImportLog

--- a/modules/admin/app/services/ingest/WSIngestService.scala
+++ b/modules/admin/app/services/ingest/WSIngestService.scala
@@ -1,9 +1,9 @@
 package services.ingest
 
-import akka.actor.ActorRef
-import akka.stream.Materializer
-import akka.stream.scaladsl.{FileIO, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{FileIO, Source}
+import org.apache.pekko.util.ByteString
 import com.fasterxml.jackson.databind.JsonMappingException
 import models._
 import play.api.cache.AsyncCacheApi

--- a/modules/admin/app/services/ingest/XmlFormatter.scala
+++ b/modules/admin/app/services/ingest/XmlFormatter.scala
@@ -2,11 +2,11 @@ package services.ingest
 
 import java.util
 
-import akka.NotUsed
-import akka.stream.alpakka.xml.{Characters, EndElement, ParseEvent, StartElement}
-import akka.stream.scaladsl.Flow
-import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
-import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.connectors.xml.{Characters, EndElement, ParseEvent, StartElement}
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import org.apache.pekko.stream.{Attributes, FlowShape, Inlet, Outlet}
 
 
 object XmlFormatter {

--- a/modules/admin/app/services/transformation/DataTransformationService.scala
+++ b/modules/admin/app/services/transformation/DataTransformationService.scala
@@ -1,6 +1,6 @@
 package services.transformation
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import com.google.inject.ImplementedBy
 import models.{DataTransformation, DataTransformationInfo}
 import play.api.http.{MimeTypes, Writeable}

--- a/modules/admin/app/services/transformation/SqlDataTransformationService.scala
+++ b/modules/admin/app/services/transformation/SqlDataTransformationService.scala
@@ -1,7 +1,7 @@
 package services.transformation
 
 import _root_.utils.{db => dbUtils}
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.postgresql._
 import anorm.{Macro, RowParser, _}
 import models.{DataTransformation, DataTransformationInfo}

--- a/modules/admin/app/services/transformation/WrappingXmlTransformer.scala
+++ b/modules/admin/app/services/transformation/WrappingXmlTransformer.scala
@@ -1,8 +1,8 @@
 package services.transformation
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Flow, Source}
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Flow, Source}
+import org.apache.pekko.util.ByteString
 import eu.ehri.project.xml.{Timer, XQueryXmlTransformer, XsltXmlTransformer}
 import models.TransformationType
 import play.api.cache.{NamedCache, SyncCacheApi}

--- a/modules/admin/app/services/transformation/XmlTransformer.scala
+++ b/modules/admin/app/services/transformation/XmlTransformer.scala
@@ -1,7 +1,7 @@
 package services.transformation
 
-import akka.stream.scaladsl.Flow
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.util.ByteString
 import com.google.inject.ImplementedBy
 import models.TransformationType
 import play.api.libs.json.JsObject

--- a/modules/admin/app/services/transformation/utils/package.scala
+++ b/modules/admin/app/services/transformation/utils/package.scala
@@ -1,10 +1,10 @@
 package services.transformation
 
-import akka.NotUsed
-import akka.http.scaladsl.model.ContentType
-import akka.stream.alpakka.text.scaladsl.TextFlow
-import akka.stream.scaladsl.Flow
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.http.scaladsl.model.ContentType
+import org.apache.pekko.stream.connectors.text.scaladsl.TextFlow
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.util.ByteString
 import models.TransformationType
 import play.api.libs.Codecs
 import play.api.libs.json.{JsObject, Json}

--- a/modules/admin/test/services/harvesting/OaiPmhRecordParserSpec.scala
+++ b/modules/admin/test/services/harvesting/OaiPmhRecordParserSpec.scala
@@ -1,10 +1,10 @@
 package services.harvesting
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.alpakka.xml.scaladsl.{XmlParsing, XmlWriting}
-import akka.stream.scaladsl.{Keep, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.xml.scaladsl.{XmlParsing, XmlWriting}
+import org.apache.pekko.stream.scaladsl.{Keep, Source}
+import org.apache.pekko.util.ByteString
 import play.api.test.PlaySpecification
 
 import scala.concurrent.Future

--- a/modules/admin/test/services/harvesting/OaiPmhTokenParserSpec.scala
+++ b/modules/admin/test/services/harvesting/OaiPmhTokenParserSpec.scala
@@ -1,10 +1,10 @@
 package services.harvesting
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.alpakka.xml.scaladsl.{XmlParsing, XmlWriting}
-import akka.stream.scaladsl.{Keep, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.xml.scaladsl.{XmlParsing, XmlWriting}
+import org.apache.pekko.stream.scaladsl.{Keep, Source}
+import org.apache.pekko.util.ByteString
 import play.api.test.PlaySpecification
 
 import scala.concurrent.Future

--- a/modules/admin/test/services/harvesting/XmlFormatterSpec.scala
+++ b/modules/admin/test/services/harvesting/XmlFormatterSpec.scala
@@ -1,11 +1,11 @@
 package services.harvesting
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.alpakka.xml.Characters
-import akka.stream.alpakka.xml.scaladsl.XmlParsing
-import akka.stream.scaladsl.{Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.xml.Characters
+import org.apache.pekko.stream.connectors.xml.scaladsl.XmlParsing
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import org.apache.pekko.util.ByteString
 import play.api.test.PlaySpecification
 import services.ingest.XmlFormatter
 

--- a/modules/admin/test/services/ingest/RelaxNGEadValidatorSpec.scala
+++ b/modules/admin/test/services/ingest/RelaxNGEadValidatorSpec.scala
@@ -2,10 +2,10 @@ package services.ingest
 
 import java.nio.file.Paths
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
-import akka.stream.scaladsl.FileIO
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.FileIO
 import com.google.common.io.Resources
 import play.api.test.PlaySpecification
 

--- a/modules/api/app/controllers/api/datasets/Datasets.scala
+++ b/modules/api/app/controllers/api/datasets/Datasets.scala
@@ -1,9 +1,9 @@
 package controllers.api.datasets
 
-import akka.stream.Materializer
-import akka.stream.alpakka.csv.scaladsl.CsvFormatting
-import akka.stream.scaladsl.{Keep, Source}
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.csv.scaladsl.CsvFormatting
+import org.apache.pekko.stream.scaladsl.{Keep, Source}
+import org.apache.pekko.util.ByteString
 import controllers.portal.base.PortalController
 import controllers.{AppComponents, DataFormat}
 import models.CypherQuery

--- a/modules/api/app/controllers/api/graphql/GraphQL.scala
+++ b/modules/api/app/controllers/api/graphql/GraphQL.scala
@@ -1,6 +1,6 @@
 package controllers.api.graphql
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import controllers.AppComponents
 import controllers.portal.base.PortalController
 import play.api.http.{ContentTypes, HeaderNames, HttpVerbs}

--- a/modules/api/app/controllers/api/oaipmh/OaiPmhHome.scala
+++ b/modules/api/app/controllers/api/oaipmh/OaiPmhHome.scala
@@ -1,6 +1,6 @@
 package controllers.api.oaipmh
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import controllers.AppComponents
 import controllers.portal.base.PortalController
 import play.api.http.{ContentTypes, HttpVerbs}

--- a/modules/api/app/controllers/api/v1/ApiV1.scala
+++ b/modules/api/app/controllers/api/v1/ApiV1.scala
@@ -1,6 +1,6 @@
 package controllers.api.v1
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import auth.handler.AuthHandler
 import controllers.AppComponents
 import controllers.base.{CoreActionBuilders, SearchRelated, SearchVC}

--- a/modules/backend/src/main/scala/services/cypher/CypherService.scala
+++ b/modules/backend/src/main/scala/services/cypher/CypherService.scala
@@ -1,7 +1,7 @@
 package services.cypher
 
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import play.api.libs.json._
 
 import scala.concurrent.Future

--- a/modules/backend/src/main/scala/services/cypher/WsCypherService.scala
+++ b/modules/backend/src/main/scala/services/cypher/WsCypherService.scala
@@ -1,10 +1,10 @@
 package services.cypher
 
-import akka.actor.ActorSystem
-import akka.stream.alpakka.json.scaladsl.JsonReader
-import akka.stream.scaladsl.Source
-import akka.stream.{Materializer, scaladsl}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.connectors.json.scaladsl.JsonReader
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.stream.{Materializer, scaladsl}
+import org.apache.pekko.util.ByteString
 import play.api.Logger
 import play.api.cache.SyncCacheApi
 import play.api.http.HttpVerbs

--- a/modules/backend/src/main/scala/services/data/DataServiceBuilder.scala
+++ b/modules/backend/src/main/scala/services/data/DataServiceBuilder.scala
@@ -1,6 +1,6 @@
 package services.data
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import models.{ContentTypes, EntityType, GlobalPermissionSet, ItemPermissionSet, Readable, Resource, WithId, Writable}
 import play.api.libs.json.{JsObject, JsValue}
 import play.api.libs.ws.WSResponse

--- a/modules/backend/src/main/scala/services/data/EventForwarder.scala
+++ b/modules/backend/src/main/scala/services/data/EventForwarder.scala
@@ -1,6 +1,6 @@
 package services.data
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Terminated}
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, Terminated}
 
 import javax.inject.Inject
 

--- a/modules/backend/src/main/scala/services/data/EventHandler.scala
+++ b/modules/backend/src/main/scala/services/data/EventHandler.scala
@@ -1,6 +1,6 @@
 package services.data
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 
 trait EventHandler {
   def subscribe(actorRef: ActorRef): Unit = ()

--- a/modules/backend/src/main/scala/services/data/WsDataService.scala
+++ b/modules/backend/src/main/scala/services/data/WsDataService.scala
@@ -1,8 +1,8 @@
 package services.data
 
-import akka.Done
-import akka.stream.scaladsl.{JsonFraming, Source}
-import akka.util.ByteString
+import org.apache.pekko.Done
+import org.apache.pekko.stream.scaladsl.{JsonFraming, Source}
+import org.apache.pekko.util.ByteString
 import models.{ContentTypes, EntityType, GlobalPermissionSet, ItemPermissionSet, Readable, Resource, WithId, Writable}
 import play.api.Configuration
 import play.api.cache.AsyncCacheApi

--- a/modules/backend/src/main/scala/services/data/streams/ByteStreamResizer.scala
+++ b/modules/backend/src/main/scala/services/data/streams/ByteStreamResizer.scala
@@ -1,10 +1,10 @@
 package services.data.streams
 
-import akka.NotUsed
-import akka.stream.scaladsl.Flow
-import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
-import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.{Attributes, FlowShape, Inlet, Outlet}
+import org.apache.pekko.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import org.apache.pekko.util.ByteString
 
 object ByteStreamResizer {
   /**

--- a/modules/backend/src/main/scala/utils/CsvHelpers.scala
+++ b/modules/backend/src/main/scala/utils/CsvHelpers.scala
@@ -1,8 +1,8 @@
 package utils
 
-import akka.NotUsed
-import akka.stream.alpakka.csv.scaladsl.CsvFormatting
-import akka.stream.scaladsl.Source
+import org.apache.pekko.NotUsed
+import org.apache.pekko.stream.connectors.csv.scaladsl.CsvFormatting
+import org.apache.pekko.stream.scaladsl.Source
 
 trait CsvHelpers {
   def writeCsv(headers: Seq[String], data: Seq[Array[String]], sep: Char = ','): Source[String, NotUsed] = {

--- a/modules/backend/src/test/scala/services/data/streams/ByteStringResizerSpec.scala
+++ b/modules/backend/src/test/scala/services/data/streams/ByteStringResizerSpec.scala
@@ -1,9 +1,9 @@
 package services.data.streams
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Source, StreamConverters}
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{Source, StreamConverters}
+import org.apache.pekko.util.ByteString
 import play.api.test.PlaySpecification
 
 import scala.concurrent.Await
@@ -11,8 +11,8 @@ import scala.concurrent.duration._
 
 class ByteStringResizerSpec extends PlaySpecification {
 
-  private implicit val as: akka.actor.ActorSystem = ActorSystem.create("testing")
-  private implicit val mat: akka.stream.Materializer = Materializer(as)
+  private implicit val as: ActorSystem = ActorSystem.create("testing")
+  private implicit val mat: Materializer = Materializer(as)
 
   def count(size: Int, bytes: ByteString*): Int = Await.result(
     Source.apply(bytes.toList)

--- a/modules/core/src/main/scala/controllers/base/CoreActionBuilders.scala
+++ b/modules/core/src/main/scala/controllers/base/CoreActionBuilders.scala
@@ -1,6 +1,6 @@
 package controllers.base
 
-import akka.stream.scaladsl.Flow
+import org.apache.pekko.stream.scaladsl.Flow
 import auth.handler.AuthHandler
 import views.AppConfig
 import lifecycle.ItemLifecycle

--- a/modules/core/src/main/scala/services/accounts/SqlAccountManager.scala
+++ b/modules/core/src/main/scala/services/accounts/SqlAccountManager.scala
@@ -4,7 +4,7 @@ import java.sql.Connection
 import java.time.ZonedDateTime
 import java.util.UUID
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.SqlParser._
 import anorm._
 import auth._

--- a/modules/core/src/main/scala/services/datamodel/SqlEntityTypeMetadataService.scala
+++ b/modules/core/src/main/scala/services/datamodel/SqlEntityTypeMetadataService.scala
@@ -1,6 +1,6 @@
 package services.datamodel
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.{Column, SqlStringInterpolation, ToStatement, TypeDoesNotMatch}
 import models._
 import org.postgresql.jdbc.PgArray

--- a/modules/core/src/main/scala/services/search/IndexingEventHandler.scala
+++ b/modules/core/src/main/scala/services/search/IndexingEventHandler.scala
@@ -1,8 +1,9 @@
 package services.search
 
-import akka.actor.ActorRef
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
+import org.apache.pekko.Done
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
 import play.api.{Configuration, Logger}
 import services.data.EventForwarder.{Create, Delete, Update}
 import services.data.EventHandler
@@ -54,7 +55,7 @@ case class IndexingEventHandler @Inject()(
       searchIndexer.handle.clearIds(group: _*)
     }
     // This runs all deletes in a synchronous sequence, as opposed to in parallel
-    val allDone: Future[akka.Done] = Source.fromIterator(() => deletes)
+    val allDone: Future[Done] = Source.fromIterator(() => deletes)
       .mapAsync(parallelism = 1)(identity)
       .runForeach(identity)
 

--- a/modules/core/src/main/scala/services/search/SearchIndexMediator.scala
+++ b/modules/core/src/main/scala/services/search/SearchIndexMediator.scala
@@ -1,6 +1,6 @@
 package services.search
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import models.EntityType
 
 import scala.concurrent.Future

--- a/modules/portal/app/controllers/AppComponents.scala
+++ b/modules/portal/app/controllers/AppComponents.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import auth.handler.AuthHandler
 import com.google.inject.ImplementedBy
 import views.AppConfig

--- a/modules/portal/app/controllers/base/SearchRelated.scala
+++ b/modules/portal/app/controllers/base/SearchRelated.scala
@@ -1,7 +1,7 @@
 package controllers.base
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Sink
 import controllers.generic.Search
 import play.api.libs.json.JsString
 import services.cypher.CypherService

--- a/modules/portal/app/controllers/portal/Concepts.scala
+++ b/modules/portal/app/controllers/portal/Concepts.scala
@@ -1,6 +1,6 @@
 package controllers.portal
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 
 import javax.inject.{Inject, Singleton}
 import controllers.AppComponents

--- a/modules/portal/app/controllers/portal/HistoricalAgents.scala
+++ b/modules/portal/app/controllers/portal/HistoricalAgents.scala
@@ -1,6 +1,6 @@
 package controllers.portal
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import controllers.AppComponents
 import controllers.generic.Search
 import controllers.portal.base.{Generic, PortalController, Related}

--- a/modules/portal/app/controllers/portal/base/PortalController.scala
+++ b/modules/portal/app/controllers/portal/base/PortalController.scala
@@ -1,6 +1,6 @@
 package controllers.portal.base
 
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.Uri
 import auth.handler.AuthHandler
 import controllers.base.CoreActionBuilders
 import controllers.{AppComponents, renderError}

--- a/modules/portal/app/controllers/portal/base/Related.scala
+++ b/modules/portal/app/controllers/portal/base/Related.scala
@@ -1,6 +1,6 @@
 package controllers.portal.base
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import controllers.base.SearchRelated
 import controllers.generic.{Read, Search}
 import models.{Annotation, ContentType, UserProfile}

--- a/modules/portal/app/controllers/portal/users/UserProfiles.scala
+++ b/modules/portal/app/controllers/portal/users/UserProfiles.scala
@@ -1,6 +1,6 @@
 package controllers.portal.users
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import controllers.base.{ImageHelpers, ResolutionTooHigh, UnrecognizedType}
 import controllers.generic.Search
 import controllers.portal.base.PortalController

--- a/modules/portal/app/guice/AppModule.scala
+++ b/modules/portal/app/guice/AppModule.scala
@@ -1,13 +1,13 @@
 package guice
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import com.google.inject.AbstractModule
 import com.google.inject.name.Names
 import views.AppConfig
 import data.markdown.{CommonmarkMarkdownRenderer, RawMarkdownRenderer, SanitisingMarkdownRenderer}
 import lifecycle.{GeocodingItemLifecycle, ItemLifecycle}
-import play.api.libs.concurrent.AkkaGuiceSupport
+import play.api.libs.concurrent.PekkoGuiceSupport
 import services.RateLimitChecker
 import services.cypher.{CypherQueryService, CypherService, SqlCypherQueryService, WsCypherService}
 import services.data._
@@ -36,7 +36,7 @@ private class AwsGeocodingServiceProvider @Inject()(config: play.api.Configurati
   override def get(): GeocodingService = AwsGeocodingService(config.get[com.typesafe.config.Config]("services.geocoding"))(ec)
 }
 
-class AppModule extends AbstractModule with AkkaGuiceSupport {
+class AppModule extends AbstractModule with PekkoGuiceSupport {
   override def configure(): Unit = {
     bind(classOf[AppConfig])
     bind(classOf[RateLimitChecker])

--- a/modules/portal/app/services/cypher/SqlCypherQueryService.scala
+++ b/modules/portal/app/services/cypher/SqlCypherQueryService.scala
@@ -3,7 +3,7 @@ package services.cypher
 import java.time.ZonedDateTime
 import javax.inject.{Inject, Singleton}
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm.{Macro, RowParser, SqlParser, _}
 import models.CypherQuery
 import play.api.db.Database

--- a/modules/portal/app/services/feedback/SqlFeedbackService.scala
+++ b/modules/portal/app/services/feedback/SqlFeedbackService.scala
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import java.time.ZonedDateTime
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm._
 import javax.inject.{Inject, Singleton}
 import models.{Feedback, FeedbackContext}

--- a/modules/portal/app/services/redirects/SqlMovedPageLookup.scala
+++ b/modules/portal/app/services/redirects/SqlMovedPageLookup.scala
@@ -2,7 +2,7 @@ package services.redirects
 
 import javax.inject.Inject
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import anorm._
 import org.apache.commons.codec.digest.DigestUtils
 import play.api.db.Database

--- a/modules/portal/app/services/search/CmdlineIndexMediator.scala
+++ b/modules/portal/app/services/search/CmdlineIndexMediator.scala
@@ -1,6 +1,6 @@
 package services.search
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import com.google.common.collect.EvictingQueue
 import models.EntityType
 import play.api.{Configuration, Logger}

--- a/modules/portal/app/services/search/SearchToolsIndexMediator.scala
+++ b/modules/portal/app/services/search/SearchToolsIndexMediator.scala
@@ -1,6 +1,6 @@
 package services.search
 
-import akka.actor.{ActorRef, ActorSystem}
+import org.apache.pekko.actor.{ActorRef, ActorSystem}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper, ObjectWriter}
 import eu.ehri.project.indexing.Pipeline.Builder
 import eu.ehri.project.indexing.converter.impl.JsonConverter

--- a/modules/portal/app/services/storage/FileStorage.scala
+++ b/modules/portal/app/services/storage/FileStorage.scala
@@ -1,8 +1,8 @@
 package services.storage
 
 import java.net.URI
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.google.common.hash.Hashing
 import com.google.common.io.Files
 

--- a/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
+++ b/modules/portal/app/services/storage/S3CompatibleFileStorage.scala
@@ -1,14 +1,14 @@
 package services.storage
 
-import akka.NotUsed
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model._
-import akka.stream.Materializer
-import akka.stream.alpakka.s3._
-import akka.stream.alpakka.s3.headers.CannedAcl
-import akka.stream.alpakka.s3.scaladsl.S3
-import akka.stream.scaladsl.{FileIO, Sink, Source}
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.s3.{BucketVersioningStatus => _, _}
+import org.apache.pekko.stream.connectors.s3.headers.CannedAcl
+import org.apache.pekko.stream.connectors.s3.scaladsl.S3
+import org.apache.pekko.stream.scaladsl.{FileIO, Sink, Source}
+import org.apache.pekko.util.ByteString
 import play.api.Logger
 import software.amazon.awssdk.auth.credentials.{AwsCredentials, AwsCredentialsProvider, StaticCredentialsProvider}
 import software.amazon.awssdk.core.exception.SdkException
@@ -182,7 +182,7 @@ case class S3CompatibleFileStorage(
         f.key,
         f.lastModified,
         f.size,
-        // NB: S3 returns eTags wrapped in quotes, but Alpakka doesn't
+        // NB: S3 returns eTags wrapped in quotes, but Pekko Connectors doesn't
         // hence for compatibility we add it here.
         Some(f.eTag).map(f => "\"" + f + "\""),
       ))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 //resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.5")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 

--- a/test/actors/cleanup/CleanupRunnerManagerSpec.scala
+++ b/test/actors/cleanup/CleanupRunnerManagerSpec.scala
@@ -2,7 +2,7 @@ package actors.cleanup
 
 import actors.LongRunningJob
 import actors.cleanup.CleanupRunner.CleanupJob
-import akka.actor.{ActorContext, ActorRef, Props}
+import org.apache.pekko.actor.{ActorContext, ActorRef, Props}
 import com.google.inject.name.Names
 import controllers.datasets.CleanupConfirmation
 import helpers.IntegrationTestRunner
@@ -32,7 +32,7 @@ class CleanupRunnerManagerSpec extends IntegrationTestRunner {
 
   "Harvester Manager" should {
 
-    "send correct messages when running a cleanup job" in new DBTestAppWithAkka("import-log-fixture.sql",
+    "send correct messages when running a cleanup job" in new DBTestAppWithPekko("import-log-fixture.sql",
         specificConfig = Map("ehri.admin.bulkOperations.maxDeletions" -> 1)) {
       val cleanupConfirmation = CleanupConfirmation("Delete it")
       val cleanupJob: CleanupJob = CleanupJob("r1", 1, jobId, cleanupConfirmation.msg)
@@ -52,7 +52,7 @@ class CleanupRunnerManagerSpec extends IntegrationTestRunner {
       expectMsg("Done")
     }
 
-    "be cancellable" in new DBTestAppWithAkka("import-log-fixture.sql") {
+    "be cancellable" in new DBTestAppWithPekko("import-log-fixture.sql") {
       val cleanupConfirmation = CleanupConfirmation("Delete it")
       val cleanupJob: CleanupJob = CleanupJob("r1", 1, jobId, cleanupConfirmation.msg)
 

--- a/test/actors/datamodel/AuditorSpec.scala
+++ b/test/actors/datamodel/AuditorSpec.scala
@@ -3,7 +3,7 @@ package actors.datamodel
 import actors.LongRunningJob.Cancel
 import actors.datamodel.Auditor.RunAudit
 import actors.datamodel.AuditorManager.{AuditTask, AuditorJob}
-import akka.actor.Props
+import org.apache.pekko.actor.Props
 import helpers.IntegrationTestRunner
 import mockdata.adminUserProfile
 import models.{EntityType, FieldMetadata, FieldMetadataSet, UserProfile}
@@ -47,7 +47,7 @@ class AuditorSpec extends IntegrationTestRunner {
 
   "Auditor runner" should {
 
-    "send correct messages when auditing an entity type" in new ITestAppWithAkka {
+    "send correct messages when auditing an entity type" in new ITestAppWithPekko {
       val runner = system.actorOf(Props(Auditor(searchEngine, resolver, fieldMetadataSet, 5, 10)))
 
       runner ! RunAudit(job, None)
@@ -56,7 +56,7 @@ class AuditorSpec extends IntegrationTestRunner {
       expectMsgClass(classOf[Auditor.Completed])
     }
 
-    "allow cancellation" in new ITestAppWithAkka {
+    "allow cancellation" in new ITestAppWithPekko {
       val runner = system.actorOf(Props(Auditor(searchEngine, resolver, fieldMetadataSet, 5, 10)))
 
       runner ! RunAudit(job, None)

--- a/test/actors/harvesting/HarvesterManagerSpec.scala
+++ b/test/actors/harvesting/HarvesterManagerSpec.scala
@@ -5,7 +5,7 @@ import actors.harvesting
 import actors.harvesting.OaiPmhHarvester.{OaiPmhHarvestData, OaiPmhHarvestJob}
 import actors.harvesting.ResourceSyncHarvester.{ResourceSyncData, ResourceSyncJob}
 import actors.harvesting.UrlSetHarvester.{UrlSetHarvesterData, UrlSetHarvesterJob}
-import akka.actor.{ActorContext, Props}
+import org.apache.pekko.actor.{ActorContext, Props}
 import helpers.IntegrationTestRunner
 import mockdata.adminUserProfile
 import models.HarvestEvent.HarvestEventType
@@ -68,7 +68,7 @@ class HarvesterManagerSpec extends IntegrationTestRunner {
   "Harvester Manager" should {
     import scala.concurrent.duration._
 
-    "send correct messages when harvesting an endpoint via OAI-PMH" in new ITestAppWithAkka {
+    "send correct messages when harvesting an endpoint via OAI-PMH" in new ITestAppWithPekko {
       val events = MockHarvestEventService()
       val init = (context: ActorContext) => context.actorOf(Props(OaiPmhHarvester(oaiPmhClient, storage)))
       val harvester = system.actorOf(Props(HarvesterManager(oaiPmhJob, init, events)))
@@ -85,7 +85,7 @@ class HarvesterManagerSpec extends IntegrationTestRunner {
         .eventually(20, 100.millis)
     }
 
-    "send correct messages when harvesting an endpoint via ResourceSync" in new ITestAppWithAkka {
+    "send correct messages when harvesting an endpoint via ResourceSync" in new ITestAppWithPekko {
       val events = MockHarvestEventService()
       val init = (context: ActorContext) => context.actorOf(Props(ResourceSyncHarvester(rsClient, storage)))
       val harvester = system.actorOf(Props(HarvesterManager(rsJob, init, events)))
@@ -103,7 +103,7 @@ class HarvesterManagerSpec extends IntegrationTestRunner {
         .eventually(20, 100.millis)
     }
 
-    "send correct messages when harvesting an endpoint via an URL set" in new ITestAppWithAkka {
+    "send correct messages when harvesting an endpoint via an URL set" in new ITestAppWithPekko {
         val events = MockHarvestEventService()
         val init = (context: ActorContext) => context.actorOf(Props(UrlSetHarvester(wsClient, storage)))
         val harvester = system.actorOf(Props(HarvesterManager(urlSetJob, init, events)))
@@ -120,7 +120,7 @@ class HarvesterManagerSpec extends IntegrationTestRunner {
           .eventually(20, 100.millis)
     }
 
-    "handle errors" in new ITestAppWithAkka {
+    "handle errors" in new ITestAppWithPekko {
       val events = MockHarvestEventService()
       val harvestConf = oaiPmhJob.copy(data = oaiPmhJob.data.copy(config = oaiPmhJob.data.config.copy(url = "http://example.com/oaipmh")))
       val init = (context: ActorContext) => context.actorOf(Props(OaiPmhHarvester(oaiPmhClient, storage)))
@@ -135,7 +135,7 @@ class HarvesterManagerSpec extends IntegrationTestRunner {
       await(events.get("r1")) must_== List.empty[HarvestEvent]
     }
 
-    "harvest selectively with `from` date" in new ITestAppWithAkka {
+    "harvest selectively with `from` date" in new ITestAppWithPekko {
         val events = MockHarvestEventService()
         val start: Instant = Instant.now()
         val job2 = oaiPmhJob(app)
@@ -150,7 +150,7 @@ class HarvesterManagerSpec extends IntegrationTestRunner {
         await(events.get("r1")) must_== List.empty[HarvestEvent]
     }
 
-    "cancel jobs" in new ITestAppWithAkka {
+    "cancel jobs" in new ITestAppWithPekko {
         val events = MockHarvestEventService()
         val init = (context: ActorContext) => context.actorOf(Props(OaiPmhHarvester(oaiPmhClient, storage)))
         val harvester = system.actorOf(Props(harvesting.HarvesterManager(oaiPmhJob, init, events)))

--- a/test/actors/harvesting/OaiPmhHarvesterSpec.scala
+++ b/test/actors/harvesting/OaiPmhHarvesterSpec.scala
@@ -3,7 +3,7 @@ package actors.harvesting
 import actors.LongRunningJob.Cancel
 import actors.harvesting
 import actors.harvesting.OaiPmhHarvester.{OaiPmhHarvestData, OaiPmhHarvestJob}
-import akka.actor.Props
+import org.apache.pekko.actor.Props
 import helpers.IntegrationTestRunner
 import mockdata.adminUserProfile
 import models.{OaiPmhConfig, BasicAuthConfig, UserProfile}
@@ -36,7 +36,7 @@ class OaiPmhHarvesterSpec extends IntegrationTestRunner {
 
   "OAI-PMH harvest runner" should {
 
-    "send correct messages when harvesting an endpoint" in new ITestAppWithAkka {
+    "send correct messages when harvesting an endpoint" in new ITestAppWithPekko {
       val runner = system.actorOf(Props(OaiPmhHarvester(client, storage)))
 
       runner ! job
@@ -46,7 +46,7 @@ class OaiPmhHarvesterSpec extends IntegrationTestRunner {
       expectMsgClass(classOf[Completed])
     }
 
-    "allow cancellation" in new ITestAppWithAkka {
+    "allow cancellation" in new ITestAppWithPekko {
       val runner = system.actorOf(Props(harvesting.OaiPmhHarvester(client, storage)))
 
       runner ! job

--- a/test/actors/harvesting/ResourceSyncHarvesterSpec.scala
+++ b/test/actors/harvesting/ResourceSyncHarvesterSpec.scala
@@ -3,8 +3,8 @@ package actors.harvesting
 import actors.LongRunningJob.Cancel
 import actors.harvesting
 import actors.harvesting.ResourceSyncHarvester.{ResourceSyncData, ResourceSyncJob}
-import akka.actor.Props
-import akka.testkit.{ImplicitSender, TestKit}
+import org.apache.pekko.actor.Props
+import org.apache.pekko.testkit.{ImplicitSender, TestKit}
 import helpers.IntegrationTestRunner
 import mockdata.adminUserProfile
 import models.{ResourceSyncConfig, UserProfile}

--- a/test/actors/harvesting/UrlSetHarvesterSpec.scala
+++ b/test/actors/harvesting/UrlSetHarvesterSpec.scala
@@ -3,7 +3,7 @@ package actors.harvesting
 import actors.LongRunningJob.Cancel
 import actors.harvesting
 import actors.harvesting.UrlSetHarvester.{UrlSetHarvesterData, UrlSetHarvesterJob}
-import akka.actor.Props
+import org.apache.pekko.actor.Props
 import helpers.IntegrationTestRunner
 import mockdata.adminUserProfile
 import models.{BasicAuthConfig, UrlSetConfig, UserProfile}
@@ -47,7 +47,7 @@ class UrlSetHarvesterSpec extends IntegrationTestRunner {
 
   "URL set harvest runner" should {
 
-    "send correct messages when harvesting an endpoint" in new ITestAppWithAkka {
+    "send correct messages when harvesting an endpoint" in new ITestAppWithPekko {
       val runner = system.actorOf(Props(UrlSetHarvester(client, storage)))
 
       runner ! job
@@ -58,7 +58,7 @@ class UrlSetHarvesterSpec extends IntegrationTestRunner {
       expectMsgClass(classOf[Completed])
     }
 
-    "allow cancellation" in new ITestAppWithAkka {
+    "allow cancellation" in new ITestAppWithPekko {
       val runner = system.actorOf(Props(harvesting.UrlSetHarvester(client, storage)))
 
       runner ! job
@@ -69,7 +69,7 @@ class UrlSetHarvesterSpec extends IntegrationTestRunner {
       expectMsgClass(classOf[Cancelled])
     }
 
-    "support POST requests to endpoints" in new ITestAppWithAkka {
+    "support POST requests to endpoints" in new ITestAppWithPekko {
       val runner = system.actorOf(Props(UrlSetHarvester(client, storage)))
 
       runner ! postJob

--- a/test/actors/ingest/DataImporterManagerSpec.scala
+++ b/test/actors/ingest/DataImporterManagerSpec.scala
@@ -1,6 +1,6 @@
 package actors.ingest
 
-import akka.actor.Props
+import org.apache.pekko.actor.Props
 import helpers.IntegrationTestRunner
 import models._
 import services.data.DataUser
@@ -35,7 +35,7 @@ class DataImporterManagerSpec extends IntegrationTestRunner {
 
   "Data Import manager" should {
 
-    "send correct messages when importing files" in new ITestAppWithAkka {
+    "send correct messages when importing files" in new ITestAppWithPekko {
       val importApi = MockIngestService(ImportLog())
       val importManager = system.actorOf(Props(DataImporterManager(job, importApi)))
 
@@ -49,7 +49,7 @@ class DataImporterManagerSpec extends IntegrationTestRunner {
       expectMsg(WebsocketConstants.DONE_MESSAGE)
     }
 
-    "send correct messages when imports throw an error" in new ITestAppWithAkka {
+    "send correct messages when imports throw an error" in new ITestAppWithPekko {
       val importApi = MockIngestService(ErrorLog("identifier", "Missing field"))
       val importManager = system.actorOf(Props(DataImporterManager(job, importApi)))
 

--- a/test/actors/ingest/DataImporterSpec.scala
+++ b/test/actors/ingest/DataImporterSpec.scala
@@ -1,7 +1,7 @@
 package actors.ingest
 
 import actors.ingest.DataImporter.{Done, Start, Message}
-import akka.actor.Props
+import org.apache.pekko.actor.Props
 import helpers.IntegrationTestRunner
 import models._
 import services.data.DataUser
@@ -35,7 +35,7 @@ class DataImporterSpec extends IntegrationTestRunner {
 
 
   "Data Importer" should {
-    "send correct messages when importing files" in new ITestAppWithAkka {
+    "send correct messages when importing files" in new ITestAppWithPekko {
       val importLog = ImportLog()
       val importApi = MockIngestService(importLog)
       val importer = system.actorOf(Props(DataImporter(job, importApi, (_, _) => Future.successful(()))))
@@ -51,7 +51,7 @@ class DataImporterSpec extends IntegrationTestRunner {
       expectMsgType[Done]
     }
 
-    "send correct messages when batch importing files" in new ITestAppWithAkka {
+    "send correct messages when batch importing files" in new ITestAppWithPekko {
       val batchData = payload.toSeq.zipWithIndex.map { case ((k, v), i) =>
         ingestData.copy(params = ingestData.params.copy(data = UrlMapPayload(Map(k -> v))), batch = Some(i + 1))
       }.toList
@@ -79,7 +79,7 @@ class DataImporterSpec extends IntegrationTestRunner {
       expectMsgType[Done]
     }
 
-    "send correct messages when imports throw an error" in new ITestAppWithAkka {
+    "send correct messages when imports throw an error" in new ITestAppWithPekko {
       val importApi = MockIngestService(ErrorLog("identifier", "Missing field"))
       val importer = system.actorOf(Props(DataImporter(job, importApi, (_, _) => Future.successful(()))))
 

--- a/test/actors/transformation/XmlConverterSpec.scala
+++ b/test/actors/transformation/XmlConverterSpec.scala
@@ -1,9 +1,9 @@
 package actors.transformation
 
 import actors.transformation.XmlConverterManager.{XmlConvertData, XmlConvertJob}
-import akka.actor.Props
-import akka.stream.scaladsl.{Flow, Source}
-import akka.util.ByteString
+import org.apache.pekko.actor.Props
+import org.apache.pekko.stream.scaladsl.{Flow, Source}
+import org.apache.pekko.util.ByteString
 import com.google.inject.name.Names
 import helpers.IntegrationTestRunner
 import mockdata.adminUserProfile
@@ -36,7 +36,7 @@ class XmlConverterSpec extends IntegrationTestRunner {
 
 
   "XML converter" should {
-    "send the right messages when there's nothing to do" in new ITestAppWithAkka {
+    "send the right messages when there's nothing to do" in new ITestAppWithPekko {
         val ds = UUID.randomUUID().toString
         val job = XmlConvertJob("r1", ds, ds,
           XmlConvertData(Seq.empty, s"ingest-data/r1/$ds/input/", s"ingest-data/r1/$ds/output/"))
@@ -48,7 +48,7 @@ class XmlConverterSpec extends IntegrationTestRunner {
         expectMsgClass(classOf[Completed])
     }
 
-    "transcode input charset to UTF-8" in new ITestAppWithAkka {
+    "transcode input charset to UTF-8" in new ITestAppWithPekko {
       val ds = UUID.randomUUID().toString
       val job = XmlConvertJob("r1", ds, ds,
         XmlConvertData(Seq.empty, s"ingest-data/r1/$ds/input/", s"ingest-data/r1/$ds/output/"))
@@ -72,7 +72,7 @@ class XmlConverterSpec extends IntegrationTestRunner {
       }
     }
 
-    "copy files when transformation is a no-op" in new ITestAppWithAkka {
+    "copy files when transformation is a no-op" in new ITestAppWithPekko {
         val ds = UUID.randomUUID().toString
         val job = XmlConvertJob("r1", ds, ds,
           XmlConvertData(Seq.empty, s"ingest-data/r1/$ds/input/", s"ingest-data/r1/$ds/output/"))
@@ -87,7 +87,7 @@ class XmlConverterSpec extends IntegrationTestRunner {
         expectMsgClass(classOf[Completed])
     }
 
-    "handle conversion errors without halting" in new ITestAppWithAkka {
+    "handle conversion errors without halting" in new ITestAppWithPekko {
       val ds = UUID.randomUUID().toString
       val job = XmlConvertJob("r1", ds, ds,
         XmlConvertData(Seq.empty, s"ingest-data/r1/$ds/input/", s"ingest-data/r1/$ds/output/"))
@@ -103,7 +103,7 @@ class XmlConverterSpec extends IntegrationTestRunner {
     }
 
 
-    "handle storage errors by halting" in new ITestAppWithAkka {
+    "handle storage errors by halting" in new ITestAppWithPekko {
       val noKey = "nope.xml"
       val ds = UUID.randomUUID().toString
       val job = XmlConvertJob("r1", ds, ds,
@@ -121,7 +121,7 @@ class XmlConverterSpec extends IntegrationTestRunner {
       expectNoMessage()
     }
 
-    "not re-copy when a prior identical transformation has been run" in new ITestAppWithAkka {
+    "not re-copy when a prior identical transformation has been run" in new ITestAppWithPekko {
         val ds = UUID.randomUUID().toString
         val job = XmlConvertJob("r1", ds, ds,
           XmlConvertData(Seq.empty, s"ingest-data/r1/$ds/input/", s"ingest-data/r1/$ds/output/"))

--- a/test/helpers/SearchTestRunner.scala
+++ b/test/helpers/SearchTestRunner.scala
@@ -4,7 +4,7 @@ import eu.ehri.project.search.solr.SolrSearchEngine
 import play.api.inject.bind
 import play.api.inject.guice.GuiceableModule
 import play.api.test.PlaySpecification
-import services.search.{AkkaStreamsIndexMediator, SearchEngine, SearchIndexMediator}
+import services.search.{PekkoStreamsIndexMediator, SearchEngine, SearchIndexMediator}
 
 /**
  * Override the standard Test runner with non-mock search components.
@@ -12,7 +12,7 @@ import services.search.{AkkaStreamsIndexMediator, SearchEngine, SearchIndexMedia
 trait SearchTestRunner extends PlaySpecification with UserFixtures with TestConfiguration {
 
   override def testSearchComponents: Seq[GuiceableModule] = Seq(
-    bind[SearchIndexMediator].to[AkkaStreamsIndexMediator],
+    bind[SearchIndexMediator].to[PekkoStreamsIndexMediator],
     bind[SearchEngine].to[SolrSearchEngine],
   )
 }

--- a/test/helpers/TestConfiguration.scala
+++ b/test/helpers/TestConfiguration.scala
@@ -1,9 +1,9 @@
 package helpers
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.testkit.{ImplicitSender, TestKitBase}
-import akka.util.Timeout
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.testkit.{ImplicitSender, TestKitBase}
+import org.apache.pekko.util.Timeout
 import auth.handler.cookie.CookieIdContainer
 import auth.handler.{AuthHandler, AuthIdContainer}
 import auth.oauth2.MockOAuth2Service
@@ -199,11 +199,11 @@ trait TestConfiguration {
   }
 
   /**
-    * Same as ITestApp but with Akka TestKit() functionality.
+    * Same as ITestApp but with Pekko TestKit() functionality.
     *
     * @param specificConfig A map of config values for this test
     */
-  protected abstract class ITestAppWithAkka(specificConfig: Map[String,Any] = Map.empty)
+  protected abstract class ITestAppWithPekko(specificConfig: Map[String,Any] = Map.empty)
     extends ITestApp(specificConfig) with TestKitBase with ImplicitSender
 
   /**
@@ -241,7 +241,7 @@ trait TestConfiguration {
       super.around(withDatabaseFixture(db, resource)(implicit db => AsResult.effectively(t)))
   }
 
-  protected abstract class DBTestAppWithAkka(resource: String = "", specificConfig: Map[String,Any] = Map.empty)
+  protected abstract class DBTestAppWithPekko(resource: String = "", specificConfig: Map[String,Any] = Map.empty)
     extends DBTestApp(resource, specificConfig) with TestKitBase with ImplicitSender
 
   /**

--- a/test/integration/admin/ConvertConfigsSpec.scala
+++ b/test/integration/admin/ConvertConfigsSpec.scala
@@ -1,6 +1,6 @@
 package integration.admin
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import helpers._
 import models.{FileStage, TransformationType, _}
 import play.api.http.{ContentTypes, HeaderNames, Writeable}

--- a/test/integration/admin/ImportFilesSpec.scala
+++ b/test/integration/admin/ImportFilesSpec.scala
@@ -1,6 +1,6 @@
 package integration.admin
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import controllers.datasets.FileToUpload
 import helpers._
 import models.{FileStage, _}

--- a/test/integration/admin/IndexingSpec.scala
+++ b/test/integration/admin/IndexingSpec.scala
@@ -1,9 +1,9 @@
 package integration.admin
 
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
+import org.apache.pekko.stream.scaladsl.{Flow, Keep, Sink, Source}
 import controllers.admin.IndexTypes
 import helpers.SearchTestRunner
 import play.api.libs.json.{Json, Writes}
@@ -44,7 +44,7 @@ class IndexingSpec extends SearchTestRunner {
       // NB: using the technique mentioned for "half-closed" websockets here to get output
       // even when we are not putting any items in. We tell the system we want to get the output
       // by closing the server side connection by sending a None message:
-      // https://doc.akka.io/docs/akka-http/current/client-side/websocket-support.html#half-closed-websockets
+      // https://pekko.apache.org/docs/pekko-http/current/client-side/websocket-support.html#half-closed-client-websockets
       val outFlow: Flow[Message, Message, (Future[Seq[Message]], Promise[Option[Message]])] =
         Flow.fromSinkAndSourceMat(Sink.seq[Message], src.concatMat(Source.maybe[Message])(Keep.right))(Keep.both)
 

--- a/test/integration/admin/IngestSpec.scala
+++ b/test/integration/admin/IngestSpec.scala
@@ -1,9 +1,9 @@
 package integration.admin
 
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
+import org.apache.pekko.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.google.inject.name.Names
 import helpers.{FakeMultipartUpload, IntegrationTestRunner}
 import models.{ContentTypes, IngestParams}

--- a/test/integration/admin/SearchSpec.scala
+++ b/test/integration/admin/SearchSpec.scala
@@ -1,11 +1,11 @@
 package integration.admin
 
-import akka.NotUsed
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import org.apache.pekko.NotUsed
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
+import org.apache.pekko.stream.scaladsl.{Flow, Keep, Sink, Source}
 import controllers.admin.IndexTypes
 import helpers._
 import models.EntityType

--- a/test/integration/admin/UtilsSpec.scala
+++ b/test/integration/admin/UtilsSpec.scala
@@ -1,6 +1,6 @@
 package integration.admin
 
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 import helpers._
 import play.api.test.FakeRequest
 

--- a/test/integration/portal/PortalSpec.scala
+++ b/test/integration/portal/PortalSpec.scala
@@ -1,6 +1,6 @@
 package integration.portal
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import cookies.{SessionPreferences, SessionPrefs}
 import helpers.IntegrationTestRunner
 import play.api.libs.json.Json

--- a/test/services/data/WsDataServiceSpec.scala
+++ b/test/services/data/WsDataServiceSpec.scala
@@ -1,6 +1,6 @@
 package services.data
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import helpers.IntegrationTestRunner
 import models._
 import play.api.Configuration

--- a/test/services/harvesting/MockHarvestEventService.scala
+++ b/test/services/harvesting/MockHarvestEventService.scala
@@ -1,9 +1,9 @@
 package services.harvesting
 
-import akka.actor.{Actor, ActorSystem, Props}
-import akka.pattern.ask
-import akka.stream.Materializer
-import akka.util.Timeout
+import org.apache.pekko.actor.{Actor, ActorSystem, Props}
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.Timeout
 import models.HarvestEvent.HarvestEventType
 import models.{HarvestEvent, UserProfile}
 import services.harvesting.EventDb.Query

--- a/test/services/harvesting/MockResourceSyncClient.scala
+++ b/test/services/harvesting/MockResourceSyncClient.scala
@@ -1,6 +1,6 @@
 package services.harvesting
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import javax.inject.Inject
 import models.{FileLink, ResourceSyncConfig}
 

--- a/test/services/harvesting/WSOaiPmhClientSpec.scala
+++ b/test/services/harvesting/WSOaiPmhClientSpec.scala
@@ -1,7 +1,7 @@
 package services.harvesting
 
-import akka.stream.scaladsl.Sink
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.util.ByteString
 import helpers.TestConfiguration
 import models.OaiPmhIdentity.Granularity
 import models.{OaiPmhConfig, BasicAuthConfig, OaiPmhIdentity}

--- a/test/services/harvesting/WSResourceSyncClientSpec.scala
+++ b/test/services/harvesting/WSResourceSyncClientSpec.scala
@@ -1,7 +1,7 @@
 package services.harvesting
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
 import helpers.TestConfiguration
 import models.ResourceSyncConfig
 import play.api.BuiltInComponentsFromContext

--- a/test/services/ingest/MockEadValidatorService.scala
+++ b/test/services/ingest/MockEadValidatorService.scala
@@ -1,9 +1,9 @@
 package services.ingest
 
-import akka.http.scaladsl.model.Uri
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import play.api.Configuration
 import services.storage.FileStorage
 

--- a/test/services/ingest/MockIngestService.scala
+++ b/test/services/ingest/MockIngestService.scala
@@ -1,6 +1,6 @@
 package services.ingest
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import models.{ContentTypes, IngestResult}
 import services.data.DataUser
 

--- a/test/services/ingest/SqlCoreferenceServiceSpec.scala
+++ b/test/services/ingest/SqlCoreferenceServiceSpec.scala
@@ -1,6 +1,6 @@
 package services.ingest
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import helpers._
 import org.specs2.specification.AfterAll
 import play.api.db.Database

--- a/test/services/ingest/SqlImportLogServiceSpec.scala
+++ b/test/services/ingest/SqlImportLogServiceSpec.scala
@@ -1,7 +1,7 @@
 package services.ingest
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.Source
 import helpers._
 import models.{ContentTypes, ImportLog, IngestParams, UrlMapPayload}
 import org.specs2.specification.AfterAll

--- a/test/services/storage/MockFileStorage.scala
+++ b/test/services/storage/MockFileStorage.scala
@@ -1,10 +1,10 @@
 package services.storage
 
-import akka.NotUsed
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.{FileIO, Source}
-import akka.util.ByteString
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.{FileIO, Source}
+import org.apache.pekko.util.ByteString
 
 import java.net.URI
 import java.time.Instant

--- a/test/services/storage/MockFileStorageSpec.scala
+++ b/test/services/storage/MockFileStorageSpec.scala
@@ -1,9 +1,9 @@
 package services.storage
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import helpers.TestConfiguration
 import play.api.test.PlaySpecification
 

--- a/test/services/storage/S3CompatibleFileStorageSpec.scala
+++ b/test/services/storage/S3CompatibleFileStorageSpec.scala
@@ -1,9 +1,9 @@
 package services.storage
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import com.typesafe.config.Config
 import helpers.TestConfiguration
 import play.api.Configuration

--- a/test/utils/CsvHelpersSpec.scala
+++ b/test/utils/CsvHelpersSpec.scala
@@ -1,8 +1,8 @@
 package utils
 
-import akka.actor.ActorSystem
-import akka.stream.Materializer
-import akka.stream.scaladsl.Source
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
 import play.api.test.PlaySpecification
 
 import scala.concurrent.Future


### PR DESCRIPTION
Pekko Connectors forked from Alpakka 4.0.0, and we were on 3.x, so there are some unaddressed deprecation warnings as of now.