### PR TITLE
Support the ?info query for fetching ARK metadata.

### DIFF
--- a/modules/portal/app/controllers/portal/Portal.scala
+++ b/modules/portal/app/controllers/portal/Portal.scala
@@ -115,10 +115,10 @@ case class Portal @Inject()(
     getStats.map(s => Ok(views.html.index(s, accountForms)))
   }
 
-  def lookupPid(pid: String): Action[AnyContent] = OptionalUserAction.async { implicit request =>
+  def lookupPid(pid: String, info: Boolean): Action[AnyContent] = OptionalUserAction.async { implicit request =>
     userDataApi.getAnyByPid[Model](pid).map { m =>
-      if (request.uri.endsWith("?")) {
-        val extended = request.uri.endsWith("??")
+      if (info || request.uri.endsWith("?")) {
+        val extended = info || request.uri.endsWith("??")
         m match {
           case d: DocumentaryUnit => Ok(views.txt.documentaryUnit.pidInfo(d, extended))
           case a: Accessible => Ok(views.txt.common.pidInfo(a, extended))

--- a/modules/portal/conf/portal.routes
+++ b/modules/portal/conf/portal.routes
@@ -66,7 +66,7 @@ GET         /activity/:id                         @controllers.portal.Portal.ite
 GET         /event/:id                            @controllers.portal.Portal.eventDetails(id: String, paging: utils.PageParams ?= utils.PageParams.empty)
 GET         /feed/$key<\w+>                       @controllers.portal.Portal.externalFeed(key: String)
 GET         /item/:entityType/:id                 @controllers.portal.Portal.browseItem(entityType: models.EntityType.Value, id: String)
-GET         /pid/:pid                             @controllers.portal.Portal.lookupPid(pid: String)
+GET         /pid/:pid                             @controllers.portal.Portal.lookupPid(pid: String, info: Boolean ?= false)
 
 # Virtual Units
 GET         /virtual                              @controllers.portal.VirtualUnits.browseVirtualCollections(params: services.search.SearchParams ?= services.search.SearchParams.empty, paging: utils.PageParams ?= utils.PageParams.empty)

--- a/test/integration/portal/PortalSpec.scala
+++ b/test/integration/portal/PortalSpec.scala
@@ -198,6 +198,26 @@ class PortalSpec extends IntegrationTestRunner {
       contentAsString(show) must contain("<meta property=\"og:type\" content=\"website\">")
       contentAsString(show) must contain("<meta property=\"og:description\" content=\"Some description text for c4\">")
     }
+
+    "resolve PIDs" in new ITestApp {
+      val redir = FakeRequest(controllers.portal.routes.Portal.lookupPid("gb-1234")).call()
+      status(redir) must_== SEE_OTHER
+      redirectLocation(redir) must beSome(controllers.portal.routes.Countries.browse("gb").url)
+    }
+
+    "resolve PID info via inflections" in new ITestApp {
+      val info1 = FakeRequest(controllers.portal.routes.Portal.lookupPid("gb-1234", info = true)).call()
+      status(info1) must_== OK
+      contentAsString(info1) must contain("erc-support:") // extended info via ?info
+
+      val info2 = FakeRequest(GET, controllers.portal.routes.Portal.lookupPid("gb-1234").url + "?").call()
+      status(info2) must_== OK
+      contentAsString(info2) must contain("erc:") // minimal info via ?
+
+      val info3 = FakeRequest(GET, controllers.portal.routes.Portal.lookupPid("gb-1234").url + "??").call()
+      status(info3) must_== OK
+      contentAsString(info3) must contain("erc-support:") // extended info via ??
+    }
   }
 
   private def zipEntries(bytes: ByteString): List[ZipEntry] = {


### PR DESCRIPTION
This is not official yet but only in the latest draft spec:

https://datatracker.ietf.org/doc/draft-kunze-ark/

It's needed because a plain '?' does not get passed along by resolvers