### PR TITLE
Make the various validators more robust to BOMs and DTD resolution

### DIFF
--- a/modules/xslt/src/main/scala/eu/ehri/project/xml/XsltXmlTransformer.scala
+++ b/modules/xslt/src/main/scala/eu/ehri/project/xml/XsltXmlTransformer.scala
@@ -5,6 +5,17 @@ import play.api.libs.json.JsObject
 trait XsltXmlTransformer {
   def transform(input: String, mapping: String, params: JsObject): String
 
+  /**
+    * Strips BOM from the beginning of a string if present
+    */
+  protected def stripUTF8BOM(input: String): String = {
+    if (input != null && input.nonEmpty) {
+      // UTF-8 BOM is represented as \uFEFF in Java strings
+      if (input.charAt(0) == '\uFEFF') return input.substring(1)
+    }
+    input
+  }
+
   @throws[XsltConfigError]
   def validationMapping(mapping: String): Unit = {
     val lines = mapping.split('\n').toSeq

--- a/modules/xslt/src/test/scala/eu/ehri/project/xml/SaxonXsltXmlTransformerSpec.scala
+++ b/modules/xslt/src/test/scala/eu/ehri/project/xml/SaxonXsltXmlTransformerSpec.scala
@@ -29,5 +29,23 @@ class SaxonXsltXmlTransformerSpec extends Specification {
       out must contain("example")
       out must contain("Hello, world")
     }
+
+    "handle BOMs" in {
+      val transformer = SaxonXsltXmlTransformer()
+      val map = Source.fromResource("simple-mapping.xsl").mkString
+      val payload = "\uFEFF" + testPayload
+      val out = transformer.transform(payload, map, Json.obj("test-param" -> "example", "test-value" -> "Hello, world"))
+      out must contain("example")
+      out must contain("Hello, world")
+    }
+
+    "handle DTDs" in {
+      val transformer = SaxonXsltXmlTransformer()
+      val map = Source.fromResource("simple-mapping.xsl").mkString
+      val payload = testPayload.replace("<ead>", "<!DOCTYPE ead PUBLIC \"+//ISBN 1-931666-00-8//DTD ead.dtd (Encoded Archival Description (EAD) Version 2002)//EN\" \"ead.dtd\"><ead>")
+      val out = transformer.transform(payload, map, Json.obj("test-param" -> "example", "test-value" -> "Hello, world"))
+      out must contain("example")
+      out must contain("Hello, world")
+    }
   }
 }


### PR DESCRIPTION
DTDs are ignored, since I'm not sure what else would work here. Only the Saxon XSLT processor seemed to choke for UTF-8 files w/ BOMs.